### PR TITLE
Add submission forensics and clean-room baseline reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Esquema resumido, no exhaustivo:
 |   |-- experiment_pseudo_label_family.py
 |   |-- experiment_local_calibrator.py
 |   |-- experiment_specialist_model.py
+|   |-- experiment_telco_joint_training.py
 |   |-- build_teacher_component_frame.py
 |   |-- gate_submission_candidate.py
 |   |-- make_submission_residual_hierarchical.py
@@ -594,6 +595,34 @@ Notas:
   - `<label>_transfer_test.csv`
   - `validation_protocol_<label>_vs_v3_smoke.json`
 - El primer gate es siempre directo contra `v3`; no hay blend por default en esta linea.
+
+3g5c. Correr el smoke minimo `source-aware joint training` con Telco original
+
+```bash
+python scripts/experiment_telco_joint_training.py \
+  --train-csv data/raw/train.csv \
+  --test-csv data/raw/test.csv \
+  --original-csv artifacts/external/blastchar_telco/WA_Fn-UseC_-Telco-Customer-Churn.csv \
+  --feature-blocks R,V \
+  --external-weight 0.25 \
+  --label telco_joint_training_smoke
+```
+
+Notas:
+- Esta linea no proyecta un score externo; agrega filas reales del Telco original al fit de cada fold.
+- El OOF y el gate se calculan solo sobre filas de la competencia.
+- Agrega una categorica nueva:
+  - `dataset_source` con valores `competition` y `telco_original`
+- Las filas externas entran con peso configurable via `--external-weight`.
+- El script elimina filas del Telco original que coincidan exactamente con `train/test` antes del joint training.
+- El smoke nace comparado directamente contra `v3`; no se promueve si falla `validation_protocol_*_vs_v3_smoke.json`.
+- Artefactos principales:
+  - `<label>_metrics.json`
+  - `<label>_oof.csv`
+  - `<label>_analysis_oof.csv`
+  - `<label>_candidate_metrics.json`
+  - `<label>_reference_v3_metrics.json`
+  - `validation_protocol_<label>_vs_v3_smoke.json`
 
 3g6. Correr el smoke minimo `GraphSAGE + ANN graph`
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |       |-- linear_probe.py
 |       |-- mlp_probe.py
 |       |-- modeling.py
+|       |-- pseudo_labeling.py
 |       |-- specialist.py
 |       |-- target_priors.py
 |       `-- pipeline.py
@@ -35,6 +36,7 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |   |-- experiment_hierarchical_priors.py
 |   |-- experiment_linear_probe.py
 |   |-- experiment_mlp_probe.py
+|   |-- experiment_pseudo_label_family.py
 |   |-- experiment_local_calibrator.py
 |   |-- experiment_specialist_model.py
 |   |-- build_teacher_component_frame.py
@@ -567,6 +569,43 @@ Salidas esperadas:
 - bundle `.pt` a `--model-path` (default: `artifacts/models/mlp_probe_smoke.pt`)
 - OOF a `--oof-path` (default: `artifacts/reports/mlp_probe_smoke_oof.csv`)
 - metricas y blend scan a `--metrics-path` (default: `artifacts/reports/mlp_probe_smoke_metrics.json`)
+
+3i7. Simular pseudo-labeling offline por familia
+
+```bash
+python scripts/experiment_pseudo_label_family.py \
+  --family-key "Electronic check__Month-to-month__Fiber optic__Yes__13_24" \
+  --feature-blocks "H,R,S,V" \
+  --label-mode soft \
+  --scale-pseudo-weight-by-confidence \
+  --upper-thresholds "0.88,0.85" \
+  --lower-thresholds "0.15,0.12" \
+  --pseudo-weights "0.05,0.10,0.20"
+```
+
+Este experimento no usa `test.csv`. Hace una simulacion offline dentro de `train.csv`:
+- separa un `holdout` global real para medir AUC;
+- esconde una fraccion de la familia objetivo como `pseudo_pool`;
+- genera pseudo-labels solo sobre esas filas usando el teacher OOF (`cb/xgb/lgb/r/rv`);
+- reentrena un `student` con pesos bajos en esas filas pseudo-etiquetadas;
+- barre `thresholds + pseudo_weight` y reporta el delta contra un baseline sin pseudo-labels.
+
+Contrato minimo:
+- `--family-key`: key exacta `segment5 = PaymentMethod__Contract__InternetService__PaperlessBilling__tenure_bin`
+- `--oof` y `--reference-weights-json` deben reconstruir el teacher OOF por `id`
+- si usas `--require-teacher-agreement` o `--max-teacher-std`, esos `--oof` deben exponer componentes `pred_*`, no solo la mezcla final
+- `--label-mode hard`: usa pseudo etiquetas binarias por threshold
+- `--label-mode soft`: duplica cada pseudo fila en dos ejemplos ponderados (`y=1` y `y=0`) usando la probabilidad del teacher
+- `--scale-pseudo-weight-by-confidence`: multiplica el peso base por `2 * |p - 0.5|`
+- `--require-teacher-agreement` exige que todos los componentes `pred_*` queden del mismo lado de `0.5`
+- `--max-teacher-std` permite filtrar solo filas con bajo desacuerdo entre teachers
+- defaults operativos: `holdout_size=0.15`, `valid_size=0.15`, `pseudo_pool_fraction=0.50`, `repeats=3`, `min_selected_rows=100`
+- la familia objetivo debe tener al menos `2000` filas en `train`, y cada repeticion debe dejar al menos `1000` filas de esa familia en el split de fit
+- `--results-csv-path` guarda el barrido detallado por repeticion/configuracion
+- `--metrics-path` resume la mejor configuracion y el ranking de configs
+
+La primera familia sugerida para smoke es:
+- `Electronic check__Month-to-month__Fiber optic__Yes__13_24`
 
 3j. Aplicar gate automatico GO/NO_GO para decidir submission
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,22 @@ Con disagreement del teacher:
 python scripts/experiment_specialist_model.py --approach residual --preset fiber_paperless_early --feature-blocks "H,R,S,V" --include-teacher-disagreement-features
 ```
 
+Formulacion `prediction as feature` para una macrofamilia:
+
+```bash
+python scripts/experiment_specialist_model.py --approach feature --preset ec_mtm_fiber_any --feature-blocks "H,R,S,V" --include-teacher-disagreement-features
+```
+
+En `approach=feature`, el CLI:
+- entrena un especialista local sobre el preset;
+- materializa su score local y lo transforma en features apiladas (`family_specialist_pred_feature`, `family_specialist_available`, `family_specialist_delta_vs_reference`);
+- entrena luego un challenger global con esas features apiladas;
+- guarda dos modelos:
+  - `--model-path`: challenger global
+  - `--model-path` con sufijo `_family<suffix>`: especialista usado para construir la feature
+- el JSON de metricas expone ambos artefactos como `global_model_path` y `family_model_path`
+- el OOF resultante escribe `family_specialist_pred`, `challenger_pred` y `candidate_pred`
+
 Notas para `--include-teacher-disagreement-features`:
 - agrega `teacher_component_*` y estadisticas derivadas (`std`, `range`, `top_gap`, deltas por pares) usando las columnas `pred_*` del OOF de referencia;
 - requiere que los `--oof` del incumbente expongan componentes individuales (`pred_cb`, `pred_xgb`, `pred_lgb`, `pred_r`, `pred_rv`) y no solo la mezcla final;

--- a/README.md
+++ b/README.md
@@ -15,17 +15,34 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |       |-- config.py
 |       |-- data.py
 |       |-- diagnostics.py
-|       |-- modeling.py
-|       |-- evaluation.py
+|       |-- feature_engineering.py
+|       |-- fm_probe.py
 |       |-- artifacts.py
+|       |-- evaluation.py
 |       |-- kaggle_api.py
+|       |-- linear_probe.py
+|       |-- mlp_probe.py
+|       |-- modeling.py
+|       |-- specialist.py
+|       |-- target_priors.py
 |       `-- pipeline.py
 |-- scripts/
 |   |-- audit_submission_parity.py
 |   |-- analyze_train_test_drift.py
+|   |-- analyze_error_by_class.py
 |   |-- evaluate_ensemble_robustness.py
+|   |-- experiment_fm_probe.py
+|   |-- experiment_hierarchical_priors.py
+|   |-- experiment_linear_probe.py
+|   |-- experiment_mlp_probe.py
+|   |-- experiment_local_calibrator.py
+|   |-- experiment_specialist_model.py
+|   |-- build_teacher_component_frame.py
 |   |-- gate_submission_candidate.py
+|   |-- make_submission_residual_hierarchical.py
 |   |-- snapshot_submission_artifacts.py
+|   |-- make_submission_hierarchical_priors.py
+|   |-- materialize_residual_submission.py
 |   |-- train_baseline.py
 |   |-- make_submission.py
 |   |-- submit_kaggle.py
@@ -72,29 +89,80 @@ python scripts/train_cv_multiseed.py --folds 5 --seeds "42,2024,3407"
 Con bloques de features:
 
 ```bash
-python scripts/train_cv_multiseed.py --folds 5 --seeds "42,2024,3407" --feature-blocks "O,P"
+python scripts/train_cv_multiseed.py --folds 5 --seeds "42,2024,3407" --feature-blocks "H,R,V"
 ```
 
-2d. Ejecutar experimento de feature engineering por bloques (A/B/C/O/P)
+Con estratificacion compuesta por target + familia:
 
 ```bash
-python scripts/experiment_features.py --feature-blocks "A"
+python scripts/train_cv_multiseed.py --folds 5 --seeds "42,2024,3407" --feature-blocks "G,H,R,V" --stratify-mode composite
+```
+
+2d. Ejecutar experimento de feature engineering por bloques (A/B/C/G/H/R/S/V/O/P)
+
+```bash
+python scripts/experiment_features.py --feature-blocks "G,H,R,V" --stratify-mode composite
+```
+
+Notas:
+- `experiment_features.py` compara contra un baseline leyendo `--baseline-metrics-path`.
+- Ese JSON debe contener `ensemble_oof_auc`, `oof_auc` o `holdout_auc`.
+- Si quieres un benchmark distinto, apunta `--baseline-metrics-path` al reporte correcto.
+
+2e. Ejecutar experimento con priors jerarquicos fold-safe
+
+```bash
+python scripts/experiment_hierarchical_priors.py --feature-mode raw_plus_priors --folds 5
+```
+
+Con desvio del cliente respecto de su cohorte:
+
+```bash
+python scripts/experiment_hierarchical_priors.py --feature-mode raw_plus_priors --include-deviation-features --folds 5
+```
+
+Con bloques base antes de construir priors:
+
+```bash
+python scripts/experiment_hierarchical_priors.py --base-feature-blocks "H,R" --feature-mode raw_plus_priors --folds 5
 ```
 
 Bloques relevantes para outliers:
 - `O`: banderas `is_outlier_*` + `outlier_flag_count` usando umbrales p01/p99.
 - `P`: features continuas recortadas p01/p99 (`pclip_*`) para mitigacion de colas.
 
+Bloques estructurales:
+- `G`: cobertura y backoff por familia fit-aware (`segment3/segment5`, soporte train-only, unseen/low-support, familia colapsada al padre).
+- Si entrenas con `G`, en inferencia debes pasar `--train-csv` a los CLI que materializan submissions para reconstruir el estado train-only.
+- `H`: contrastes intra-cohorte para bundles raros dentro de grupos duros (rareza y desvio respecto de la cohorte).
+- `R`: lifecycle y renovacion (`tenure_mod_*`, distancia a borde de contrato, bins de ciclo).
+- `S`: topologia del bundle y firma de servicios (support vs entertainment, archetype, signatures).
+- `V`: presion de valor y friccion de pago (cargo efectivo, cohort del precio, service pressure).
+
 3. Generar submission
 
 ```bash
-python scripts/make_submission.py
+python scripts/make_submission.py --feature-blocks "G,H,R,V" --train-csv data/raw/train.csv
 ```
+
+Nota:
+- `--train-csv` solo es obligatorio cuando usas bloques fit-aware como `G`.
 
 3b. Generar submission ensemble desde modelos multi-seed
 
 ```bash
-python scripts/make_submission_ensemble.py
+python scripts/make_submission_ensemble.py --feature-blocks "G,H,R,V" --train-csv data/raw/train.csv
+```
+
+Notas:
+- `make_submission_ensemble.py` usa `--model-paths` si los pasas manualmente.
+- Si no, lee `--metrics-path` y espera una clave `model_paths` en ese JSON.
+- `--train-csv` es necesario cuando usas bloques fit-aware como `G`, para reconstruir soporte/backoff con estado aprendido solo en train.
+
+3b2. Generar submission desde experimento de priors jerarquicos
+
+```bash
+python scripts/make_submission_hierarchical_priors.py --metrics-path artifacts/reports/hierarchical_priors_cv_metrics.json
 ```
 
 3c. Auditar paridad train/inferencia para una submission candidata
@@ -121,7 +189,272 @@ python scripts/analyze_train_test_drift.py --feature-blocks none --adv-folds 3 -
 python scripts/evaluate_ensemble_robustness.py --oof cb=artifacts/reports/train_cv_multiseed_full_hiiter_oof.csv#oof_ensemble --oof lgb=artifacts/reports/train_lightgbm_cv_full_hiiter_oof.csv#oof_pred --oof xgb=artifacts/reports/train_xgboost_cv_full_hiiter_oof.csv#oof_pred --repeats 3 --folds 5
 ```
 
-3g. Aplicar gate automatico GO/NO_GO para decidir submission
+3g. Analizar error por clase/cohorte entre referencia y challenger
+
+```bash
+python scripts/analyze_error_by_class.py --reference-weights-json artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_weights.json --challenger-weights-json artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json
+```
+
+3h. Ejecutar experimento de especialista local sobre el incumbente
+
+```bash
+python scripts/experiment_specialist_model.py --preset early_manual_internet --feature-blocks "H,R,S,V"
+```
+
+Requiere que exista el OOF del incumbente (`cb/xgb/lgb/r/rv`) y el archivo de pesos
+`artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json`.
+Por defecto escribe a `artifacts/models/`, `artifacts/reports/` y usa `--alpha-grid`
+para escanear el override local. Si tus artefactos OOF tienen otros nombres o columnas,
+debes pasarlos por `--oof` y hacerlos coincidir con las keys del JSON de pesos
+(la mezcla usa columnas `pred_<name>` internamente).
+
+Tambien soporta `--approach residual`, que aprende una correccion aditiva sobre el
+score del incumbente para intentar mejorar ranking dentro de la cohorte dura.
+La correccion final se aplica con clipping numericamente estable a
+`[1e-6, 1 - 1e-6]`:
+
+```bash
+python scripts/experiment_specialist_model.py --approach residual --preset fiber_paperless_early --feature-blocks "H,R,S,V"
+```
+
+Con disagreement del teacher:
+
+```bash
+python scripts/experiment_specialist_model.py --approach residual --preset fiber_paperless_early --feature-blocks "H,R,S,V" --include-teacher-disagreement-features
+```
+
+Notas para `--include-teacher-disagreement-features`:
+- agrega `teacher_component_*` y estadisticas derivadas (`std`, `range`, `top_gap`, deltas por pares) usando las columnas `pred_*` del OOF de referencia;
+- requiere que los `--oof` del incumbente expongan componentes individuales (`pred_cb`, `pred_xgb`, `pred_lgb`, `pred_r`, `pred_rv`) y no solo la mezcla final;
+- si el modelo especialista se promociona a inferencia, debes reconstruir el mismo `reference_component_frame` en test para mantener paridad train/test.
+
+3i. Ejecutar calibracion local sobre el score del incumbente
+
+```bash
+python scripts/experiment_local_calibrator.py --preset early_manual_internet --method platt
+```
+
+Usa los mismos OOF y archivo de pesos del incumbente, y por defecto escribe a
+`artifacts/models/` y `artifacts/reports/`. Metodos disponibles: `platt`, `isotonic`.
+Los nombres de pesos del JSON deben coincidir con los nombres entregados en `--oof`,
+y la calibracion solo es valida si la submission final usa exactamente el mismo incumbente
+que genero ese `reference_pred`.
+
+3i2. Generar una submission final aplicando una cadena residual ya entrenada
+
+```bash
+python scripts/make_submission_residual_hierarchical.py \
+  --train-csv data/raw/train.csv \
+  --reference-submission artifacts/submissions/playground-series-s6e3-rvblend.csv \
+  --step "early_all_internet|artifacts/models/residual_reranker_early_all_internet_midcap.cbm|1.0|H,R,S,V" \
+  --step "fiber_paperless_early|artifacts/models/residual_reranker_fiber_paperless_early_midcap.cbm|1.0|H,R,S,V"
+```
+
+Este CLI no entrena ni valida: solo aplica, en orden, modelos residuales ya entrenados
+sobre un submission base y escribe CSV final + JSON de trazabilidad.
+
+Si alguno de esos rerankers fue entrenado con disagreement del teacher, la inferencia
+debe recibir ademas el `reference_component_frame` correspondiente al incumbente base.
+Puedes construirlo con:
+
+```bash
+python scripts/build_teacher_component_frame.py \
+  --cbrv-submission artifacts/submissions/playground-series-s6e3-rvblend.csv \
+  --output-csv artifacts/reports/reference_component_frame_rvblend_test.csv
+```
+
+El builder CLI se llama `build_teacher_component_frame.py` y escribe un CSV con
+`id + pred_cb/pred_xgb/pred_lgb/pred_r/pred_rv`, mas un JSON de paridad que
+reconstruye numericamente las tres submissions base.
+
+Y luego aplicarlo al reranker teacher-aware:
+
+```bash
+python scripts/make_submission_residual_hierarchical.py \
+  --train-csv data/raw/train.csv \
+  --reference-submission artifacts/submissions/playground-series-s6e3-rvblend.csv \
+  --reference-component-csv artifacts/reports/reference_component_frame_rvblend_test.csv \
+  --reference-mode base \
+  --step "early_all_internet|artifacts/models/residual_reranker_early_all_internet_midcap.cbm|1.0|H,R,S,V" \
+  --step "fiber_paperless_early|artifacts/models/residual_reranker_fiber_paperless_early_teacher_midcap.cbm|1.0|H,R,S,V"
+```
+
+Formato de cada `--step`:
+- `<preset>|<model_path>|<alpha>|<feature_blocks>`
+- `preset`: una key de la lista de presets soportados
+- `model_path`: modelo residual CatBoost ya entrenado sobre 100% de su cohorte
+- `alpha`: multiplicador aditivo en `[0, 1]`
+- `feature_blocks`: bloques usados al entrenar ese reranker; deben coincidir al aplicar inferencia
+
+Prerequisitos minimos:
+- `test.csv`
+- `train.csv` si algun step usa bloques fit-aware como `G`
+- submission base con columnas `id, Churn`
+- modelos `.cbm` residuales ya entrenados
+
+El JSON de salida guarda la secuencia aplicada, `changed_rows`, `mae_vs_base`,
+`max_abs_shift_vs_base` y rango final de predicciones. Cada paso aplica clipping
+numericamente estable en `[1e-6, 1 - 1e-6]`.
+
+`--reference-mode` controla contra que score corre cada reranker:
+- `previous`: cada paso usa la salida del paso anterior.
+- `base`: todos los pasos usan la submission base original; esto es util cuando
+  validaste los rerankers de forma independiente contra el mismo teacher.
+
+Si pasas `--reference-component-csv`, debes usar `--reference-mode base`.
+Combinar `teacher components` con `previous` rompe la paridad entre
+`reference_pred_feature` y las features `teacher_component_*` despues del primer paso.
+
+3i3. Orquestar builder teacher-aware + submission residual en un solo comando
+
+```bash
+python scripts/materialize_residual_submission.py \
+  --teacher-aware \
+  --train-csv data/raw/train.csv \
+  --reference-mode base \
+  --reference-submission artifacts/submissions/playground-series-s6e3-rvblend.csv \
+  --output-csv artifacts/submissions/playground-series-s6e3-residual-hier-v2-cli.csv \
+  --report-json artifacts/reports/submission_candidate_residual_hierarchical_v2_cli.json \
+  --step "early_all_internet|artifacts/models/residual_reranker_early_all_internet_midcap.cbm|1.0|H,R,S,V" \
+  --step "fiber_paperless_early|artifacts/models/residual_reranker_fiber_paperless_early_teacher_midcap.cbm|1.0|H,R,S,V"
+```
+
+Este wrapper:
+- construye el `reference_component_frame` si activas `--teacher-aware`;
+- guarda el CSV/JSON del builder con nombres derivados del output final;
+- aplica luego la cadena residual con los mismos parametros;
+- imprime `run_config` resuelto antes de materializar la submission.
+
+Flags utiles del wrapper:
+- `--step` es obligatorio y puede repetirse una o mas veces.
+- `--teacher-aware` exige `--reference-mode base`.
+- `--train-csv` es necesario si algun paso o reconstruccion usa bloques fit-aware como `G`.
+- `--reference-component-csv` permite reutilizar un frame `id + pred_*` ya construido.
+- `--reference-component-report-json` fija la ruta del JSON del builder cuando usas `--teacher-aware`.
+- `--test-csv` permite apuntar a otro `test.csv`.
+- `--cb-metrics-json`, `--cb-feature-blocks`, `--r-model-path`, `--r-feature-blocks` controlan como se reconstruyen `cb` y `r`.
+- `--cbxgblgb-submission`, `--cbxgblgb-weights-json`, `--cbr-submission`, `--cbr-weights-json`, `--cbrv-submission`, `--cbrv-weights-json` controlan las tres submissions base usadas para resolver `xgb`, `lgb` y `rv`.
+
+Defaults derivados cuando usas `--teacher-aware`:
+- CSV del builder: `<output_csv_stem>_teacher_components.csv`
+- JSON del builder: `<report_json_stem>_teacher_components.json`
+
+Presets soportados por la linea local:
+- `early_manual_internet`
+- `early_all_internet`
+- `fiber_paperless_early`
+- `late_mtm_fiber`
+- `late_mtm_fiber_paperless`
+- `long_fiber_any`
+- `manual_no_internet`
+- `one_year_fiber_any`
+- `one_year_dsl_any`
+- `two_year_fiber_any`
+- `one_year_fiber_paperless_49plus`
+- `two_year_fiber_paperless_49plus`
+
+3i4. Probar una senal ortogonal barata con modelo lineal disperso
+
+```bash
+python scripts/experiment_linear_probe.py \
+  --model-family spline_logistic \
+  --feature-blocks "H,R,S,V" \
+  --reference-weights-json artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json \
+  --oof cb=artifacts/reports/train_cv_multiseed_gate_s5_hiiter_oof.csv#oof_ensemble \
+  --oof xgb=artifacts/reports/train_xgboost_cv_multiseed_hiiter_oof.csv#oof_ensemble \
+  --oof lgb=artifacts/reports/train_lightgbm_cv_full_hiiter_oof.csv#oof_pred \
+  --oof r=artifacts/reports/fe_blockR_hiiter_oof.csv#oof_pred \
+  --oof rv=artifacts/reports/fe_blockRV_hiiter_oof.csv#oof_pred
+```
+
+El probe lineal usa `one-hot + escalado numerico + logistic regression` para buscar una
+senal menos correlacionada con los boosters. Reporta OOF, correlacion contra el incumbente
+y un scan de blend simple.
+
+Familias soportadas:
+- `logistic`
+- `spline_logistic`: aplica spline basis solo sobre un subconjunto curado de variables
+  numericas continuas y deja el resto en camino lineal
+
+Prerequisitos minimos del probe lineal:
+- `train.csv`
+- `--reference-weights-json` con objeto `{"weights": {...}}`
+- uno o mas `--oof` con formato `<name>=<path>[#<prediction_column>]`
+- las keys de `weights` deben coincidir con los nombres entregados en `--oof`
+
+3i5. Probar una senal ortogonal con `FM/FFM` via `river`
+
+```bash
+python -m pip install river
+
+python scripts/experiment_fm_probe.py \
+  --model-family ffm \
+  --feature-blocks none \
+  --reference-weights-json artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json \
+  --oof cb=artifacts/reports/train_cv_multiseed_gate_s5_hiiter_oof.csv#oof_ensemble \
+  --oof xgb=artifacts/reports/train_xgboost_cv_multiseed_hiiter_oof.csv#oof_ensemble \
+  --oof lgb=artifacts/reports/train_lightgbm_cv_full_hiiter_oof.csv#oof_pred \
+  --oof r=artifacts/reports/fe_blockR_hiiter_oof.csv#oof_pred \
+  --oof rv=artifacts/reports/fe_blockRV_hiiter_oof.csv#oof_pred
+```
+
+Familias soportadas:
+- `fm`
+- `ffm`
+
+El probe FM/FFM usa entrenamiento online con `river`, OOF por folds, correlacion contra
+el incumbente y scan de blend simple. Es mas lento que el probe lineal, asi que conviene
+usarlo primero en smoke pequeño antes de pensar en promocion.
+
+Prerequisitos minimos del probe FM/FFM:
+- `train.csv` con la misma estructura del proyecto base
+- `river>=0.23.0`
+- `--reference-weights-json` con objeto `{"weights": {...}}` si quieres comparar contra el incumbente
+- uno o mas `--oof` con formato `<name>=<path>[#<prediction_column>]`
+
+Salidas esperadas:
+- modelo full-train serializado a `--model-path`
+- OOF a `--oof-path`
+- metricas y blend scan a `--metrics-path`
+
+Reproducibilidad:
+- usa `--random-state` para fijar folds y semilla del modelo
+- el smoke recomendado parte con `--folds 2 --epochs 1`
+
+3i6. Probar una senal ortogonal con `MLP` tabular y embeddings
+
+```bash
+python scripts/experiment_mlp_probe.py \
+  --train-csv artifacts/tmp/train_smoke_20pct.csv \
+  --feature-blocks none \
+  --hidden-dims 128,64 \
+  --epochs 6 \
+  --device auto \
+  --reference-weights-json artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json \
+  --oof cb=artifacts/reports/train_cv_multiseed_gate_s5_hiiter_oof.csv#oof_ensemble \
+  --oof xgb=artifacts/reports/train_xgboost_cv_multiseed_hiiter_oof.csv#oof_ensemble \
+  --oof lgb=artifacts/reports/train_lightgbm_cv_full_hiiter_oof.csv#oof_pred \
+  --oof r=artifacts/reports/fe_blockR_hiiter_oof.csv#oof_pred \
+  --oof rv=artifacts/reports/fe_blockRV_hiiter_oof.csv#oof_pred
+```
+
+El probe MLP usa embeddings por categorica, normalizacion numerica por fold, OOF,
+correlacion contra el incumbente y scan de blend simple.
+
+Prerequisitos minimos del probe MLP:
+- `train.csv` o una muestra estratificada compatible
+- `torch>=2`
+- `--reference-weights-json` con objeto `{"weights": {...}}` si quieres comparar contra el incumbente
+- uno o mas `--oof` con formato `<name>=<path>[#<prediction_column>]`
+- `feature-blocks` acepta `none` o cualquier combinacion soportada por el proyecto
+- `device=auto` usa `cuda` si esta disponible; si no, cae a `cpu`
+
+Salidas esperadas:
+- bundle `.pt` a `--model-path` (default: `artifacts/models/mlp_probe_smoke.pt`)
+- OOF a `--oof-path` (default: `artifacts/reports/mlp_probe_smoke_oof.csv`)
+- metricas y blend scan a `--metrics-path` (default: `artifacts/reports/mlp_probe_smoke_metrics.json`)
+
+3j. Aplicar gate automatico GO/NO_GO para decidir submission
 
 ```bash
 python scripts/gate_submission_candidate.py --candidate-name playground-series-s6e3 --parity-json artifacts/reports/diagnostic_submission_parity_issue5.json --drift-json artifacts/reports/diagnostic_train_test_drift_issue5.json --robustness-json artifacts/reports/diagnostic_ensemble_robustness_issue5.json
@@ -136,7 +469,7 @@ python scripts/submit_kaggle.py --message "playground-series-s6e3"
 ## Pipeline end-to-end (una sola llamada)
 
 ```bash
-python scripts/run_baseline.py --submit --message "playground-series-s6e3"
+python scripts/run_baseline.py --feature-blocks "G,H,R,V" --stratify-mode composite --submit --message "playground-series-s6e3"
 ```
 
 ## Notas
@@ -145,3 +478,5 @@ python scripts/run_baseline.py --submit --message "playground-series-s6e3"
 - La logica de negocio vive en `src/churn_baseline/`.
 - `artifacts/` guarda salidas locales y no se versiona (solo estructura).
 - Antes de descargar/enviar, debes aceptar reglas en `Join Competition`.
+- Los priors jerarquicos usan target encoding fold-safe con smoothing y fallback de cohortes.
+- `--include-deviation-features` agrega medias de cohorte y desvio relativo del cliente respecto de su cohorte jerarquica.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |       |-- kaggle_api.py
 |       |-- linear_probe.py
 |       |-- mlp_probe.py
+|       |-- ngram_xgb.py
 |       |-- modeling.py
 |       |-- pseudo_labeling.py
 |       |-- specialist.py
@@ -39,6 +40,7 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |   |-- experiment_hierarchical_priors.py
 |   |-- experiment_linear_probe.py
 |   |-- experiment_mlp_probe.py
+|   |-- run_ngram_xgb.py
 |   |-- experiment_pseudo_label_family.py
 |   |-- experiment_local_calibrator.py
 |   |-- experiment_specialist_model.py
@@ -324,6 +326,39 @@ Notas:
   - metrics JSON comparables (`cv_std_auc` incluido)
   - veredicto del protocolo aplicado directamente contra `v3`
   - summary JSON con el resumen del veredicto y los paths generados
+
+3g5. Correr la linea minima `bi-gram + target encoding + XGBoost`
+
+```bash
+python scripts/run_ngram_xgb.py \
+  --train-csv data/raw/train.csv \
+  --test-csv data/raw/test.csv \
+  --original-csv artifacts/external/blastchar_telco/WA_Fn-UseC_-Telco-Customer-Churn.csv \
+  --folds 2 \
+  --inner-folds 3 \
+  --metrics-path artifacts/reports/ngram_te_xgb_smoke_metrics.json \
+  --oof-path artifacts/reports/ngram_te_xgb_smoke_oof.csv \
+  --reference-v3-oof artifacts/reports/validation_protocol_v3_chain_oof.csv \
+  --analysis-oof-path artifacts/reports/ngram_te_xgb_smoke_analysis_oof.csv
+```
+
+Notas:
+- La linea vive separada del pipeline principal en `src/churn_baseline/ngram_xgb.py`.
+- Usa:
+  - numericas crudas (`SeniorCitizen`, `tenure`, `MonthlyCharges`, `TotalCharges`)
+  - target encoding fold-safe para categoricas simples
+  - bi-grams sobre `Contract`, `InternetService`, `PaymentMethod`, `OnlineSecurity`, `TechSupport`, `PaperlessBilling`
+- `--include-trigrams` agrega tri-grams sobre las primeras 4 categoricas base.
+- `--original-csv` es opcional; si se pasa, el CSV original se usa solo como apoyo para los mapas de target encoding.
+  Debe incluir la columna objetivo `Churn`; si no existe, el CLI falla de forma explicita.
+- El experimento elimina filas del dataset original que coincidan exactamente con filas de `train/test` para evitar solapamientos triviales.
+- `--reference-v3-oof` y `--analysis-oof-path` tambien son opcionales; si ambos estan presentes, `--reference-v3-oof`
+  debe apuntar a un CSV con columnas `id`, `target` y `candidate_pred`. El CLI deja listo un CSV con:
+  - `id`
+  - `target`
+  - `reference_pred`
+  - `candidate_pred`
+  que se puede pasar directo a `evaluate_validation_protocol.py`.
 
 3h. Ejecutar experimento de especialista local sobre el incumbente
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,37 @@ Notas:
 - El conflicto `coarse` solo cuenta grupos chicos (`--max-near-duplicate-group-size`, default `5`, minimo `2`) para no confundir cohortes grandes con near-duplicates.
 - El JSON resume concentracion por `segment3`, `segment5` y por la macrofamilia dominante `Electronic check / Month-to-month / Fiber optic`.
 
+3g2c. Probar mitigacion minima de near-duplicates directamente contra `v3`
+
+```bash
+python scripts/experiment_noise_mitigation.py \
+  --mode downweight \
+  --feature-blocks R,V \
+  --label noise_mitigation_downweight_smoke
+```
+
+Notas:
+- El experimento entrena un challenger CatBoost en smoke y lo compara directamente contra `v3`.
+- `--mode` soporta `downweight` o `drop`.
+- La regla se deriva solo sobre el fold de train y marca filas minoritarias dentro de grupos `coarse` chicos y mixtos.
+- La firma `coarse` usa:
+  - categoricas crudas normalizadas (`gender`, `SeniorCitizen`, `Partner`, `Dependents`, `PhoneService`, `MultipleLines`, `InternetService`, `OnlineSecurity`, `OnlineBackup`, `DeviceProtection`, `TechSupport`, `StreamingTV`, `StreamingMovies`, `Contract`, `PaperlessBilling`, `PaymentMethod`)
+  - `tenure` exacto
+  - `MonthlyCharges` redondeado al entero mas cercano
+  - `TotalCharges` redondeado a decenas
+  - `segment3` y `segment5`
+- Por default restringe la mitigacion a la macrofamilia dominante `Electronic check / Month-to-month / Fiber optic`; usa `--no-dominant-only` para desactivarlo.
+- `--suspect-weight` solo aplica en `downweight`.
+- `--min-group-size`, `--max-group-size` y `--majority-share-min` controlan la agresividad de la regla.
+- El script siempre construye `analysis_oof` y corre el gate directo contra `v3`.
+- Los artefactos principales son:
+  - `<label>_metrics.json`
+  - `<label>_oof.csv`
+  - `<label>_analysis_oof.csv`
+  - `<label>_candidate_metrics.json`
+  - `<label>_reference_v3_metrics.json`
+  - `validation_protocol_<label>_vs_v3_smoke.json`
+
 3g3. Evaluar un candidato OOF bajo el protocolo de `validation reset`
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |   |-- analyze_train_test_drift.py
 |   |-- analyze_error_by_class.py
 |   |-- analyze_family_generalization.py
+|   |-- evaluate_against_v3.py
 |   |-- evaluate_validation_protocol.py
 |   |-- evaluate_ensemble_robustness.py
 |   |-- experiment_fm_probe.py
@@ -282,6 +283,47 @@ Notas:
   - `--reference-metrics-json`
 - Sin esos JSON el script igual corre, pero el check `midcap_cv_std` queda en `FAIL`.
 - Para `submission`, el gate exige `--submission-csv` para trazar el artefacto final.
+
+3g4. Comparar una chain challenger directamente contra `v3`
+
+```bash
+python scripts/evaluate_against_v3.py --stage midcap --label "ec_any_best" --candidate-order "early_all_internet,ec_mtm_fiber_paperless_any,fiber_paperless_early" --candidate-step "ec_mtm_fiber_paperless_any|artifacts/reports/residual_reranker_ec_mtm_fiber_paperless_any_teacher_midcap_oof.csv"
+```
+
+Notas:
+- Este CLI existe para no volver a comparar challengers solo contra `rvblend` cuando el incumbent operativo ya es `v3`.
+- Usa `v3` como referencia fija:
+  - `early_all_internet`
+  - `fiber_paperless_early`
+  - `late_mtm_fiber`
+  - `late_mtm_fiber_paperless`
+- Los OOF por defecto de `v3` son los artefactos `midcap`; `--stage` cambia los thresholds del protocolo, no esos paths por defecto.
+- `--candidate-order` define la chain challenger completa; puede reutilizar pasos de `v3`, omitirlos o sobrescribirlos.
+- `--candidate-step` usa formato `<preset>|<oof_path>` y solo hace falta para pasos que no pertenezcan al set fijo de `v3` o que quieras reemplazar.
+- Los OOF usados por defecto para los pasos fijos de `v3` se leen desde `artifacts/reports`:
+  - `residual_reranker_early_all_internet_midcap_oof.csv`
+  - `residual_reranker_fiber_paperless_early_teacher_midcap_oof.csv`
+  - `residual_reranker_late_mtm_fiber_teacher_midcap_oof.csv`
+  - `residual_reranker_late_mtm_fiber_paperless_teacher_midcap_oof.csv`
+- Todos los OOF de pasos deben contener estas columnas:
+  - `id`
+  - `oof_target`
+  - `specialist_mask`
+  - `candidate_pred`
+  - `reference_pred`
+- Todos los pasos deben compartir exactamente:
+  - los mismos `id`
+  - el mismo `oof_target`
+  - el mismo `reference_pred` base dentro de una tolerancia numérica pequeña
+- Si sobrescribes un paso existente de `v3`, el challenger cambia, pero la referencia `v3` sigue usando los OOF fijos originales.
+- La union de `id` en los OOF debe cubrir exactamente `train.csv`; el script falla si detecta cobertura parcial.
+- El script deja:
+  - OOF de referencia `v3`
+  - OOF del challenger
+  - analysis OOF `candidate vs v3`
+  - metrics JSON comparables (`cv_std_auc` incluido)
+  - veredicto del protocolo aplicado directamente contra `v3`
+  - summary JSON con el resumen del veredicto y los paths generados
 
 3h. Ejecutar experimento de especialista local sobre el incumbente
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |   |-- analyze_train_test_drift.py
 |   |-- analyze_error_by_class.py
 |   |-- analyze_family_generalization.py
+|   |-- evaluate_validation_protocol.py
 |   |-- evaluate_ensemble_robustness.py
 |   |-- experiment_fm_probe.py
 |   |-- experiment_hierarchical_priors.py
@@ -252,6 +253,35 @@ Notas:
   `min_test_rows`, y luego se evalua solo el `top-k` ordenado por `reference_logloss_contribution`.
 - En el CSV, las columnas `lofo_*` y `generalization_gap_*` quedan en `NaN` para familias que no
   entraron en ese rerun LOFO.
+
+3g3. Evaluar un candidato OOF bajo el protocolo de `validation reset`
+
+```bash
+python scripts/evaluate_validation_protocol.py --stage smoke --analysis-oof artifacts/reports/family_gated_ec_mtm_fiber_any_teacher_smoke_oof.csv --target-family-level segment3 --target-family-value "Electronic check__Month-to-month__Fiber optic"
+```
+
+Notas:
+- `--analysis-oof` acepta un CSV ya armado con columnas `id`, `target`, `reference_pred` y `candidate_pred`.
+- Si no tienes ese artefacto, puedes usar `--candidate-oof <path>[#<prediction_column>]` y reconstruir la referencia con:
+  - `--reference-oof <path>[#<prediction_column>]`, o
+  - `--oof ...` + `--reference-weights-json`
+- Defaults importantes:
+  - `--train-csv data/raw/train.csv`
+  - `--test-csv data/raw/test.csv`
+  - `--reference-weights-json artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json`
+  - si no pasas `--oof`, el script usa el teacher blend por defecto `cb+xgb+lgb+r+rv`
+  - `--out-json artifacts/reports/validation_protocol_verdict.json`
+- El JSON de salida deja:
+  - metricas globales Split A
+  - checks por macrofamilia dominante y top-3 por dano
+  - checks adicionales por familia objetivo solo si pasas `--target-family-value`
+  - guardrail de familia hermana solo en `segment5` y solo para `submission`; si no pasas `--sister-family-value`, el script intenta derivarla automaticamente desde la clave `segment5`
+  - veredicto agregado `PASS/WARN/FAIL`
+- Para `midcap` o `submission`, debes pasar tambien:
+  - `--candidate-metrics-json`
+  - `--reference-metrics-json`
+- Sin esos JSON el script igual corre, pero el check `midcap_cv_std` queda en `FAIL`.
+- Para `submission`, el gate exige `--submission-csv` para trazar el artefacto final.
 
 3h. Ejecutar experimento de especialista local sobre el incumbente
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Con estratificacion compuesta por target + familia:
 python scripts/train_cv_multiseed.py --folds 5 --seeds "42,2024,3407" --feature-blocks "G,H,R,V" --stratify-mode composite
 ```
 
-2d. Ejecutar experimento de feature engineering por bloques (A/B/C/G/H/R/S/V/O/P)
+2d. Ejecutar experimento de feature engineering por bloques (A/B/C/F/G/H/R/S/V/O/P)
 
 ```bash
 python scripts/experiment_features.py --feature-blocks "G,H,R,V" --stratify-mode composite
@@ -111,6 +111,8 @@ Notas:
 - `experiment_features.py` compara contra un baseline leyendo `--baseline-metrics-path`.
 - Ese JSON debe contener `ensemble_oof_auc`, `oof_auc` o `holdout_auc`.
 - Si quieres un benchmark distinto, apunta `--baseline-metrics-path` al reporte correcto.
+- `F` agrega una superficie target-free enfocada en `Electronic check + Month-to-month + Fiber optic`,
+  con buckets de tenure mas finos, ranks y gaps internos dentro de esa macrofamilia.
 - Soporta un smoke monotónico experimental con:
   - `--monotonic-feature-set minimal`
   - `--monotonic-preset minimal`

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Esquema resumido, no exhaustivo:
 |       |-- specialist.py
 |       |-- telco_transfer.py
 |       |-- target_priors.py
+|       |-- uncertainty_band.py
 |       |-- v3_dominance.py
 |       `-- pipeline.py
 |-- scripts/
@@ -51,6 +52,7 @@ Esquema resumido, no exhaustivo:
 |   |-- experiment_mlp_probe.py
 |   |-- experiment_noise_mitigation.py
 |   |-- experiment_telco_transfer.py
+|   |-- experiment_uncertainty_band.py
 |   |-- run_ngram_xgb.py
 |   |-- experiment_pseudo_label_family.py
 |   |-- experiment_local_calibrator.py
@@ -423,6 +425,33 @@ Notas:
   - metrics JSON comparables (`cv_std_auc` incluido)
   - veredicto del protocolo aplicado directamente contra `v3`
   - summary JSON con el resumen del veredicto y los paths generados
+
+3g4b. Correr un `uncertainty-band reranker` local directamente contra `v3`
+
+```bash
+python scripts/experiment_uncertainty_band.py \
+  --stage smoke \
+  --feature-blocks "H,R,S,V" \
+  --target-family-level segment3 \
+  --target-family-value "Electronic check__Month-to-month__Fiber optic"
+```
+
+Notas:
+- La referencia se fija en `v3` leyendo por defecto:
+  - `artifacts/reports/validation_protocol_v3_chain_oof.csv#candidate_pred`
+- El modelo no reemplaza al incumbent global:
+  - solo corrige filas dentro de la familia objetivo
+  - y solo si `abs(v3 - 0.5) <= --band-half-width`
+- Por defecto agrega tambien las componentes `cb/xgb/lgb/r/rv` como features de desacuerdo del teacher.
+- Guardrails relevantes:
+  - valida alineacion exacta de `v3` contra `train.csv`
+  - exige ambos labels dentro de la banda
+  - exige minimo de filas en train y valid por fold
+  - si pasas `--min-teacher-std`, aborta si el filtro adicional de desacuerdo distorsiona demasiado la tasa base del mask segun `--max-relative-mask-drift`
+- Artefactos principales:
+  - `artifacts/reports/uncertainty_band_smoke_metrics.json`
+  - `artifacts/reports/uncertainty_band_smoke_oof.csv`
+  - `artifacts/reports/validation_protocol_uncertainty_band_smoke_vs_v3.json`
 
 3g5. Correr la linea minima `bi-gram + target encoding + XGBoost`
 

--- a/README.md
+++ b/README.md
@@ -303,6 +303,22 @@ En `approach=feature`, el CLI:
 - el JSON de metricas expone ambos artefactos como `global_model_path` y `family_model_path`
 - el OOF resultante escribe `family_specialist_pred`, `challenger_pred` y `candidate_pred`
 
+Formulacion `gated` para una macrofamilia:
+
+```bash
+python scripts/experiment_specialist_model.py --approach gated --preset ec_mtm_fiber_any --feature-blocks "H,R,S,V" --include-teacher-disagreement-features --family-weight 2.0
+```
+
+En `approach=gated`, el CLI:
+- entrena un challenger global sobre todas las filas;
+- agrega features de gating (`family_focus_mask`, `family_focus_reference_delta`) para la familia objetivo;
+- repondera train y validacion dentro del `preset` con `--family-weight`;
+- mantiene el mismo scan de blend contra `reference_pred`.
+- `--family-weight` debe ser `> 0`, por defecto vale `2.0`, y se reutiliza tambien en el fit final sobre todo el train.
+- guarda un solo modelo global en `--model-path`;
+- el OOF escribe `specialist_mask`, `reference_pred`, `challenger_pred` y `candidate_pred`;
+- el JSON de metricas expone `family_weight`, `family_gating_columns`, `best_alpha` y el delta global/on-mask contra la referencia.
+
 Notas para `--include-teacher-disagreement-features`:
 - agrega `teacher_component_*` y estadisticas derivadas (`std`, `range`, `top_gap`, deltas por pares) usando las columnas `pred_*` del OOF de referencia;
 - requiere que los `--oof` del incumbente expongan componentes individuales (`pred_cb`, `pred_xgb`, `pred_lgb`, `pred_r`, `pred_rv`) y no solo la mezcla final;

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |       |-- diagnostics.py
 |       |-- feature_engineering.py
 |       |-- fm_probe.py
+|       |-- gnn_probe.py
 |       |-- artifacts.py
 |       |-- evaluation.py
 |       |-- kaggle_api.py
@@ -37,6 +38,7 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |   |-- evaluate_validation_protocol.py
 |   |-- evaluate_ensemble_robustness.py
 |   |-- experiment_fm_probe.py
+|   |-- experiment_gnn_probe.py
 |   |-- experiment_hierarchical_priors.py
 |   |-- experiment_linear_probe.py
 |   |-- experiment_mlp_probe.py
@@ -359,6 +361,44 @@ Notas:
   - `reference_pred`
   - `candidate_pred`
   que se puede pasar directo a `evaluate_validation_protocol.py`.
+
+3g6. Correr el smoke minimo `GraphSAGE + ANN graph`
+
+```bash
+python scripts/experiment_gnn_probe.py \
+  --train-csv data/raw/train.csv \
+  --test-csv data/raw/test.csv \
+  --folds 2 \
+  --device auto \
+  --hidden-dim 64 \
+  --epochs 12 \
+  --patience 4 \
+  --k-neighbors 8 \
+  --metrics-path artifacts/reports/gnn_probe_smoke_v2_metrics.json \
+  --oof-path artifacts/reports/gnn_probe_smoke_v2_oof.csv \
+  --reference-v3-oof artifacts/reports/validation_protocol_v3_chain_oof.csv \
+  --analysis-oof-path artifacts/reports/gnn_probe_smoke_v2_analysis_oof.csv
+```
+
+Notas:
+- La linea vive separada del pipeline principal en `src/churn_baseline/gnn_probe.py`.
+- Es una adaptacion minima del notebook externo de GNN:
+  - `torch-geometric` para `GraphSAGE`
+  - `pynndescent` para construir un grafo ANN sobre `train+test`
+  - sin RAPIDS (`cuml/cupy`) y sin hill climbing en esta primera pasada
+- Usa solo:
+  - 16 categoricas base como embeddings de nodo
+  - 3 numericas (`tenure`, `MonthlyCharges`, `TotalCharges`) estandarizadas
+  - grafo KNN sobre `OHE(base_cats) + numericas escaladas`
+- El entrenamiento es transductivo:
+  - el grafo se construye sobre `train+test`
+  - la perdida de cada fold usa solo los nodos de train del fold
+- `--reference-v3-oof` y `--analysis-oof-path` son opcionales; si ambos estan presentes, el CLI deja listo un CSV con:
+  - `id`
+  - `target`
+  - `reference_pred`
+  - `candidate_pred`
+  para pasarlo directo a `evaluate_validation_protocol.py`.
 
 3h. Ejecutar experimento de especialista local sobre el incumbente
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |       |-- modeling.py
 |       |-- pseudo_labeling.py
 |       |-- specialist.py
+|       |-- telco_transfer.py
 |       |-- target_priors.py
 |       `-- pipeline.py
 |-- scripts/
@@ -44,6 +45,8 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |   |-- experiment_hierarchical_priors.py
 |   |-- experiment_linear_probe.py
 |   |-- experiment_mlp_probe.py
+|   |-- experiment_noise_mitigation.py
+|   |-- experiment_telco_transfer.py
 |   |-- run_ngram_xgb.py
 |   |-- experiment_pseudo_label_family.py
 |   |-- experiment_local_calibrator.py
@@ -422,6 +425,38 @@ Notas:
   - `reference_pred`
   - `candidate_pred`
   que se puede pasar directo a `evaluate_validation_protocol.py`.
+
+3g5b. Correr la linea minima `external Telco transfer feature`
+
+```bash
+python scripts/experiment_telco_transfer.py \
+  --train-csv data/raw/train.csv \
+  --test-csv data/raw/test.csv \
+  --original-csv artifacts/external/blastchar_telco/WA_Fn-UseC_-Telco-Customer-Churn.csv \
+  --feature-blocks R,V \
+  --label telco_transfer_smoke
+```
+
+Notas:
+- Entrena un teacher CatBoost solo sobre el dataset original `blastchar` y proyecta una sola feature nueva:
+  - `external_telco_pred`
+- El teacher externo no usa etiquetas de la competencia.
+- El script registra hash/metadata de:
+  - `train.csv`
+  - `test.csv`
+  - `original.csv`
+- Si hay filas del dataset original que coinciden exactamente con `train/test`, las elimina antes de entrenar el teacher externo.
+- El challenger de la competencia se entrena en smoke con `feature_blocks` normales mas `external_telco_pred`.
+- Los artefactos principales son:
+  - `<label>_metrics.json`
+  - `<label>_oof.csv`
+  - `<label>_analysis_oof.csv`
+  - `<label>_candidate_metrics.json`
+  - `<label>_reference_v3_metrics.json`
+  - `<label>_transfer_train.csv`
+  - `<label>_transfer_test.csv`
+  - `validation_protocol_<label>_vs_v3_smoke.json`
+- El primer gate es siempre directo contra `v3`; no hay blend por default en esta linea.
 
 3g6. Correr el smoke minimo `GraphSAGE + ANN graph`
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,24 @@ Notas:
 - `experiment_features.py` compara contra un baseline leyendo `--baseline-metrics-path`.
 - Ese JSON debe contener `ensemble_oof_auc`, `oof_auc` o `holdout_auc`.
 - Si quieres un benchmark distinto, apunta `--baseline-metrics-path` al reporte correcto.
+- Soporta un smoke monotónico experimental con:
+  - `--monotonic-feature-set minimal`
+  - `--monotonic-preset minimal`
+- Si pasas `--monotonic-preset minimal` y dejas `--monotonic-feature-set none`, el CLI activa
+  automaticamente `minimal` para no dejar constraints apuntando a columnas inexistentes.
+- Valores soportados para ambos flags: `none`, `minimal`. Cualquier otro valor falla de forma explicita.
+- Alias aceptados para desactivar: `off`, `false`, `0`.
+- `minimal` agrega solo cuatro señales numéricas estables para este experimento:
+  - `tenure`
+  - `contract_commitment_ordinal`
+  - `is_manual_payment`
+  - `payment_friction_index`
+- Para medir el efecto neto de la restricción, conviene comparar contra el mismo experimento con
+  `--monotonic-feature-set minimal --monotonic-preset none`.
+- Los reportes JSON de `train_baseline*` ahora incluyen `include_monotonic_features`; y
+  `experiment_features.py` agrega `monotonic_feature_set` y `monotonic_preset`.
+- Cuando hay constraints activas, `params_cv` y `params_full_train` también serializan
+  `monotone_constraints` en el JSON.
 
 2e. Ejecutar experimento con priors jerarquicos fold-safe
 
@@ -149,6 +167,9 @@ python scripts/make_submission.py --feature-blocks "G,H,R,V" --train-csv data/ra
 
 Nota:
 - `--train-csv` solo es obligatorio cuando usas bloques fit-aware como `G`.
+- El resultado JSON de `make_submission.py` y `make_submission_ensemble.py` ahora tambien expone
+  `include_monotonic_features` para mantener trazabilidad cuando la inferencia se hace por API
+  usando esa ruta del pipeline.
 
 3b. Generar submission ensemble desde modelos multi-seed
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Esquema resumido, no exhaustivo:
 |       |-- gnn_probe.py
 |       |-- hard_example_stability.py
 |       |-- artifacts.py
+|       |-- cleanroom_baseline.py
 |       |-- evaluation.py
 |       |-- kaggle_api.py
 |       |-- linear_probe.py
@@ -31,6 +32,7 @@ Esquema resumido, no exhaustivo:
 |       |-- modeling.py
 |       |-- pseudo_labeling.py
 |       |-- specialist.py
+|       |-- submission_forensics.py
 |       |-- telco_transfer.py
 |       |-- target_priors.py
 |       |-- uncertainty_band.py
@@ -42,6 +44,7 @@ Esquema resumido, no exhaustivo:
 |   |-- analyze_error_by_class.py
 |   |-- analyze_family_generalization.py
 |   |-- analyze_label_noise.py
+|   |-- analyze_submission_forensics.py
 |   |-- analyze_v3_dominance.py
 |   |-- evaluate_against_v3.py
 |   |-- evaluate_validation_protocol.py
@@ -53,6 +56,7 @@ Esquema resumido, no exhaustivo:
 |   |-- experiment_linear_probe.py
 |   |-- experiment_mlp_probe.py
 |   |-- experiment_noise_mitigation.py
+|   |-- experiment_cleanroom_baselines.py
 |   |-- experiment_telco_transfer.py
 |   |-- experiment_uncertainty_band.py
 |   |-- run_ngram_xgb.py
@@ -301,7 +305,30 @@ Notas:
 - El conflicto `coarse` solo cuenta grupos chicos (`--max-near-duplicate-group-size`, default `5`, minimo `2`) para no confundir cohortes grandes con near-duplicates.
 - El JSON resume concentracion por `segment3`, `segment5` y por la macrofamilia dominante `Electronic check / Month-to-month / Fiber optic`.
 
-3g2c. Probar mitigacion minima de near-duplicates directamente contra `v3`
+3g2c. Hacer submission forensics sobre el historial de Kaggle y los artefactos locales
+
+```bash
+python scripts/analyze_submission_forensics.py \
+  --competition playground-series-s6e3 \
+  --reports-dir artifacts/reports \
+  --submissions-dir artifacts/submissions
+```
+
+Notas:
+- Usa la API autenticada de Kaggle y cruza el historial remoto con JSONs locales que referencian CSVs de `artifacts/submissions/`.
+- El linking entre Kaggle y reportes locales se hace por nombre de CSV; `--submissions-dir` solo controla la verificacion de existencia del archivo local.
+- Salidas por defecto:
+  - `artifacts/reports/submission_forensics_summary.json`
+  - `artifacts/reports/submission_forensics_ledger.csv`
+  - `artifacts/reports/submission_forensics_report_links.csv`
+- El resumen destaca:
+  - mejor submission publica
+  - clustering por `submission_family`
+  - cantidad de submissions con artefactos locales ligados
+  - correlacion local/public cuando existe una metrica local comparable suficiente
+- Sirve para identificar familias que ya mostraron supervivencia publica antes de gastar CPU en `midcap`.
+
+3g2d. Probar mitigacion minima de near-duplicates directamente contra `v3`
 
 ```bash
 python scripts/experiment_noise_mitigation.py \
@@ -331,6 +358,35 @@ Notas:
   - `<label>_candidate_metrics.json`
   - `<label>_reference_v3_metrics.json`
   - `validation_protocol_<label>_vs_v3_smoke.json`
+
+3g2e. Correr el clean-room baseline rebuild minimo contra `v3`
+
+```bash
+python scripts/experiment_cleanroom_baselines.py \
+  --train-csv data/raw/train.csv \
+  --v3-oof artifacts/reports/validation_protocol_v3_chain_oof.csv#candidate_pred
+```
+
+Notas:
+- Ejecuta tres reconstrucciones minimas del baseline con CatBoost:
+  - `cb_raw`
+  - `cb_r`
+  - `cb_rv`
+- Todas se comparan directamente contra `v3` desde `smoke` usando el mismo protocolo de validacion.
+- Los labels efectivos del suite son:
+  - `cleanroom_cb_raw_smoke`
+  - `cleanroom_cb_r_smoke`
+  - `cleanroom_cb_rv_smoke`
+- Salidas por defecto:
+  - `artifacts/reports/cleanroom_baseline_suite_summary.json`
+  - `artifacts/reports/cleanroom_reference_v3_metrics.json`
+  - por cada label (`cleanroom_cb_raw_smoke`, `cleanroom_cb_r_smoke`, `cleanroom_cb_rv_smoke`):
+    - `<label>_metrics.json`
+    - `<label>_oof.csv`
+    - `<label>_analysis_oof.csv`
+    - `<label>_candidate_metrics.json`
+    - `validation_protocol_<label>_vs_v3_smoke.json`
+- El objetivo no es encontrar un nuevo incumbent, sino medir cuanto del edge de `v3` sigue existiendo cuando se reconstruye el stack desde una base simple.
 
 3g3. Evaluar un candidato OOF bajo el protocolo de `validation reset`
 

--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ python scripts/experiment_linear_probe.py \
 ```bash
 python scripts/experiment_rank_reranker.py \
   --feature-blocks H,R,S,V \
+  --preset global \
   --loss-function PairLogitPairwise \
   --folds 2 \
   --iterations 150 \
@@ -437,6 +438,10 @@ python scripts/experiment_rank_reranker.py \
 
 Notas del reranker:
 - usa el blend incumbente como `reference_pred`
+- puede correr en modo global o local con `--preset`
+  - default: `global`
+  - los valores locales validos son los mismos presets de `experiment_specialist_model.py`
+  - `python scripts/experiment_rank_reranker.py --help` muestra la lista exacta
 - agrega `pred_cb/xgb/lgb/r/rv` y estadisticas de desacuerdo del teacher
 - construye queries jerarquicas con fallback:
   - `segment5`

--- a/README.md
+++ b/README.md
@@ -14,12 +14,17 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |   `-- churn_baseline/
 |       |-- config.py
 |       |-- data.py
+|       |-- diagnostics.py
 |       |-- modeling.py
 |       |-- evaluation.py
 |       |-- artifacts.py
 |       |-- kaggle_api.py
 |       `-- pipeline.py
 |-- scripts/
+|   |-- audit_submission_parity.py
+|   |-- analyze_train_test_drift.py
+|   |-- evaluate_ensemble_robustness.py
+|   |-- snapshot_submission_artifacts.py
 |   |-- train_baseline.py
 |   |-- make_submission.py
 |   |-- submit_kaggle.py
@@ -83,6 +88,30 @@ python scripts/make_submission.py
 
 ```bash
 python scripts/make_submission_ensemble.py
+```
+
+3c. Auditar paridad train/inferencia para una submission candidata
+
+```bash
+python scripts/audit_submission_parity.py --metrics-path artifacts/reports/train_cv_multiseed_metrics.json --submission-csv artifacts/submissions/playground-series-s6e3.csv
+```
+
+3d. Capturar snapshot reproducible de artefactos de submission
+
+```bash
+python scripts/snapshot_submission_artifacts.py --metrics-path artifacts/reports/train_cv_multiseed_metrics.json --submission-csv artifacts/submissions/playground-series-s6e3.csv --label "pre-submit-check"
+```
+
+3e. Analizar drift train/test y adversarial validation
+
+```bash
+python scripts/analyze_train_test_drift.py --feature-blocks none --adv-folds 3 --adv-sample-frac 0.35
+```
+
+3f. Medir robustez de ensemble (equal/rank/weighted) con validacion repetida
+
+```bash
+python scripts/evaluate_ensemble_robustness.py --oof cb=artifacts/reports/train_cv_multiseed_full_hiiter_oof.csv#oof_ensemble --oof lgb=artifacts/reports/train_lightgbm_cv_full_hiiter_oof.csv#oof_pred --oof xgb=artifacts/reports/train_xgboost_cv_full_hiiter_oof.csv#oof_pred --repeats 3 --folds 5
 ```
 
 4. Enviar a Kaggle (opcional)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |   |-- audit_submission_parity.py
 |   |-- analyze_train_test_drift.py
 |   |-- evaluate_ensemble_robustness.py
+|   |-- gate_submission_candidate.py
 |   |-- snapshot_submission_artifacts.py
 |   |-- train_baseline.py
 |   |-- make_submission.py
@@ -112,6 +113,12 @@ python scripts/analyze_train_test_drift.py --feature-blocks none --adv-folds 3 -
 
 ```bash
 python scripts/evaluate_ensemble_robustness.py --oof cb=artifacts/reports/train_cv_multiseed_full_hiiter_oof.csv#oof_ensemble --oof lgb=artifacts/reports/train_lightgbm_cv_full_hiiter_oof.csv#oof_pred --oof xgb=artifacts/reports/train_xgboost_cv_full_hiiter_oof.csv#oof_pred --repeats 3 --folds 5
+```
+
+3g. Aplicar gate automatico GO/NO_GO para decidir submission
+
+```bash
+python scripts/gate_submission_candidate.py --candidate-name playground-series-s6e3 --parity-json artifacts/reports/diagnostic_submission_parity_issue5.json --drift-json artifacts/reports/diagnostic_train_test_drift_issue5.json --robustness-json artifacts/reports/diagnostic_ensemble_robustness_issue5.json
 ```
 
 4. Enviar a Kaggle (opcional)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Con estratificacion compuesta por target + familia:
 python scripts/train_cv_multiseed.py --folds 5 --seeds "42,2024,3407" --feature-blocks "G,H,R,V" --stratify-mode composite
 ```
 
-2d. Ejecutar experimento de feature engineering por bloques (A/B/C/F/G/H/R/S/V/O/P)
+2d. Ejecutar experimento de feature engineering por bloques (A/B/C/F/G/T/H/R/S/V/O/P)
 
 ```bash
 python scripts/experiment_features.py --feature-blocks "G,H,R,V" --stratify-mode composite
@@ -113,6 +113,9 @@ Notas:
 - Si quieres un benchmark distinto, apunta `--baseline-metrics-path` al reporte correcto.
 - `F` agrega una superficie target-free enfocada en `Electronic check + Month-to-month + Fiber optic`,
   con buckets de tenure mas finos, ranks y gaps internos dentro de esa macrofamilia.
+- `T` agrega la version `fit-aware` de esa superficie: ajusta mapas solo sobre train,
+  hace fallback `fine tenure + paperless -> tenure_bin + paperless -> paperless` y expone
+  ranks aproximados respecto de la distribucion aprendida en train.
 - Soporta un smoke monotónico experimental con:
   - `--monotonic-feature-set minimal`
   - `--monotonic-preset minimal`
@@ -156,7 +159,8 @@ Bloques relevantes para outliers:
 
 Bloques estructurales:
 - `G`: cobertura y backoff por familia fit-aware (`segment3/segment5`, soporte train-only, unseen/low-support, familia colapsada al padre).
-- Si entrenas con `G`, en inferencia debes pasar `--train-csv` a los CLI que materializan submissions para reconstruir el estado train-only.
+- `T`: superficie fit-aware enfocada en `Electronic check + Month-to-month + Fiber optic`, con fallback `fine tenure + paperless -> tenure_bin + paperless -> paperless` y ranks aproximados respecto del train.
+- Si entrenas con `G` o `T`, en inferencia debes pasar `--train-csv` a los CLI que materializan submissions para reconstruir el estado train-only.
 - `H`: contrastes intra-cohorte para bundles raros dentro de grupos duros (rareza y desvio respecto de la cohorte).
 - `R`: lifecycle y renovacion (`tenure_mod_*`, distancia a borde de contrato, bins de ciclo).
 - `S`: topologia del bundle y firma de servicios (support vs entertainment, archetype, signatures).
@@ -169,7 +173,7 @@ python scripts/make_submission.py --feature-blocks "G,H,R,V" --train-csv data/ra
 ```
 
 Nota:
-- `--train-csv` solo es obligatorio cuando usas bloques fit-aware como `G`.
+- `--train-csv` solo es obligatorio cuando usas bloques fit-aware como `G` o `T`.
 - El resultado JSON de `make_submission.py` y `make_submission_ensemble.py` ahora tambien expone
   `include_monotonic_features` para mantener trazabilidad cuando la inferencia se hace por API
   usando esa ruta del pipeline.
@@ -183,7 +187,7 @@ python scripts/make_submission_ensemble.py --feature-blocks "G,H,R,V" --train-cs
 Notas:
 - `make_submission_ensemble.py` usa `--model-paths` si los pasas manualmente.
 - Si no, lee `--metrics-path` y espera una clave `model_paths` en ese JSON.
-- `--train-csv` es necesario cuando usas bloques fit-aware como `G`, para reconstruir soporte/backoff con estado aprendido solo en train.
+- `--train-csv` es necesario cuando usas bloques fit-aware como `G` o `T`, para reconstruir estado aprendido solo en train.
 
 3b2. Generar submission desde experimento de priors jerarquicos
 
@@ -342,7 +346,7 @@ Formato de cada `--step`:
 
 Prerequisitos minimos:
 - `test.csv`
-- `train.csv` si algun step usa bloques fit-aware como `G`
+- `train.csv` si algun step usa bloques fit-aware como `G` o `T`
 - submission base con columnas `id, Churn`
 - modelos `.cbm` residuales ya entrenados
 
@@ -382,7 +386,7 @@ Este wrapper:
 Flags utiles del wrapper:
 - `--step` es obligatorio y puede repetirse una o mas veces.
 - `--teacher-aware` exige `--reference-mode base`.
-- `--train-csv` es necesario si algun paso o reconstruccion usa bloques fit-aware como `G`.
+- `--train-csv` es necesario si algun paso o reconstruccion usa bloques fit-aware como `G` o `T`.
 - `--reference-component-csv` permite reutilizar un frame `id + pred_*` ya construido.
 - `--reference-component-report-json` fija la ruta del JSON del builder cuando usas `--teacher-aware`.
 - `--test-csv` permite apuntar a otro `test.csv`.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |       |-- config.py
 |       |-- data.py
 |       |-- diagnostics.py
+|       |-- noise_audit.py
 |       |-- feature_engineering.py
 |       |-- fm_probe.py
 |       |-- gnn_probe.py
@@ -34,6 +35,7 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |   |-- analyze_train_test_drift.py
 |   |-- analyze_error_by_class.py
 |   |-- analyze_family_generalization.py
+|   |-- analyze_label_noise.py
 |   |-- evaluate_against_v3.py
 |   |-- evaluate_validation_protocol.py
 |   |-- evaluate_ensemble_robustness.py
@@ -258,6 +260,34 @@ Notas:
   `min_test_rows`, y luego se evalua solo el `top-k` ordenado por `reference_logloss_contribution`.
 - En el CSV, las columnas `lofo_*` y `generalization_gap_*` quedan en `NaN` para familias que no
   entraron en ese rerun LOFO.
+
+3g2b. Auditar `label noise`, `near-duplicates` y ejemplos duros contra `v3`
+
+```bash
+python scripts/analyze_label_noise.py \
+  --train-csv data/raw/train.csv \
+  --v3-oof artifacts/reports/validation_protocol_v3_chain_oof.csv#candidate_pred \
+  --out-json artifacts/reports/label_noise_audit_summary.json \
+  --out-rows-csv artifacts/reports/label_noise_audit_suspicious_rows.csv \
+  --out-duplicate-csv artifacts/reports/label_noise_audit_duplicate_groups.csv
+```
+
+Notas:
+- `--train-csv` default: `data/raw/train.csv`.
+- `--v3-oof` debe apuntar a un CSV con `id`, `target` y una columna de prediccion continua; el sufijo `#candidate_pred` indica explicitamente esa columna.
+- Usa `v3` como referencia fija y falla si el OOF no cubre exactamente `train.csv`.
+- Si estan disponibles los OOF `cb/xgb/lgb/r/rv`, agrega desacuerdo del teacher:
+  - `teacher_mean`
+  - `teacher_std`
+  - `teacher_range`
+  - `teacher_unanimous_side`
+- Distingue tres clases diagnosticas:
+  - `label_noise_candidate`
+  - `near_duplicate_conflict`
+  - `hard_example_stable`
+- El CSV de grupos de duplicados reporta firmas `exact` y `coarse`.
+- El conflicto `coarse` solo cuenta grupos chicos (`--max-near-duplicate-group-size`, default `5`, minimo `2`) para no confundir cohortes grandes con near-duplicates.
+- El JSON resume concentracion por `segment3`, `segment5` y por la macrofamilia dominante `Electronic check / Month-to-month / Fiber optic`.
 
 3g3. Evaluar un candidato OOF bajo el protocolo de `validation reset`
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 
 ## Estructura del proyecto
 
+Esquema resumido, no exhaustivo:
+
 ```
 .
 |-- src/
@@ -30,6 +32,7 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |       |-- specialist.py
 |       |-- telco_transfer.py
 |       |-- target_priors.py
+|       |-- v3_dominance.py
 |       `-- pipeline.py
 |-- scripts/
 |   |-- audit_submission_parity.py
@@ -37,6 +40,7 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |   |-- analyze_error_by_class.py
 |   |-- analyze_family_generalization.py
 |   |-- analyze_label_noise.py
+|   |-- analyze_v3_dominance.py
 |   |-- evaluate_against_v3.py
 |   |-- evaluate_validation_protocol.py
 |   |-- evaluate_ensemble_robustness.py
@@ -351,6 +355,33 @@ Notas:
   - `--reference-metrics-json`
 - Sin esos JSON el script igual corre, pero el check `midcap_cv_std` queda en `FAIL`.
 - Para `submission`, el gate exige `--submission-csv` para trazar el artefacto final.
+
+3g3b. Diagnosticar por que `v3` domina challengers fallidos
+
+```bash
+python scripts/analyze_v3_dominance.py --label v3_dominance_v1
+```
+
+Notas:
+- Usa `v3` fijo desde `artifacts/reports/validation_protocol_v3_chain_oof.csv#candidate_pred`.
+- Por default compara un set curado de challengers que representan familias distintas de fracaso:
+  - bloque global
+  - challenger por familia
+  - mitigacion data-centric
+  - transfer externo
+  - residual casi-vivo
+- Produce:
+  - `<label>_summary.json`
+  - `<label>_challengers.csv`
+  - `<label>_families.csv`
+  - `<label>_slices.csv`
+- Los cortes incluyen:
+  - `segment3`
+  - `segment5`
+  - deciles de score `v3`
+  - buckets de confianza `abs(v3 - 0.5)`
+  - buckets de desacuerdo `abs(candidate - v3)`
+- Sirve para decidir la siguiente hipotesis sin entrenar modelos nuevos.
 
 3g4. Comparar una chain challenger directamente contra `v3`
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ python scripts/train_cv.py --folds 5
 python scripts/train_cv_multiseed.py --folds 5 --seeds "42,2024,3407"
 ```
 
+Con bloques de features:
+
+```bash
+python scripts/train_cv_multiseed.py --folds 5 --seeds "42,2024,3407" --feature-blocks "O,P"
+```
+
 2d. Ejecutar experimento de feature engineering por bloques (A/B/C/O/P)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -349,9 +349,17 @@ Presets soportados por la linea local:
 - `manual_no_internet`
 - `one_year_fiber_any`
 - `one_year_dsl_any`
+- `one_year_dsl_paperless_49plus`: One year + DSL + PaperlessBilling=Yes + tenure >= 49
 - `two_year_fiber_any`
+- `two_year_dsl_paperless_49plus`: Two year + DSL + PaperlessBilling=Yes + tenure >= 49
 - `one_year_fiber_paperless_49plus`
+- `one_year_fiber_paperless_25_48`: One year + Fiber optic + PaperlessBilling=Yes + tenure 25-48 inclusive
 - `two_year_fiber_paperless_49plus`
+- `two_year_fiber_nopaperless_49plus`: Two year + Fiber optic + PaperlessBilling=No + tenure >= 49
+- `mtm_dsl_paperless_25_48_manual`: Month-to-month + DSL + PaperlessBilling=Yes + tenure 25-48 + pago manual
+- `mtm_dsl_paperless_25_48_any`: Month-to-month + DSL + PaperlessBilling=Yes + tenure 25-48 + cualquier pago
+- `mtm_nointernet_mailed_0_24`: Month-to-month + InternetService=No + Mailed check + tenure <= 24
+- `mtm_nointernet_no_0_6`: Month-to-month + InternetService=No + PaperlessBilling=No + tenure <= 6
 
 3i4. Probar una senal ortogonal barata con modelo lineal disperso
 
@@ -375,12 +383,73 @@ Familias soportadas:
 - `logistic`
 - `spline_logistic`: aplica spline basis solo sobre un subconjunto curado de variables
   numericas continuas y deja el resto en camino lineal
+- `catboost_meta`: booster chico sobre el mismo `teacher_meta`, pensado para detectar
+  interacciones no lineales con regularizacion fuerte
+
+Modos de features soportados:
+- `raw`: usa la matriz tabular normal construida desde `train.csv` y `--feature-blocks`
+- `teacher_meta`: usa una matriz compacta con:
+  - cohort keys (`PaymentMethod`, `Contract`, `InternetService`, `PaperlessBilling`, `tenure_bin`)
+  - `reference_pred_feature`
+  - `reference_logit_feature`
+  - componentes `pred_*` del teacher
+  - estadisticas de desacuerdo entre componentes del teacher
+  - requiere que `--reference-weights-json` y `--oof` apunten a predicciones OOF
+    alineadas por `id`
+  - `catboost_meta` solo se soporta sobre este modo
+
+Nota:
+- en `teacher_meta`, `--feature-blocks` se ignora; dejarlo en `none` evita ambiguedad
+
+Ejemplo `teacher_meta`:
+
+```bash
+python scripts/experiment_linear_probe.py \
+  --model-family logistic \
+  --feature-mode teacher_meta \
+  --feature-blocks none \
+  --reference-is-oof \
+  --reference-weights-json artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json \
+  --oof cb=artifacts/reports/train_cv_multiseed_gate_s5_hiiter_oof.csv#oof_ensemble \
+  --oof xgb=artifacts/reports/train_xgboost_cv_multiseed_hiiter_oof.csv#oof_ensemble \
+  --oof lgb=artifacts/reports/train_lightgbm_cv_full_hiiter_oof.csv#oof_pred \
+  --oof r=artifacts/reports/fe_blockR_hiiter_oof.csv#oof_pred \
+  --oof rv=artifacts/reports/fe_blockRV_hiiter_oof.csv#oof_pred
+```
+
+Ejemplo `catboost_meta`:
+
+```bash
+python scripts/experiment_linear_probe.py \
+  --model-family catboost_meta \
+  --feature-mode teacher_meta \
+  --feature-blocks none \
+  --reference-is-oof \
+  --tree-iterations 300 \
+  --tree-depth 4 \
+  --tree-learning-rate 0.05 \
+  --tree-l2-leaf-reg 8.0 \
+  --tree-early-stopping-rounds 50 \
+  --reference-weights-json artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json \
+  --oof cb=artifacts/reports/train_cv_multiseed_gate_s5_hiiter_oof.csv#oof_ensemble \
+  --oof xgb=artifacts/reports/train_xgboost_cv_multiseed_hiiter_oof.csv#oof_ensemble \
+  --oof lgb=artifacts/reports/train_lightgbm_cv_full_hiiter_oof.csv#oof_pred \
+  --oof r=artifacts/reports/fe_blockR_hiiter_oof.csv#oof_pred \
+  --oof rv=artifacts/reports/fe_blockRV_hiiter_oof.csv#oof_pred
+```
 
 Prerequisitos minimos del probe lineal:
 - `train.csv`
-- `--reference-weights-json` con objeto `{"weights": {...}}`
-- uno o mas `--oof` con formato `<name>=<path>[#<prediction_column>]`
-- las keys de `weights` deben coincidir con los nombres entregados en `--oof`
+- para `--feature-mode raw`: solo `train.csv`
+- para `--feature-mode teacher_meta`:
+  - `--reference-is-oof`
+  - `--reference-weights-json` con objeto `{"weights": {...}}`
+  - uno o mas `--oof` con formato `<name>=<path>[#<prediction_column>]`
+  - las keys de `weights` deben coincidir con los nombres entregados en `--oof`
+  - el merge OOF debe contener columnas `pred_*` y cubrir todos los `id` de train
+- nota: incluso en `--feature-mode raw`, si entregas `--reference-weights-json` para
+  medir contra una referencia, debes entregar tambien `--oof` y `--reference-is-oof`
+  porque el script reconstruye la referencia OOF y valida esa cobertura por `id`
 
 3i5. Probar una senal ortogonal con `FM/FFM` via `river`
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,12 @@ Notas:
 python scripts/experiment_specialist_model.py --preset early_manual_internet --feature-blocks "H,R,S,V"
 ```
 
+Para la macrofamilia dominante de `issue #8`, el primer challenger supervisado se prueba con:
+
+```bash
+python scripts/experiment_specialist_model.py --approach classifier --preset ec_mtm_fiber_any --feature-blocks "H,R,S,V"
+```
+
 Requiere que exista el OOF del incumbente (`cb/xgb/lgb/r/rv`) y el archivo de pesos
 `artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json`.
 Por defecto escribe a `artifacts/models/`, `artifacts/reports/` y usa `--alpha-grid`
@@ -397,7 +403,7 @@ Defaults derivados cuando usas `--teacher-aware`:
 - CSV del builder: `<output_csv_stem>_teacher_components.csv`
 - JSON del builder: `<report_json_stem>_teacher_components.json`
 
-Presets soportados por la linea local:
+Presets soportados por la linea local (`scripts/experiment_specialist_model.py`):
 - `early_manual_internet`
 - `early_all_internet`
 - `fiber_paperless_early`
@@ -418,6 +424,7 @@ Presets soportados por la linea local:
 - `mtm_dsl_paperless_25_48_any`: Month-to-month + DSL + PaperlessBilling=Yes + tenure 25-48 + cualquier pago
 - `mtm_nointernet_mailed_0_24`: Month-to-month + InternetService=No + Mailed check + tenure <= 24
 - `mtm_nointernet_no_0_6`: Month-to-month + InternetService=No + PaperlessBilling=No + tenure <= 6
+- `ec_mtm_fiber_any`: Electronic check + Month-to-month + Fiber optic + cualquier PaperlessBilling + cualquier tenure
 - `ec_mtm_fiber_paperless_0_6`: Electronic check + Month-to-month + Fiber optic + PaperlessBilling=Yes + tenure <= 6
 - `ec_mtm_fiber_paperless_25_48`: Electronic check + Month-to-month + Fiber optic + PaperlessBilling=Yes + tenure 25-48
 - `ec_mtm_fiber_paperless_any`: Electronic check + Month-to-month + Fiber optic + PaperlessBilling=Yes + cualquier tenure

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Predecir la probabilidad de `Churn` para cada `id` del archivo `test.csv`.
 |   |-- audit_submission_parity.py
 |   |-- analyze_train_test_drift.py
 |   |-- analyze_error_by_class.py
+|   |-- analyze_family_generalization.py
 |   |-- evaluate_ensemble_robustness.py
 |   |-- experiment_fm_probe.py
 |   |-- experiment_hierarchical_priors.py
@@ -217,6 +218,34 @@ python scripts/evaluate_ensemble_robustness.py --oof cb=artifacts/reports/train_
 ```bash
 python scripts/analyze_error_by_class.py --reference-weights-json artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_weights.json --challenger-weights-json artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json
 ```
+
+3g2. Construir una brujula de generalizacion por familia con leave-one-family-out
+
+```bash
+python scripts/analyze_family_generalization.py --family-level segment5 --feature-blocks "H,R,V" --top-k-families 12
+```
+
+Notas:
+- Salidas por defecto:
+  - JSON: `artifacts/reports/diagnostic_family_generalization_summary.json`
+  - CSV: `artifacts/reports/diagnostic_family_generalization_families.csv`
+- El script tambien imprime el JSON resumido a `stdout`.
+- Por defecto usa como referencia el teacher blend `cb+xgb+lgb+r+rv` definido en `submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json`.
+- Si quieres una referencia directa distinta, puedes pasar `--reference-oof <path>[#<prediction_column>]`.
+- Si quieres reconstruir otra referencia ponderada, puedes pasar `--oof ...` y `--reference-weights-json ...`.
+- `--family-level` soporta `segment3` y `segment5`.
+- El rerun LOFO usa hiperparametros fijos y expone `--iterations`, `--learning-rate`, `--depth`, `--l2-leaf-reg`.
+- El JSON resume familias de mayor dano y mayor gap de generalizacion; el CSV deja la tabla completa con:
+  - `reference_auc`, `reference_logloss`, `reference_logloss_contribution`
+  - `lofo_auc`, `lofo_logloss`
+  - `generalization_gap_auc`, `generalization_gap_logloss`, `generalization_gap_logloss_contribution`
+- El JSON tambien incluye bloques estructurados: `reference_source`, `selection`, `model_params`,
+  `top_reference_risk_families` y `top_generalization_gap_families`.
+- `min_train_rows` y `min_test_rows` filtran familias que no tienen soporte suficiente para ser accionables.
+- El rerun LOFO no se ejecuta sobre todas las familias: primero se filtra por `min_train_rows` y
+  `min_test_rows`, y luego se evalua solo el `top-k` ordenado por `reference_logloss_contribution`.
+- En el CSV, las columnas `lofo_*` y `generalization_gap_*` quedan en `NaN` para familias que no
+  entraron en ese rerun LOFO.
 
 3h. Ejecutar experimento de especialista local sobre el incumbente
 

--- a/README.md
+++ b/README.md
@@ -412,6 +412,9 @@ Presets soportados por la linea local:
 - `mtm_dsl_paperless_25_48_any`: Month-to-month + DSL + PaperlessBilling=Yes + tenure 25-48 + cualquier pago
 - `mtm_nointernet_mailed_0_24`: Month-to-month + InternetService=No + Mailed check + tenure <= 24
 - `mtm_nointernet_no_0_6`: Month-to-month + InternetService=No + PaperlessBilling=No + tenure <= 6
+- `ec_mtm_fiber_paperless_0_6`: Electronic check + Month-to-month + Fiber optic + PaperlessBilling=Yes + tenure <= 6
+- `ec_mtm_fiber_paperless_25_48`: Electronic check + Month-to-month + Fiber optic + PaperlessBilling=Yes + tenure 25-48
+- `ec_mtm_fiber_paperless_any`: Electronic check + Month-to-month + Fiber optic + PaperlessBilling=Yes + cualquier tenure
 
 3i4. Probar una senal ortogonal barata con modelo lineal disperso
 

--- a/README.md
+++ b/README.md
@@ -417,6 +417,46 @@ python scripts/experiment_linear_probe.py \
   --oof rv=artifacts/reports/fe_blockRV_hiiter_oof.csv#oof_pred
 ```
 
+3i4b. Probar un reranker orientado a ranking sobre el teacher
+
+```bash
+python scripts/experiment_rank_reranker.py \
+  --feature-blocks H,R,S,V \
+  --loss-function PairLogitPairwise \
+  --folds 2 \
+  --iterations 150 \
+  --learning-rate 0.05 \
+  --depth 6 \
+  --l2-leaf-reg 5.0 \
+  --max-pairs-per-group 1000 \
+  --early-stopping-rounds 40 \
+  --metrics-path artifacts/reports/rank_reranker_pairlogit_smoke_metrics.json \
+  --oof-path artifacts/reports/rank_reranker_pairlogit_smoke_oof.csv \
+  --model-path artifacts/models/rank_reranker_pairlogit_smoke.cbm
+```
+
+Notas del reranker:
+- usa el blend incumbente como `reference_pred`
+- agrega `pred_cb/xgb/lgb/r/rv` y estadisticas de desacuerdo del teacher
+- construye queries jerarquicas con fallback:
+  - `segment5`
+  - `segment3`
+  - `contract_internet_tenure`
+  - `contract_tenure`
+  - `contract`
+  - `global`
+- combina el score del ranker con el teacher mediante `rank-average` ponderado por `alpha`
+- limita el costo pairwise muestreando hasta `max-pairs-per-group` pares por query
+- flags operativos importantes:
+  - `--reference-weights-json` y `--oof` controlan exactamente el teacher base
+  - `--alpha-grid` controla la mezcla `teacher + ranker`
+  - `--stratify-mode` controla solo el split externo de CV
+  - `--min-query-rows`, `--min-query-positive-rows`, `--min-query-negative-rows` controlan el fallback jerarquico
+  - `--train-csv`, `--random-state` y `--verbose` quedan expuestos para reproducibilidad
+- losses soportadas:
+  - `PairLogitPairwise`
+  - `YetiRankPairwise`
+
 Ejemplo `catboost_meta`:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Esquema resumido, no exhaustivo:
 |       |-- feature_engineering.py
 |       |-- fm_probe.py
 |       |-- gnn_probe.py
+|       |-- hard_example_stability.py
 |       |-- artifacts.py
 |       |-- evaluation.py
 |       |-- kaggle_api.py
@@ -48,6 +49,7 @@ Esquema resumido, no exhaustivo:
 |   |-- experiment_fm_probe.py
 |   |-- experiment_gnn_probe.py
 |   |-- experiment_hierarchical_priors.py
+|   |-- experiment_hard_example_stability.py
 |   |-- experiment_linear_probe.py
 |   |-- experiment_mlp_probe.py
 |   |-- experiment_noise_mitigation.py
@@ -452,6 +454,31 @@ Notas:
   - `artifacts/reports/uncertainty_band_smoke_metrics.json`
   - `artifacts/reports/uncertainty_band_smoke_oof.csv`
   - `artifacts/reports/validation_protocol_uncertainty_band_smoke_vs_v3.json`
+
+3g4c. Correr la linea `hard-example stability` directamente contra `v3`
+
+```bash
+python scripts/experiment_hard_example_stability.py \
+  --stage smoke \
+  --stability-feature-blocks "R,V" \
+  --reranker-feature-blocks "H,R,S,V" \
+  --family-level segment3 \
+  --family-value "Electronic check__Month-to-month__Fiber optic"
+```
+
+Notas:
+- Esta linea construye primero un `hard_example_score` por fila usando OOF repetidos baratos.
+- El score sale de:
+  - `stability_pred_std`
+  - `stability_flip_rate`
+- Luego entrena un residual reranker local solo dentro de:
+  - la familia objetivo
+  - y el top cuantílico de `hard_example_score` dentro de esa familia
+- `--reference-band-half-width` es opcional; sirve para intersectar el mask de dureza con la banda ambigua de `v3`.
+- Artefactos principales:
+  - `artifacts/reports/hard_example_stability_smoke_metrics.json`
+  - `artifacts/reports/hard_example_stability_smoke_oof.csv`
+  - `artifacts/reports/validation_protocol_hard_example_stability_smoke_vs_v3.json`
 
 3g5. Correr la linea minima `bi-gram + target encoding + XGBoost`
 

--- a/README.md
+++ b/README.md
@@ -415,6 +415,8 @@ Presets soportados por la linea local:
 - `ec_mtm_fiber_paperless_0_6`: Electronic check + Month-to-month + Fiber optic + PaperlessBilling=Yes + tenure <= 6
 - `ec_mtm_fiber_paperless_25_48`: Electronic check + Month-to-month + Fiber optic + PaperlessBilling=Yes + tenure 25-48
 - `ec_mtm_fiber_paperless_any`: Electronic check + Month-to-month + Fiber optic + PaperlessBilling=Yes + cualquier tenure
+- `ec_mtm_dsl_paperless_0_6`: Electronic check + Month-to-month + DSL + PaperlessBilling=Yes + tenure <= 6
+- `ec_mtm_dsl_paperless_any`: Electronic check + Month-to-month + DSL + PaperlessBilling=Yes + cualquier tenure
 
 3i4. Probar una senal ortogonal barata con modelo lineal disperso
 

--- a/README.md
+++ b/README.md
@@ -480,6 +480,56 @@ Notas:
   - `artifacts/reports/hard_example_stability_smoke_oof.csv`
   - `artifacts/reports/validation_protocol_hard_example_stability_smoke_vs_v3.json`
 
+3g4d. Correr la linea `counterfactual teacher sensitivity` directamente contra `v3`
+
+```bash
+python scripts/experiment_counterfactual_sensitivity.py \
+  --stage smoke \
+  --target-family-level segment3 \
+  --target-family-value "Electronic check__Month-to-month__Fiber optic"
+```
+
+Notas:
+- Esta linea no entrena otro challenger grande. Parte desde `v3` y construye una correccion aditiva local.
+- La correccion se basa en perturbaciones plausibles del mismo cliente, evaluadas con esta subfamilia del teacher disponible como modelos full-train:
+  - `cb`
+  - `r`
+  - `rv`
+  con pesos renormalizados desde `artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json`.
+- Los escenarios contrafactuales se controlan con `--counterfactuals`; por defecto usa:
+  - `auto_payment`
+  - `paperless_off`
+  - `contract_upgrade`
+  - `stability_bundle`
+- La señal no es una probabilidad nueva; es una medida de `counterfactual drop`:
+  - cuanto baja el teacher si movemos al cliente a un estado mas estable
+  - las subidas se recortan a `0`, o sea, el smoke usa solo `positive drop`
+- `--signal-names` define como se agrega esa sensibilidad:
+  - `stable_bundle_drop`
+  - `mean_positive_drop`
+  - `max_positive_drop`
+- `--alpha-grid` escanea una correccion aditiva sobre `v3` y elige el mejor `candidate_pred` por AUC OOF.
+- La correccion solo se aplica dentro del mask objetivo:
+  - `target-family-level`
+  - `target-family-value`
+  y fuera de ese mask deja `candidate_pred == reference_pred`.
+- `--reference-band-half-width` es opcional; si se pasa, la correccion solo se aplica tambien dentro de la banda ambigua de `v3`.
+  Debe cumplir `0 < width < 0.5`.
+- El mask final debe tener al menos `2000` filas; si no, el script falla de forma explicita.
+- `--component-weights-json` debe contener:
+  - `weights`
+  - `components.cb_models`
+  - `components.r_model`
+  - `components.rv_model`
+- El input crudo debe seguir teniendo estas columnas porque los contrafactuales las mutan directamente:
+  - `PaymentMethod`
+  - `PaperlessBilling`
+  - `Contract`
+- Artefactos principales:
+  - `artifacts/reports/counterfactual_teacher_smoke_metrics.json`
+  - `artifacts/reports/counterfactual_teacher_smoke_analysis_oof.csv`
+  - `artifacts/reports/validation_protocol_counterfactual_teacher_smoke_vs_v3.json`
+
 3g5. Correr la linea minima `bi-gram + target encoding + XGBoost`
 
 ```bash

--- a/docs/estado.md
+++ b/docs/estado.md
@@ -29,4 +29,7 @@ Estado operativo actual:
   - `public score = 0.91421`
 - La linea data-centric de `label noise / near-duplicates` quedo cerrada como `NO-GO` para mitigacion directa.
 - La linea `external telco transfer feature` tambien quedo cerrada como `NO-GO`.
-- Siguiente direccion recomendada: `uncertainty-band reranker` focal sobre la banda ambigua de `v3`.
+- La linea `uncertainty-band reranker` tambien quedo cerrada como `NO-GO`.
+- Siguiente direccion recomendada:
+  - no abrir otra linea sin pasar primero por el filtro documentado en `phase-reset-summary.md` y `model-family-ledger.md`
+  - toda hipotesis nueva debe nacer comparada directamente contra `v3` desde `smoke`

--- a/docs/estado.md
+++ b/docs/estado.md
@@ -2,6 +2,8 @@
 
 Fecha de inicializacion: `2026-03-04`
 
+Estado operativo actual: ver [phase-reset-summary.md](./phase-reset-summary.md)
+
 ## Hecho
 
 - Repositorio GitHub creado:
@@ -18,4 +20,7 @@ Fecha de inicializacion: `2026-03-04`
 
 - Los CSV y ZIP se ignoran en git por `.gitignore`.
 - Esta competencia usa `ROC AUC` como metrica.
-
+- Mejor incumbent publico vigente:
+  - `v3`
+  - Kaggle `ref 50828079`
+  - `public score = 0.91421`

--- a/docs/estado.md
+++ b/docs/estado.md
@@ -1,7 +1,7 @@
 # Estado del proyecto
 
 Fecha de inicializacion: `2026-03-04`
-Ultima actualizacion: `2026-03-12`
+Ultima actualizacion: `2026-03-13`
 
 Estado operativo actual:
 - resumen ejecutivo: [phase-reset-summary.md](./phase-reset-summary.md)
@@ -28,4 +28,5 @@ Estado operativo actual:
   - Kaggle `ref 50828079`
   - `public score = 0.91421`
 - La linea data-centric de `label noise / near-duplicates` quedo cerrada como `NO-GO` para mitigacion directa.
-- Siguiente direccion recomendada: senal supervisada externa desde `telco-customer-churn`.
+- La linea `external telco transfer feature` tambien quedo cerrada como `NO-GO`.
+- Siguiente direccion recomendada: `uncertainty-band reranker` focal sobre la banda ambigua de `v3`.

--- a/docs/estado.md
+++ b/docs/estado.md
@@ -31,7 +31,8 @@ Estado operativo actual:
 - La linea `external telco transfer feature` tambien quedo cerrada como `NO-GO`.
 - La linea `uncertainty-band reranker` tambien quedo cerrada como `NO-GO`.
 - La linea `hard-example stability score` tambien quedo cerrada como `NO-GO`.
+- La linea `counterfactual teacher sensitivity` tambien quedo cerrada como `NO-GO`.
 - Siguiente direccion recomendada:
   - no abrir otra linea sin pasar primero por el filtro documentado en `phase-reset-summary.md` y `model-family-ledger.md`
   - toda hipotesis nueva debe nacer comparada directamente contra `v3` desde `smoke`
-  - siguiente apuesta concreta recomendada: `counterfactual teacher sensitivity features`
+  - siguiente apuesta concreta recomendada: `source-aware joint training con Telco original`

--- a/docs/estado.md
+++ b/docs/estado.md
@@ -1,8 +1,11 @@
 # Estado del proyecto
 
 Fecha de inicializacion: `2026-03-04`
+Ultima actualizacion: `2026-03-12`
 
-Estado operativo actual: ver [phase-reset-summary.md](./phase-reset-summary.md)
+Estado operativo actual:
+- resumen ejecutivo: [phase-reset-summary.md](./phase-reset-summary.md)
+- ledger de familias/modelos: [model-family-ledger.md](./model-family-ledger.md)
 
 ## Hecho
 
@@ -24,3 +27,5 @@ Estado operativo actual: ver [phase-reset-summary.md](./phase-reset-summary.md)
   - `v3`
   - Kaggle `ref 50828079`
   - `public score = 0.91421`
+- La linea data-centric de `label noise / near-duplicates` quedo cerrada como `NO-GO` para mitigacion directa.
+- Siguiente direccion recomendada: senal supervisada externa desde `telco-customer-churn`.

--- a/docs/estado.md
+++ b/docs/estado.md
@@ -33,6 +33,8 @@ Estado operativo actual:
 - La linea `uncertainty-band reranker` tambien quedo cerrada como `NO-GO`.
 - La linea `hard-example stability score` tambien quedo cerrada como `NO-GO`.
 - La linea `counterfactual teacher sensitivity` tambien quedo cerrada como `NO-GO`.
+- `submission forensics` ya esta operativo y confirma que la familia con mejor supervivencia publica es `residual_hierarchy`.
+- El `clean-room baseline rebuild` ya confirmo que `v3` sigue muy por encima de `cb_raw`, `cb_r` y `cb_rv` reconstruidos desde cero.
 - Siguiente direccion recomendada:
   - no abrir otra linea sin pasar primero por el filtro documentado en `phase-reset-summary.md` y `model-family-ledger.md`
   - toda hipotesis nueva debe nacer comparada directamente contra `v3` desde `smoke`

--- a/docs/estado.md
+++ b/docs/estado.md
@@ -29,10 +29,11 @@ Estado operativo actual:
   - `public score = 0.91421`
 - La linea data-centric de `label noise / near-duplicates` quedo cerrada como `NO-GO` para mitigacion directa.
 - La linea `external telco transfer feature` tambien quedo cerrada como `NO-GO`.
+- La linea `source-aware joint training con Telco original` tambien quedo cerrada como `NO-GO`.
 - La linea `uncertainty-band reranker` tambien quedo cerrada como `NO-GO`.
 - La linea `hard-example stability score` tambien quedo cerrada como `NO-GO`.
 - La linea `counterfactual teacher sensitivity` tambien quedo cerrada como `NO-GO`.
 - Siguiente direccion recomendada:
   - no abrir otra linea sin pasar primero por el filtro documentado en `phase-reset-summary.md` y `model-family-ledger.md`
   - toda hipotesis nueva debe nacer comparada directamente contra `v3` desde `smoke`
-  - siguiente apuesta concreta recomendada: `source-aware joint training con Telco original`
+  - no reabrir `source-aware joint training` sin una formulacion materialmente distinta a la minima ya descartada

--- a/docs/estado.md
+++ b/docs/estado.md
@@ -30,6 +30,8 @@ Estado operativo actual:
 - La linea data-centric de `label noise / near-duplicates` quedo cerrada como `NO-GO` para mitigacion directa.
 - La linea `external telco transfer feature` tambien quedo cerrada como `NO-GO`.
 - La linea `uncertainty-band reranker` tambien quedo cerrada como `NO-GO`.
+- La linea `hard-example stability score` tambien quedo cerrada como `NO-GO`.
 - Siguiente direccion recomendada:
   - no abrir otra linea sin pasar primero por el filtro documentado en `phase-reset-summary.md` y `model-family-ledger.md`
   - toda hipotesis nueva debe nacer comparada directamente contra `v3` desde `smoke`
+  - siguiente apuesta concreta recomendada: `counterfactual teacher sensitivity features`

--- a/docs/model-family-ledger.md
+++ b/docs/model-family-ledger.md
@@ -119,6 +119,7 @@ Fecha: `2026-03-13`
 - `bi/tri-gram TE + XGBoost`
 - `GNN starter + ANN graph`
 - `external telco transfer feature`
+- `source-aware joint training con Telco original`
 
 ## Regla Para No Reabrir Una Familia Cerrada
 
@@ -171,15 +172,21 @@ Antes de abrir una hipotesis nueva:
    - como pasaria el gate directo contra `v3`
 2. descartar desde el diseno cualquier idea cuyo mejor caso razonable siga estando en el orden de `1e-06`
 
-La siguiente apuesta recomendada es:
+La hipotesis de `source-aware joint training con Telco original` tambien queda cerrada como `NO-GO`.
 
-- `source-aware joint training con Telco original`
+Resultado minimo:
 
-Razon:
+- `R,V + dataset_source + filas blastchar`
+- `external_weight = 0.25`
+- `candidate_oof_auc = 0.9137443511`
+- `delta_vs_v3 = -0.0031935925`
+- veredicto: `FAIL`
 
-- no reabre otra familia de modelo ni otro reranker local
-- usa una fuente supervisada externa real que ya sabemos es del mismo dominio
-- es materialmente distinta al `external telco transfer feature` que ya falló:
-  - no comprime la fuente externa a una sola prediccion
-  - incorpora filas etiquetadas adicionales con `dataset_source` y control de peso/origen
-- puede nacer comparada contra `v3` desde `smoke`
+Lectura:
+
+- la fuente externa sigue siendo util como referencia de dominio
+- pero esta formulacion minima no agrega una senal competitiva sobre `v3`
+
+La siguiente apuesta recomendada vuelve a ser un filtro, no un modelo concreto:
+
+- solo abrir una hipotesis nueva si explica explicitamente por que su senal no esta ya absorbida por `v3`

--- a/docs/model-family-ledger.md
+++ b/docs/model-family-ledger.md
@@ -64,6 +64,22 @@ Fecha: `2026-03-13`
     - `q80 + banda ambigua de v3`
   - mejor delta observado contra `v3`: `+8.28e-07`
   - no alcanza el gate operativo `1e-05`
+- `counterfactual teacher sensitivity` contra `v3`:
+  - senal: cuanto cae un subconjunto del teacher (`cb`, `r`, `rv`) bajo perturbaciones plausibles del mismo cliente
+  - contrafactuales probados:
+    - `auto_payment`
+    - `paperless_off`
+    - `contract_upgrade`
+    - `stability_bundle`
+  - mejor variante global:
+    - `stable_bundle_drop`
+    - `alpha = 0.05`
+    - `delta_vs_v3 = +5.879856e-06`
+  - variantes adicionales:
+    - banda `abs(v3-0.5) <= 0.20`: `+2.697875e-06`
+    - banda `abs(v3-0.5) <= 0.15`: `+3.279829e-06`
+  - mejora la macrofamilia dominante, pero no alcanza el gate global `1e-05`
+  - queda `NO-GO` para promocion
 
 ### Regularizacion Estructural
 
@@ -157,10 +173,13 @@ Antes de abrir una hipotesis nueva:
 
 La siguiente apuesta recomendada es:
 
-- `counterfactual teacher sensitivity features`
+- `source-aware joint training con Telco original`
 
 Razon:
 
-- agrega una senal que no existe hoy en `cb/xgb/lgb/r/rv`: la respuesta local del teacher ante perturbaciones plausibles del estado del cliente
-- no depende de otro mask local
-- puede evaluarse desde `smoke` contra `v3`
+- no reabre otra familia de modelo ni otro reranker local
+- usa una fuente supervisada externa real que ya sabemos es del mismo dominio
+- es materialmente distinta al `external telco transfer feature` que ya falló:
+  - no comprime la fuente externa a una sola prediccion
+  - incorpora filas etiquetadas adicionales con `dataset_source` y control de peso/origen
+- puede nacer comparada contra `v3` desde `smoke`

--- a/docs/model-family-ledger.md
+++ b/docs/model-family-ledger.md
@@ -30,6 +30,11 @@ Fecha: `2026-03-13`
 - Regularizacion ciega de `RV`.
 - Sample weighting damage-aware.
 - Miembros family-aware por stratify compuesto.
+- `clean-room baseline rebuild`:
+  - `cb_raw`
+  - `cb_r`
+  - `cb_rv`
+  - todos fallan el gate directo contra `v3`
 
 ### Especialistas, Challengers Y Overrides Locales
 
@@ -190,3 +195,22 @@ Lectura:
 La siguiente apuesta recomendada vuelve a ser un filtro, no un modelo concreto:
 
 - solo abrir una hipotesis nueva si explica explicitamente por que su senal no esta ya absorbida por `v3`
+
+## Submission Forensics
+
+- Historial Kaggle auditado:
+  - `20` submissions historicas
+  - `18` `COMPLETE`
+  - `2` `ERROR`
+- Mejor submission publico:
+  - `playground-series-s6e3-residual-hier-v3.csv`
+  - `ref 50828079`
+  - `public score 0.91421`
+- Familia con supervivencia publica repetida:
+  - `residual_hierarchy`
+- Familias que tuvieron score publico razonable pero sin repeticion comparable:
+  - `teacher_blend_rv`
+  - `teacher_blend_r`
+  - `pseudo_labeling`
+- Lectura operativa:
+  - el historial publico refuerza que las mejoras durables vinieron de la familia residual, no de challengers standalone ni de lineas exploratorias aisladas

--- a/docs/model-family-ledger.md
+++ b/docs/model-family-ledger.md
@@ -1,6 +1,6 @@
 # Model Family Ledger
 
-Fecha: `2026-03-12`
+Fecha: `2026-03-13`
 
 ## Incumbent
 
@@ -84,6 +84,7 @@ Fecha: `2026-03-12`
 - `MLP embeddings`
 - `bi/tri-gram TE + XGBoost`
 - `GNN starter + ANN graph`
+- `external telco transfer feature`
 
 ## Regla Para No Reabrir Una Familia Cerrada
 
@@ -102,11 +103,11 @@ No basta con:
 
 ## ROI Restante
 
-La evidencia acumulada apunta a que el ROI restante ya no esta en mas filtros sobre filas sospechosas ni en otra familia de modelo cercana al stack actual.
+La evidencia acumulada apunta a que el ROI restante ya no esta en mas filtros sobre filas sospechosas ni en otra familia de modelo global cercana al stack actual.
 
 Las apuestas que siguen vivas son:
 
-1. uso supervisado de fuente externa alineada al dominio (`telco-customer-churn`) como senal transferida
+1. correccion focal sobre la banda ambigua de `v3` dentro de la macrofamilia dominante
 2. identificacion de ejemplos duros/inestables por fold y por familia, pero solo como diagnostico
 3. stress tests de generalizacion por familia dominante
 
@@ -114,10 +115,11 @@ Las apuestas que siguen vivas son:
 
 La siguiente linea recomendada es:
 
-- `external telco transfer feature`
+- `uncertainty-band reranker`
 
 Objetivo:
 
-- entrenar un teacher externo sobre el dataset original `telco-customer-churn`
-- proyectar esa senal sobre `train/test` de la competencia
-- medir si aporta valor frente a `v3` como feature o como miembro complementario
+- no reemplazar `v3` globalmente
+- intervenir solo en la banda de baja confianza de `v3` (`abs(v3-0.5) <= 0.20`)
+- concentrarse en `Electronic check / Month-to-month / Fiber optic`
+- exigir que la correccion viva contra `v3` desde smoke

--- a/docs/model-family-ledger.md
+++ b/docs/model-family-ledger.md
@@ -62,6 +62,20 @@ Fecha: `2026-03-12`
   - `soft`
   - `soft + confidence weighting`
 
+### Intervenciones Data-Centric
+
+- Auditoria de `label noise`:
+  - util como diagnostico
+  - no hay evidencia para filtrar globalmente
+- Mitigacion minima de `near-duplicate conflicts`:
+  - `downweight` local por fold
+  - `drop` local por fold
+  - ambas fallan directamente contra `v3`
+- Reglas cerradas:
+  - no hacer drops masivos
+  - no bajar peso por sospecha global
+  - no tocar cohortes grandes completas por auditoria sola
+
 ### Familias De Modelo Alternativas
 
 - `linear probe`
@@ -88,23 +102,22 @@ No basta con:
 
 ## ROI Restante
 
-La evidencia acumulada apunta a que el ROI restante ya no esta en otra familia de modelo.
+La evidencia acumulada apunta a que el ROI restante ya no esta en mas filtros sobre filas sospechosas ni en otra familia de modelo cercana al stack actual.
 
-Las apuestas que siguen vivas son data-centric:
+Las apuestas que siguen vivas son:
 
-1. auditoria de label noise
-2. auditoria de near-duplicates
-3. identificacion de ejemplos duros/inestables por fold y por familia
-4. stress tests de generalizacion por familia dominante
+1. uso supervisado de fuente externa alineada al dominio (`telco-customer-churn`) como senal transferida
+2. identificacion de ejemplos duros/inestables por fold y por familia, pero solo como diagnostico
+3. stress tests de generalizacion por familia dominante
 
 ## Proxima Hipotesis
 
 La siguiente linea recomendada es:
 
-- `label noise and near-duplicate audit`
+- `external telco transfer feature`
 
 Objetivo:
 
-- detectar filas posiblemente mal rotuladas, casi duplicadas o structuralmente ambiguas
-- medir si estan concentradas en la macrofamilia dominante
-- decidir si conviene filtrar, bajar peso o separar esos casos antes de entrenar otra vez
+- entrenar un teacher externo sobre el dataset original `telco-customer-churn`
+- proyectar esa senal sobre `train/test` de la competencia
+- medir si aporta valor frente a `v3` como feature o como miembro complementario

--- a/docs/model-family-ledger.md
+++ b/docs/model-family-ledger.md
@@ -55,6 +55,15 @@ Fecha: `2026-03-13`
     - banda + desacuerdo alto del teacher (`min_teacher_std`)
   - mejor delta observado contra `v3`: `+6.69e-06`
   - no alcanza el gate operativo `1e-05`
+- `hard-example stability score` sobre `v3`:
+  - fuente: OOF repetidos baratos (`R,V`)
+  - score: `stability_pred_std + stability_flip_rate`
+  - variantes cerradas:
+    - `q80`
+    - `q90`
+    - `q80 + banda ambigua de v3`
+  - mejor delta observado contra `v3`: `+8.28e-07`
+  - no alcanza el gate operativo `1e-05`
 
 ### Regularizacion Estructural
 
@@ -116,9 +125,9 @@ La evidencia acumulada apunta a que el ROI restante ya no esta en mas filtros so
 
 Las apuestas que siguen vivas son:
 
-1. diagnostico de ejemplo duro/inestable con trazabilidad por familia y por banda de confianza
-2. fuente de senal materialmente nueva que nazca ya comparada contra `v3`
-3. stress tests de generalizacion por familia dominante y por banda ambigua
+1. fuente de senal materialmente nueva que nazca ya comparada contra `v3`
+2. stress tests de generalizacion por familia dominante y por banda ambigua
+3. diagnostico de ejemplo duro/inestable solo como soporte, no como challenger
 
 ## Filtro Para La Proxima Hipotesis
 
@@ -134,6 +143,7 @@ La siguiente linea no debe ser:
 - otro mask dentro de `EC / MTM / Fiber`
 - otro challenger global cercano a `R,V`
 - otra intervencion data-centric sin senal nueva
+- otro score de dureza/estabilidad derivado solo de resampling del mismo stack
 
 ## Recomendacion Operativa
 
@@ -144,3 +154,13 @@ Antes de abrir una hipotesis nueva:
    - por que no esta ya absorbida por `v3`
    - como pasaria el gate directo contra `v3`
 2. descartar desde el diseno cualquier idea cuyo mejor caso razonable siga estando en el orden de `1e-06`
+
+La siguiente apuesta recomendada es:
+
+- `counterfactual teacher sensitivity features`
+
+Razon:
+
+- agrega una senal que no existe hoy en `cb/xgb/lgb/r/rv`: la respuesta local del teacher ante perturbaciones plausibles del estado del cliente
+- no depende de otro mask local
+- puede evaluarse desde `smoke` contra `v3`

--- a/docs/model-family-ledger.md
+++ b/docs/model-family-ledger.md
@@ -1,0 +1,110 @@
+# Model Family Ledger
+
+Fecha: `2026-03-12`
+
+## Incumbent
+
+- Submission operativa vigente: `v3`
+- Kaggle `ref`: `50828079`
+- `public score`: `0.91421`
+- Gate operativo: no promover ni subir candidatos con `delta local < 1e-05 en OOF AUC` contra `v3`, salvo fix de paridad o senal materialmente nueva.
+- Referencias de terminologia:
+  - `R` y `RV`: ver [README.md](../README.md)
+  - `EC / MTM / Fiber`: macrofamilia `Electronic check / Month-to-month / Fiber optic`
+  - protocolo operativo: [validation-reset-protocol.md](./validation-reset-protocol.md)
+
+## Familias Que Si Produjeron Ganancia Durable
+
+- Teacher robusto `CatBoost + XGB + LGB + R + RV`.
+- Jerarquia residual `v3` sobre ese teacher.
+- La mejora durable vino de:
+  - diversidad moderada de modelos
+  - una senal estructural global limitada (`R`, luego `RV`)
+  - correcciones residuales muy focales
+
+## Familias De Modelo Cerradas Como NO-GO
+
+### Ajustes Incrementales Del Stack Base
+
+- Seeds extra, scans de pesos y variantes cercanas del blend sin senal nueva.
+- Regularizacion ciega de `RV`.
+- Sample weighting damage-aware.
+- Miembros family-aware por stratify compuesto.
+
+### Especialistas, Challengers Y Overrides Locales
+
+- `specialist masks` adicionales fuera de los que forman `v3`.
+- Challengers supervisados sobre `EC / MTM / Fiber`:
+  - `classifier`
+  - `feature`
+  - `gated`
+- Reordenamiento de la jerarquia `v3` sin senal nueva.
+
+### Rerankers Y Meta-Modelos
+
+- Ranking reranker global.
+- Ranking reranker local.
+- `teacher_meta` lineal.
+- `teacher_meta` no lineal (`catboost_meta`).
+
+### Regularizacion Estructural
+
+- Monotonic constraints.
+- Nuevos bloques globales que no sobrevivieron contra `v3`:
+  - `F` surface block
+  - `T` fit-aware surface block
+  - `G` coverage/backoff global
+
+### Semi-Supervisado
+
+- Pseudo-labeling por familia:
+  - `hard`
+  - `soft`
+  - `soft + confidence weighting`
+
+### Familias De Modelo Alternativas
+
+- `linear probe`
+- `spline logistic`
+- `FFM`
+- `MLP embeddings`
+- `bi/tri-gram TE + XGBoost`
+- `GNN starter + ANN graph`
+
+## Regla Para No Reabrir Una Familia Cerrada
+
+Una familia cerrada no se reabre salvo que exista al menos una de estas condiciones:
+
+- nueva fuente de senal que no estaba disponible antes
+- cambio de validacion que demuestre que el falso negativo era del protocolo y no del modelo
+- fix de paridad o leakage que invalide el resultado previo
+
+No basta con:
+
+- cambiar la seed
+- mover ligeramente hiperparametros
+- hacer otro scan de blend
+- probar otra mascara muy parecida
+
+## ROI Restante
+
+La evidencia acumulada apunta a que el ROI restante ya no esta en otra familia de modelo.
+
+Las apuestas que siguen vivas son data-centric:
+
+1. auditoria de label noise
+2. auditoria de near-duplicates
+3. identificacion de ejemplos duros/inestables por fold y por familia
+4. stress tests de generalizacion por familia dominante
+
+## Proxima Hipotesis
+
+La siguiente linea recomendada es:
+
+- `label noise and near-duplicate audit`
+
+Objetivo:
+
+- detectar filas posiblemente mal rotuladas, casi duplicadas o structuralmente ambiguas
+- medir si estan concentradas en la macrofamilia dominante
+- decidir si conviene filtrar, bajar peso o separar esos casos antes de entrenar otra vez

--- a/docs/model-family-ledger.md
+++ b/docs/model-family-ledger.md
@@ -46,6 +46,15 @@ Fecha: `2026-03-13`
 - Ranking reranker local.
 - `teacher_meta` lineal.
 - `teacher_meta` no lineal (`catboost_meta`).
+- `uncertainty-band reranker` sobre `v3`:
+  - familia objetivo: `Electronic check / Month-to-month / Fiber optic`
+  - banda ambigua: `abs(v3 - 0.5) <= 0.20`
+  - variantes cerradas:
+    - banda pura
+    - banda mas estrecha (`0.15`, `0.10`)
+    - banda + desacuerdo alto del teacher (`min_teacher_std`)
+  - mejor delta observado contra `v3`: `+6.69e-06`
+  - no alcanza el gate operativo `1e-05`
 
 ### Regularizacion Estructural
 
@@ -107,19 +116,31 @@ La evidencia acumulada apunta a que el ROI restante ya no esta en mas filtros so
 
 Las apuestas que siguen vivas son:
 
-1. correccion focal sobre la banda ambigua de `v3` dentro de la macrofamilia dominante
-2. identificacion de ejemplos duros/inestables por fold y por familia, pero solo como diagnostico
-3. stress tests de generalizacion por familia dominante
+1. diagnostico de ejemplo duro/inestable con trazabilidad por familia y por banda de confianza
+2. fuente de senal materialmente nueva que nazca ya comparada contra `v3`
+3. stress tests de generalizacion por familia dominante y por banda ambigua
 
-## Proxima Hipotesis
+## Filtro Para La Proxima Hipotesis
 
-La siguiente linea recomendada es:
+La siguiente linea solo se abre si cumple al menos una de estas condiciones:
 
-- `uncertainty-band reranker`
+- agrega una fuente de senal que no este ya contenida en `cb/xgb/lgb/r/rv`
+- o cambia la geometria del problema de forma demostrable, no solo el orden de un reranker local
+- y puede evaluarse contra `v3` desde `smoke` sin depender de un teacher intermedio
 
-Objetivo:
+La siguiente linea no debe ser:
 
-- no reemplazar `v3` globalmente
-- intervenir solo en la banda de baja confianza de `v3` (`abs(v3-0.5) <= 0.20`)
-- concentrarse en `Electronic check / Month-to-month / Fiber optic`
-- exigir que la correccion viva contra `v3` desde smoke
+- otro reranker local sobre la misma macrofamilia dominante
+- otro mask dentro de `EC / MTM / Fiber`
+- otro challenger global cercano a `R,V`
+- otra intervencion data-centric sin senal nueva
+
+## Recomendacion Operativa
+
+Antes de abrir una hipotesis nueva:
+
+1. definir explicita y por adelantado:
+   - fuente de senal nueva
+   - por que no esta ya absorbida por `v3`
+   - como pasaria el gate directo contra `v3`
+2. descartar desde el diseno cualquier idea cuyo mejor caso razonable siga estando en el orden de `1e-06`

--- a/docs/phase-reset-summary.md
+++ b/docs/phase-reset-summary.md
@@ -129,5 +129,15 @@ Lista exhaustiva y mantenida en:
   - `external_weight = 0.25`
   - `delta_vs_v3 = -0.0031935925`
   - veredicto: `FAIL`
+- `submission forensics` ya quedo operativo:
+  - `18/20` submissions historicas quedaron `COMPLETE`
+  - la unica familia con supervivencia publica repetida es `residual_hierarchy`
+  - `v3` sigue siendo el mejor submission publico (`0.91421`)
+  - la correlacion local/public aun es escasa a nivel de reportes ligados; hoy la lectura util es por familia, no por micro-delta
+- El `clean-room baseline rebuild` confirmo que `v3` no gana por complejidad accidental:
+  - `cb_raw = 0.9125779`
+  - `cb_r = 0.9132509`
+  - `cb_rv = 0.9138610`
+  - ninguno mejora ni mezcla contra `v3`
 - La siguiente apuesta concreta recomendada deja de ser esa linea.
   - toda hipotesis nueva debe volver a justificar explicitamente por que agrega senal no absorbida por `v3`

--- a/docs/phase-reset-summary.md
+++ b/docs/phase-reset-summary.md
@@ -1,7 +1,7 @@
 # Resumen De Reset De Fase
 
 Fecha: `2026-03-11`
-Ultima actualizacion: `2026-03-12`
+Ultima actualizacion: `2026-03-13`
 
 ## Incumbent
 
@@ -60,6 +60,11 @@ Lista exhaustiva y mantenida en:
   - `label noise` puro parece minoritario
   - la mayor parte de la sospecha se concentra en `near-duplicates / cohortes casi repetidas`
   - pero mitigar eso de forma minima dano el ranking frente a `v3`
+- El diagnostico agresivo de dominancia de `v3` agrego una lectura mas precisa:
+  - `v3` gana de forma consistente en la macrofamilia dominante para casi todos los challengers
+  - la mayor presion aparece en la banda de baja confianza de `v3` (`abs(v3-0.5) <= 0.20`)
+  - cuando un challenger se aleja mucho de `v3`, normalmente pierde mas logloss y ranking
+  - el residual casi-vivo mejora algo de logloss, pero no logra mejorar ranking global
 - El cuello de botella no parece ser:
   - falta de otro seed
   - otro blend scan
@@ -67,6 +72,7 @@ Lista exhaustiva y mantenida en:
 - El cuello parece estar en:
   - generalizacion real a familias/cohortes dominantes
   - evitar falsos positivos locales que no sobreviven al leaderboard
+  - resolver mejor la zona ambigua de `v3`, no reemplazarlo globalmente
 
 ## Ambiguo Pero Util
 
@@ -100,4 +106,8 @@ Lista exhaustiva y mantenida en:
 - El `validation reset` ya quedo implementado y es prerrequisito cumplido.
 - La siguiente apuesta no debe ser otro experimento pequeno sobre `EC / MTM / Fiber`.
 - La siguiente apuesta debe empezar por evaluacion y criterio de promocion, no por mas CPU.
-- La siguiente hipotesis recomendada es usar el dataset original `telco-customer-churn` como fuente supervisada externa.
+- La hipotesis de `external telco transfer feature` ya quedo cerrada como `NO-GO`.
+- La siguiente hipotesis recomendada ahora es:
+  - `uncertainty-band reranker`
+  - limitado a la macrofamilia dominante
+  - solo para filas con baja confianza de `v3` y alto desacuerdo potencial

--- a/docs/phase-reset-summary.md
+++ b/docs/phase-reset-summary.md
@@ -1,0 +1,84 @@
+# Resumen De Reset De Fase
+
+Fecha: `2026-03-11`
+
+## Incumbent
+
+- Submission operativa vigente: `v3`
+- Kaggle `ref`: `50828079`
+- `public score`: `0.91421`
+- Regla base: no reemplazar `v3` con candidatos cuyo `delta local` en `OOF AUC` contra el incumbent sea `< 1e-05`, salvo fix de paridad o senal materialmente nueva.
+
+## Lo Que Si Funciono
+
+- `CatBoost + XGB + LGB + R + RV` como teacher/blend robusto.
+- Jerarquia residual `v3` sobre ese teacher.
+- La mejora competitiva real vino de:
+  - diversidad moderada de modelo
+  - una pequena senal estructural (`R`, luego `RV`)
+  - rerankers residuales muy focales
+
+## Lo Que Ya Esta Cerrado Como NO-GO
+
+- Pseudo-labeling por familia:
+  - `hard`
+  - `soft`
+  - `soft + confidence weighting`
+- Ranking reranker:
+  - global
+  - local
+- Monotonic constraints.
+- Modelos ortogonales baratos:
+  - `linear probe`
+  - `spline logistic`
+  - `FFM`
+  - `MLP embeddings`
+- `teacher_meta`
+- Nuevos `specialist masks` y variantes de superficie sobre familias ya agotadas
+- Challengers supervisados directos sobre `EC / MTM / Fiber`:
+  - `classifier`
+  - `feature`
+  - `gated`
+
+## Lo Que Si Aprendimos
+
+- La macrofamilia dominante del problema es:
+  - `Electronic check / Month-to-month / Fiber optic`
+- El cuello de botella no parece ser:
+  - falta de otro seed
+  - otro blend scan
+  - otro mask local parecido
+- El cuello parece estar en:
+  - generalizacion real a familias/cohortes dominantes
+  - evitar falsos positivos locales que no sobreviven al leaderboard
+
+## Ambiguo Pero Util
+
+- `EC / MTM / Fiber` sigue siendo la familia mas danina.
+- Hay mejora local en algunas variantes dentro de esa macrofamilia, pero no suficiente ni estable contra `v3`.
+- La validacion local sigue siendo util, pero no lo bastante dura como para discriminar bien mejoras pequenas.
+
+## Reglas Operativas
+
+- No subir submissions con `delta local < 1e-05` en `OOF AUC` contra `v3`.
+- No promover una idea a `5x600` si no gana su smoke correspondiente.
+- No abrir mas masks dentro de familias ya agotadas.
+- No repetir scans de pesos o seeds sin una senal nueva y menos correlacionada.
+- No abrir mas hipotesis simultaneas; maximo una linea activa a la vez.
+
+## Siguiente Fase Permitida
+
+1. Recomendado: `validation reset`
+   - reforzar validacion realista por familia/cohorte
+   - medir mejor riesgo `CV -> public/private`
+   - usar eso como filtro antes de volver a entrenar modelos nuevos
+
+2. Solo despues del reset:
+   - probar una familia de modelo realmente distinta o una representacion nueva
+   - no otra variante de CatBoost local sobre la misma macrofamilia
+
+## Decision
+
+- `v3` sigue siendo el incumbent.
+- La siguiente apuesta no debe ser otro experimento pequeno sobre `EC / MTM / Fiber`.
+- La siguiente apuesta debe empezar por evaluacion y criterio de promocion, no por mas CPU.

--- a/docs/phase-reset-summary.md
+++ b/docs/phase-reset-summary.md
@@ -72,6 +72,7 @@ Fecha: `2026-03-11`
    - reforzar validacion realista por familia/cohorte
    - medir mejor riesgo `CV -> public/private`
    - usar eso como filtro antes de volver a entrenar modelos nuevos
+   - protocolo formal: [validation-reset-protocol.md](./validation-reset-protocol.md)
 
 2. Solo despues del reset:
    - probar una familia de modelo realmente distinta o una representacion nueva

--- a/docs/phase-reset-summary.md
+++ b/docs/phase-reset-summary.md
@@ -8,6 +8,9 @@ Fecha: `2026-03-11`
 - Kaggle `ref`: `50828079`
 - `public score`: `0.91421`
 - Regla base: no reemplazar `v3` con candidatos cuyo `delta local` en `OOF AUC` contra el incumbent sea `< 1e-05`, salvo fix de paridad o senal materialmente nueva.
+- Terminologia corta:
+  - `R` y `RV`: ver [README.md](../README.md)
+  - `EC / MTM / Fiber`: macrofamilia `Electronic check / Month-to-month / Fiber optic`
 
 ## Lo Que Si Funciono
 
@@ -39,6 +42,8 @@ Fecha: `2026-03-11`
   - `classifier`
   - `feature`
   - `gated`
+- `bi/tri-gram TE + XGBoost`
+- `GNN starter + ANN graph`
 
 ## Lo Que Si Aprendimos
 

--- a/docs/phase-reset-summary.md
+++ b/docs/phase-reset-summary.md
@@ -116,10 +116,14 @@ Lista exhaustiva y mantenida en:
 - La hipotesis de `external telco transfer feature` ya quedo cerrada como `NO-GO`.
 - La hipotesis de `uncertainty-band reranker` tambien queda cerrada como `NO-GO`.
 - La hipotesis de `hard-example stability score` tambien queda cerrada como `NO-GO`.
+- La hipotesis de `counterfactual teacher sensitivity` tambien queda cerrada como `NO-GO`.
+  - mejor delta global contra `v3`: `+5.879856e-06`
+  - bandas adicionales (`0.20`, `0.15`) quedaron en `+2.697875e-06` y `+3.279829e-06`
+  - mejora la macrofamilia dominante, pero no cruza el gate `1e-05`
 - La siguiente hipotesis recomendada ahora no es un modelo especifico, sino un filtro:
   - debe aportar senal materialmente nueva
   - debe explicitar por que `v3` no la absorbe ya
   - debe nacer comparada directamente contra `v3` desde `smoke`
 - La siguiente apuesta concreta recomendada es:
-  - `counterfactual teacher sensitivity features`
-  - idea base: medir como cambia el teacher cuando se perturban variables de negocio plausibles del mismo ejemplo
+  - `source-aware joint training con Telco original`
+  - idea base: incorporar filas etiquetadas del dataset Telco original con `dataset_source` y pesos de origen, en vez de reducir esa fuente externa a una sola prediccion auxiliar

--- a/docs/phase-reset-summary.md
+++ b/docs/phase-reset-summary.md
@@ -65,6 +65,9 @@ Lista exhaustiva y mantenida en:
   - la mayor presion aparece en la banda de baja confianza de `v3` (`abs(v3-0.5) <= 0.20`)
   - cuando un challenger se aleja mucho de `v3`, normalmente pierde mas logloss y ranking
   - el residual casi-vivo mejora algo de logloss, pero no logra mejorar ranking global
+  - incluso la linea mas alineada con ese hallazgo (`uncertainty-band reranker`) no supero el gate:
+    - mejor delta contra `v3`: `+6.69e-06`
+    - sigue por debajo del minimo operativo `1e-05`
 - El cuello de botella no parece ser:
   - falta de otro seed
   - otro blend scan
@@ -78,6 +81,7 @@ Lista exhaustiva y mantenida en:
 
 - `EC / MTM / Fiber` sigue siendo la familia mas danina.
 - Hay mejora local en algunas variantes dentro de esa macrofamilia, pero no suficiente ni estable contra `v3`.
+- La banda ambigua de `v3` si existe como zona de presion real, pero ya no justifica otra linea de reranker local similar.
 - La validacion local sigue siendo util, pero no lo bastante dura como para discriminar bien mejoras pequenas.
 
 ## Reglas Operativas
@@ -107,7 +111,8 @@ Lista exhaustiva y mantenida en:
 - La siguiente apuesta no debe ser otro experimento pequeno sobre `EC / MTM / Fiber`.
 - La siguiente apuesta debe empezar por evaluacion y criterio de promocion, no por mas CPU.
 - La hipotesis de `external telco transfer feature` ya quedo cerrada como `NO-GO`.
-- La siguiente hipotesis recomendada ahora es:
-  - `uncertainty-band reranker`
-  - limitado a la macrofamilia dominante
-  - solo para filas con baja confianza de `v3` y alto desacuerdo potencial
+- La hipotesis de `uncertainty-band reranker` tambien queda cerrada como `NO-GO`.
+- La siguiente hipotesis recomendada ahora no es un modelo especifico, sino un filtro:
+  - debe aportar senal materialmente nueva
+  - debe explicitar por que `v3` no la absorbe ya
+  - debe nacer comparada directamente contra `v3` desde `smoke`

--- a/docs/phase-reset-summary.md
+++ b/docs/phase-reset-summary.md
@@ -68,6 +68,9 @@ Lista exhaustiva y mantenida en:
   - incluso la linea mas alineada con ese hallazgo (`uncertainty-band reranker`) no supero el gate:
     - mejor delta contra `v3`: `+6.69e-06`
     - sigue por debajo del minimo operativo `1e-05`
+  - la extension natural de esa idea (`hard-example stability score`) tampoco abre una mejora competitiva:
+    - mejor delta contra `v3`: `+8.28e-07`
+    - sirve como diagnostico, no como challenger
 - El cuello de botella no parece ser:
   - falta de otro seed
   - otro blend scan
@@ -112,7 +115,11 @@ Lista exhaustiva y mantenida en:
 - La siguiente apuesta debe empezar por evaluacion y criterio de promocion, no por mas CPU.
 - La hipotesis de `external telco transfer feature` ya quedo cerrada como `NO-GO`.
 - La hipotesis de `uncertainty-band reranker` tambien queda cerrada como `NO-GO`.
+- La hipotesis de `hard-example stability score` tambien queda cerrada como `NO-GO`.
 - La siguiente hipotesis recomendada ahora no es un modelo especifico, sino un filtro:
   - debe aportar senal materialmente nueva
   - debe explicitar por que `v3` no la absorbe ya
   - debe nacer comparada directamente contra `v3` desde `smoke`
+- La siguiente apuesta concreta recomendada es:
+  - `counterfactual teacher sensitivity features`
+  - idea base: medir como cambia el teacher cuando se perturban variables de negocio plausibles del mismo ejemplo

--- a/docs/phase-reset-summary.md
+++ b/docs/phase-reset-summary.md
@@ -1,6 +1,7 @@
 # Resumen De Reset De Fase
 
 Fecha: `2026-03-11`
+Ultima actualizacion: `2026-03-12`
 
 ## Incumbent
 
@@ -23,6 +24,9 @@ Fecha: `2026-03-11`
 
 ## Lo Que Ya Esta Cerrado Como NO-GO
 
+Lista exhaustiva y mantenida en:
+- [model-family-ledger.md](./model-family-ledger.md)
+
 - Pseudo-labeling por familia:
   - `hard`
   - `soft`
@@ -44,11 +48,18 @@ Fecha: `2026-03-11`
   - `gated`
 - `bi/tri-gram TE + XGBoost`
 - `GNN starter + ANN graph`
+- Intervenciones data-centric minimas sobre filas sospechosas:
+  - `near-duplicate downweight`
+  - `near-duplicate drop`
 
 ## Lo Que Si Aprendimos
 
 - La macrofamilia dominante del problema es:
   - `Electronic check / Month-to-month / Fiber optic`
+- La auditoria data-centric sirve para orientar investigacion:
+  - `label noise` puro parece minoritario
+  - la mayor parte de la sospecha se concentra en `near-duplicates / cohortes casi repetidas`
+  - pero mitigar eso de forma minima dano el ranking frente a `v3`
 - El cuello de botella no parece ser:
   - falta de otro seed
   - otro blend scan
@@ -80,11 +91,13 @@ Fecha: `2026-03-11`
    - protocolo formal: [validation-reset-protocol.md](./validation-reset-protocol.md)
 
 2. Solo despues del reset:
-   - probar una familia de modelo realmente distinta o una representacion nueva
+   - probar una fuente de senal realmente distinta o una representacion nueva
    - no otra variante de CatBoost local sobre la misma macrofamilia
 
 ## Decision
 
 - `v3` sigue siendo el incumbent.
+- El `validation reset` ya quedo implementado y es prerrequisito cumplido.
 - La siguiente apuesta no debe ser otro experimento pequeno sobre `EC / MTM / Fiber`.
 - La siguiente apuesta debe empezar por evaluacion y criterio de promocion, no por mas CPU.
+- La siguiente hipotesis recomendada es usar el dataset original `telco-customer-churn` como fuente supervisada externa.

--- a/docs/phase-reset-summary.md
+++ b/docs/phase-reset-summary.md
@@ -124,6 +124,10 @@ Lista exhaustiva y mantenida en:
   - debe aportar senal materialmente nueva
   - debe explicitar por que `v3` no la absorbe ya
   - debe nacer comparada directamente contra `v3` desde `smoke`
-- La siguiente apuesta concreta recomendada es:
-  - `source-aware joint training con Telco original`
-  - idea base: incorporar filas etiquetadas del dataset Telco original con `dataset_source` y pesos de origen, en vez de reducir esa fuente externa a una sola prediccion auxiliar
+- La hipotesis de `source-aware joint training con Telco original` tambien queda cerrada como `NO-GO`.
+  - formulacion minima: `R,V + dataset_source + filas blastchar`
+  - `external_weight = 0.25`
+  - `delta_vs_v3 = -0.0031935925`
+  - veredicto: `FAIL`
+- La siguiente apuesta concreta recomendada deja de ser esa linea.
+  - toda hipotesis nueva debe volver a justificar explicitamente por que agrega senal no absorbida por `v3`

--- a/docs/validation-reset-protocol.md
+++ b/docs/validation-reset-protocol.md
@@ -1,0 +1,231 @@
+# Validation Reset Protocol
+
+Fecha: `2026-03-11`
+
+## Objetivo
+
+Definir un protocolo de evaluacion mas realista antes de:
+- promover una idea a entrenamiento caro
+- autorizar una submission nueva
+
+Este protocolo existe para reducir falsos positivos locales y dejar trazabilidad clara de por que una idea pasa o no pasa.
+
+## Incumbent De Referencia
+
+- Submission vigente: `v3`
+- Kaggle `ref`: `50828079`
+- `public score`: `0.91421`
+- Referencia local minima: comparar siempre contra el incumbent equivalente en `OOF AUC`
+
+## Definiciones Operativas
+
+- `delta local`: `candidate_oof_auc - reference_oof_auc` bajo el mismo split y la misma seed de evaluacion.
+- `incumbent comparable`: rerun del incumbent bajo exactamente:
+  - mismo split
+  - mismas seeds
+  - mismo protocolo de features permitidas para la comparacion
+- `familia`: por defecto `segment5 = PaymentMethod x Contract x InternetService x PaperlessBilling x tenure_bin`.
+- `familia grande`: familia con `train_rows >= 5000` o `test_rows >= 2000`.
+- `familia promotable`: familia con `train_rows >= 2000` y `test_rows >= 800`.
+- `familia microscopica`: familia con `train_rows < 1000` o `test_rows < 400`.
+- `macrofamilia`: por defecto `segment3 = PaymentMethod x Contract x InternetService`.
+- `macrofamilia dominante`: `Electronic check / Month-to-month / Fiber optic`.
+- `familia objetivo`: la familia principal declarada por la hipotesis.
+- `familia hermana`: misma macrofamilia de la hipotesis y mismo `PaperlessBilling`, cambiando solo al bucket de tenure vecino mas cercano en este orden:
+  - `0_6 -> 7_12 -> 13_24 -> 25_48 -> 49_plus`
+  - si la hipotesis no depende de `tenure_bin`, la familia hermana se define como el mismo grupo con `PaperlessBilling` invertido
+  - la familia hermana debe quedar nombrada explicitamente en el experimento
+- `top-3 por dano`: top-3 familias grandes ordenadas por `reference_logloss_contribution` en el split evaluado.
+
+## Metricas Definidas
+
+- `OOF AUC`: ROC AUC global sobre todas las filas OOF.
+- `OOF AUC on-mask`: ROC AUC calculado solo sobre la familia objetivo o familia auditada.
+- `logloss contribution por familia`: `mean_logloss_familia * (rows_familia / rows_eval)`.
+- `generalization_gap_logloss_contribution`: `lofo_logloss_contribution - reference_logloss_contribution`.
+- `cv_std`: desviacion estandar del AUC por fold.
+- `OOF correlation`: correlacion de Pearson entre el vector completo `candidate_pred` OOF y el vector `reference_pred` OOF bajo Split A.
+- `standalone delta`: `challenger_oof_auc - reference_oof_auc` bajo Split A, con `alpha = 1.0`.
+
+## Estructura De Evaluacion
+
+### 1. Smoke
+
+Uso:
+- ideas nuevas
+- bloques nuevos de features
+- cambios de gating o weighting
+
+Configuracion minima:
+- `2 folds`
+- `150-250` iteraciones maximo
+- `1 seed`
+
+Gate para pasar:
+- mejora local `>= 1e-05` en `OOF AUC`
+- en Split B:
+  - la macrofamilia dominante no puede caer mas de `2e-04` en `OOF AUC on-mask`
+  - ninguna familia grande del top-3 por dano puede empeorar mas de `3%` relativos en `reference_logloss_contribution`
+- la mejora no puede depender solo de familias microscopicas
+
+### 2. Midcap
+
+Uso:
+- solo ideas que pasaron smoke
+
+Configuracion minima:
+- `5 folds`
+- `~600` iteraciones
+- mismo setup de features que gano smoke
+
+Gate para pasar:
+- mejora local `>= 1e-05` contra el incumbent comparable
+- `cv_std_candidate <= 1.15 * cv_std_reference`
+- en Split B:
+  - familia objetivo: `delta OOF AUC on-mask >= -1e-04` contra la referencia on-mask del mismo split
+  - macrofamilia dominante: `delta OOF AUC on-mask >= -2e-04` contra la referencia on-mask del mismo split
+  - ninguna familia grande del top-3 por dano puede empeorar mas de `3%` relativos en `reference_logloss_contribution` del mismo split
+
+### 3. Submission Candidate
+
+Uso:
+- solo ideas que pasaron midcap
+
+Requisitos:
+- paridad de train/inferencia verificada
+- soporte suficiente tambien en `test`
+- mejora local no explicada solo por familias microscopicas
+
+Gate para subir:
+- mejora local `>= 1e-05` en Split A
+- y familia objetivo `promotable`
+- y ninguna familia critica empeorada fuera de threshold; `familias criticas` significa:
+  - familia objetivo
+  - familia hermana
+  - macrofamilia dominante
+  - top-3 por dano
+  - los thresholds que aplican aqui son los mismos thresholds de Split B, medidos contra la referencia del mismo split
+- excepcion 1: `fix de paridad`
+  - solo si no cambia el modelo entrenado
+  - y corrige un `audit FAIL` o una ruptura train/inferencia demostrable
+- excepcion 2: `senal materialmente nueva`
+  - solo si la nueva linea tiene `OOF correlation <= 0.995` contra el incumbent comparable
+  - o `standalone delta >= 2e-05` bajo Split A
+
+## Tipos De Split
+
+### Split A: CV base
+
+Objetivo:
+- medir el comportamiento general
+
+Regla:
+- mantener el `StratifiedKFold` actual como baseline de comparacion
+- este split define el gate principal de `delta local`
+
+### Split B: Family-aware stress
+
+Objetivo:
+- medir sensibilidad a familias dominantes
+
+Regla:
+- repetir diagnosticos por familia dominante, al menos:
+  - `Electronic check / Month-to-month / Fiber optic`
+  - familia secundaria relevante si aparece en la hipotesis
+
+Metricas a mirar:
+- `OOF AUC` on-mask
+- contribucion a logloss
+- soporte en `train` y `test`
+
+Uso en gates:
+- Split B no promociona por si solo
+- Split B funciona como veto cuando una mejora global esconde dano en familias grandes
+
+### Split C: Leave-one-family-out
+
+Objetivo:
+- medir generalizacion fuera de familia
+
+Regla:
+- usar `leave-one-family-out` como diagnostico, no como gate principal de promocion
+
+Salida esperada:
+- ranking de familias por `generalization_gap_logloss_contribution`
+
+## Stress Tests Obligatorios
+
+Antes de subir una idea:
+- revisar familias top por dano actual
+- revisar si la mejora depende de familias con soporte bajo en `test`
+- revisar si la idea empeora la macrofamilia dominante aunque mejore el global
+
+Lista minima:
+1. familia objetivo
+2. macrofamilia dominante
+3. familia hermana mas cercana
+4. mezcla global
+
+Pass minimo:
+- ninguna familia grande auditada puede romper los thresholds de Split B
+- si la familia objetivo no mejora, la idea no sube salvo que el global gane `>= 2e-05` y no haya dano en familias grandes
+
+## Metricas De Decision
+
+### Primaria
+
+- `OOF AUC`
+
+### Secundarias
+
+- `delta_vs_reference_oof_auc`
+- `OOF AUC` on-mask
+- `logloss contribution` por familia
+- soporte `train/test`
+- estabilidad entre folds
+
+### Regla de interpretacion
+
+- una mejora solo on-mask no basta
+- una mejora global con dano fuerte en familias grandes tampoco basta
+- una mejora menor a `1e-05` no justifica submission
+- una mejora sostenida solo en familias microscopicas no justifica promocion
+
+## Checklist Previo A Submission
+
+1. La idea paso smoke
+2. La idea paso midcap
+3. El delta local supera el gate
+4. No depende de una familia de bajo soporte en `test`
+5. La inferencia reproduce exactamente el pipeline de train
+6. El incumbent contra el que se compara es explicito
+7. El artefacto de submission queda trazado con:
+   - metrics JSON
+   - OOF CSV si existe
+   - submission CSV
+   - commit SHA o branch origen
+
+Si alguno falla:
+- no subir
+
+## Reglas De Descarte
+
+Descartar una linea si ocurre cualquiera:
+- `best_alpha = 0.0`
+- `delta_vs_reference_oof_auc < 1e-05`
+- submission plana o peor:
+  - `public_score <= incumbent_public_score`
+  - si queda en `[-0.00001, +0.00001]` se considera inconclusa, pero no promociona la linea
+- mejora solo contra teacher base y no contra incumbent real
+- la idea repite una familia o tecnica ya agotada
+
+## Proxima Aplicacion Recomendada
+
+Usar este protocolo primero en:
+1. cualquier hipotesis nueva que toque la macrofamilia `EC / MTM / Fiber`
+2. cualquier nueva familia de modelo que pretenda reemplazar o complementar `v3`
+
+## Decision Operativa
+
+- No abrir un nuevo experimento de modelo sin pasar por este protocolo.
+- La siguiente fase empieza por evaluacion y criterio de promocion, no por mas CPU.

--- a/scripts/analyze_error_by_class.py
+++ b/scripts/analyze_error_by_class.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Analyze OOF error by customer class/cohort for incumbent and challenger blends."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.artifacts import write_json
+from churn_baseline.config import ID_COLUMN, TARGET_COLUMN
+from churn_baseline.data import load_csv
+from churn_baseline.diagnostics import (
+    OOF_TARGET_COLUMN,
+    load_merged_oof_matrix,
+    parse_oof_input_spec,
+    utc_now_iso,
+)
+from churn_baseline.evaluation import binary_auc
+from churn_baseline.feature_engineering import apply_feature_engineering
+
+
+DEFAULT_OOF_SPECS = (
+    "cb=artifacts/reports/train_cv_multiseed_gate_s5_hiiter_oof.csv#oof_ensemble",
+    "xgb=artifacts/reports/train_xgboost_cv_multiseed_hiiter_oof.csv#oof_ensemble",
+    "lgb=artifacts/reports/train_lightgbm_cv_full_hiiter_oof.csv#oof_pred",
+    "r=artifacts/reports/fe_blockR_hiiter_oof.csv#oof_pred",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Analyze OOF error by class/cohort")
+    parser.add_argument("--train-csv", default="data/raw/train.csv", help="Path to train.csv")
+    parser.add_argument(
+        "--oof",
+        action="append",
+        default=[],
+        help="OOF input spec: <name>=<path>[#<prediction_column>]. Defaults to cb/xgb/lgb/r.",
+    )
+    parser.add_argument(
+        "--reference-weights-json",
+        default="artifacts/reports/submission_candidate_cb5_xgb3_lgb_weights.json",
+        help="Weights JSON for incumbent/reference blend.",
+    )
+    parser.add_argument(
+        "--challenger-weights-json",
+        default="artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_weights.json",
+        help="Weights JSON for challenger/current-best blend.",
+    )
+    parser.add_argument(
+        "--hard-loss-quantile",
+        type=float,
+        default=0.99,
+        help="Quantile of per-row logloss used to define hard cases.",
+    )
+    parser.add_argument("--top-k", type=int, default=20, help="Rows per summary section.")
+    parser.add_argument(
+        "--out-json",
+        default="artifacts/reports/diagnostic_error_by_class_summary.json",
+        help="Output summary JSON path.",
+    )
+    parser.add_argument(
+        "--out-groups-csv",
+        default="artifacts/reports/diagnostic_error_by_class_groups.csv",
+        help="Output combined group metrics CSV path.",
+    )
+    parser.add_argument(
+        "--out-hard-cases-csv",
+        default="artifacts/reports/diagnostic_error_by_class_hard_cases.csv",
+        help="Output hard-case hotspot CSV path.",
+    )
+    return parser.parse_args()
+
+
+def _load_weights(path: str | Path) -> dict[str, float]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    weights = payload.get("weights")
+    if not isinstance(weights, dict) or not weights:
+        raise ValueError(f"Could not find weights in {path}")
+    return {str(name): float(value) for name, value in weights.items()}
+
+
+def _safe_auc(y_true: pd.Series, pred: pd.Series) -> float | None:
+    if y_true.nunique(dropna=False) < 2:
+        return None
+    return float(binary_auc(y_true.astype(int), pred.astype("float64")))
+
+
+def _logloss_vector(y_true: pd.Series, pred: pd.Series, epsilon: float = 1e-6) -> pd.Series:
+    clipped = pred.astype("float64").clip(lower=epsilon, upper=1.0 - epsilon)
+    y = y_true.astype("float64")
+    return -(y * np.log(clipped) + (1.0 - y) * np.log(1.0 - clipped))
+
+
+def _build_analysis_frame(train_csv: str, merged_oof: pd.DataFrame) -> pd.DataFrame:
+    train_df = load_csv(train_csv)
+    if ID_COLUMN not in train_df.columns or TARGET_COLUMN not in train_df.columns:
+        raise ValueError(f"{train_csv} must contain {ID_COLUMN} and {TARGET_COLUMN}")
+
+    base = train_df.drop(columns=[TARGET_COLUMN]).copy()
+    engineered = apply_feature_engineering(base.drop(columns=[ID_COLUMN]), feature_blocks=["A", "R"])
+    frame = pd.concat([base[[ID_COLUMN]], engineered], axis=1)
+
+    frame["segment3"] = (
+        frame["PaymentMethod"].astype(str)
+        + "__"
+        + frame["Contract"].astype(str)
+        + "__"
+        + frame["InternetService"].astype(str)
+    )
+    frame["segment5"] = (
+        frame["PaymentMethod"].astype(str)
+        + "__"
+        + frame["Contract"].astype(str)
+        + "__"
+        + frame["InternetService"].astype(str)
+        + "__"
+        + frame["PaperlessBilling"].astype(str)
+        + "__"
+        + frame["tenure_bin"].astype(str)
+    )
+    segment5_support = frame.groupby("segment5").size()
+    frame["segment5_support"] = frame["segment5"].map(segment5_support).astype("int32")
+    frame["segment5_support_bucket"] = pd.cut(
+        frame["segment5_support"],
+        bins=[0, 49, 99, 249, 499, np.inf],
+        labels=["lt50", "50_99", "100_249", "250_499", "500_plus"],
+        right=True,
+    ).astype(str)
+
+    merged = frame.merge(merged_oof, how="inner", on=ID_COLUMN, validate="one_to_one")
+    if merged.empty:
+        raise ValueError("Merged analysis frame is empty.")
+    return merged
+
+
+def _compute_overall_metrics(frame: pd.DataFrame, pred_col: str) -> dict[str, float]:
+    y_true = frame[OOF_TARGET_COLUMN].astype(int)
+    pred = frame[pred_col].astype("float64")
+    losses = _logloss_vector(y_true, pred)
+    squared_error = (pred - y_true) ** 2
+    abs_error = (pred - y_true).abs()
+    positive_rate = float(y_true.mean())
+    pred_mean = float(pred.mean())
+    return {
+        "auc": float(binary_auc(y_true, pred)),
+        "logloss": float(losses.mean()),
+        "brier": float(squared_error.mean()),
+        "mae": float(abs_error.mean()),
+        "positive_rate": positive_rate,
+        "pred_mean": pred_mean,
+        "calibration_gap": float(pred_mean - positive_rate),
+        "pred_std": float(pred.std(ddof=0)),
+    }
+
+
+def _group_metrics(
+    frame: pd.DataFrame,
+    *,
+    family: str,
+    column: str,
+    min_rows: int,
+    challenger_col: str,
+    reference_col: str,
+    challenger_loss_col: str,
+    reference_loss_col: str,
+    challenger_hard_col: str,
+    reference_hard_col: str,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    total_rows = float(len(frame))
+
+    for group_value, part in frame.groupby(column, dropna=False):
+        if len(part) < min_rows:
+            continue
+
+        y_true = part[OOF_TARGET_COLUMN].astype(int)
+        challenger_pred = part[challenger_col].astype("float64")
+        reference_pred = part[reference_col].astype("float64")
+
+        challenger_mean = float(challenger_pred.mean())
+        reference_mean = float(reference_pred.mean())
+        positive_rate = float(y_true.mean())
+        challenger_auc = _safe_auc(y_true, challenger_pred)
+        reference_auc = _safe_auc(y_true, reference_pred)
+
+        challenger_logloss = float(part[challenger_loss_col].mean())
+        reference_logloss = float(part[reference_loss_col].mean())
+        challenger_brier = float(((challenger_pred - y_true) ** 2).mean())
+        reference_brier = float(((reference_pred - y_true) ** 2).mean())
+        challenger_mae = float((challenger_pred - y_true).abs().mean())
+        reference_mae = float((reference_pred - y_true).abs().mean())
+
+        row = {
+            "family": family,
+            "column": column,
+            "group_value": str(group_value),
+            "rows": int(len(part)),
+            "positives": int(y_true.sum()),
+            "positive_rate": positive_rate,
+            "challenger_auc": challenger_auc,
+            "reference_auc": reference_auc,
+            "delta_auc": (
+                None if challenger_auc is None or reference_auc is None else float(challenger_auc - reference_auc)
+            ),
+            "challenger_logloss": challenger_logloss,
+            "reference_logloss": reference_logloss,
+            "delta_logloss": float(challenger_logloss - reference_logloss),
+            "logloss_delta_contribution": float(
+                (challenger_logloss - reference_logloss) * float(len(part)) / total_rows
+            ),
+            "challenger_brier": challenger_brier,
+            "reference_brier": reference_brier,
+            "delta_brier": float(challenger_brier - reference_brier),
+            "challenger_mae": challenger_mae,
+            "reference_mae": reference_mae,
+            "delta_mae": float(challenger_mae - reference_mae),
+            "challenger_pred_mean": challenger_mean,
+            "reference_pred_mean": reference_mean,
+            "challenger_calibration_gap": float(challenger_mean - positive_rate),
+            "reference_calibration_gap": float(reference_mean - positive_rate),
+            "delta_abs_calibration_gap": float(
+                abs(challenger_mean - positive_rate) - abs(reference_mean - positive_rate)
+            ),
+            "mean_abs_pred_shift": float((challenger_pred - reference_pred).abs().mean()),
+            "signed_pred_shift": float((challenger_pred - reference_pred).mean()),
+            "challenger_hard_case_rate": float(part[challenger_hard_col].mean()),
+            "reference_hard_case_rate": float(part[reference_hard_col].mean()),
+            "delta_hard_case_rate": float(
+                float(part[challenger_hard_col].mean()) - float(part[reference_hard_col].mean())
+            ),
+        }
+        rows.append(row)
+
+    return rows
+
+
+def _select_records(frame: pd.DataFrame, *, sort_by: str, ascending: bool, top_k: int) -> list[dict[str, Any]]:
+    if frame.empty:
+        return []
+    return frame.sort_values(by=sort_by, ascending=ascending).head(top_k).to_dict(orient="records")
+
+
+def main() -> int:
+    args = parse_args()
+    raw_specs = args.oof if args.oof else list(DEFAULT_OOF_SPECS)
+    specs = [parse_oof_input_spec(raw) for raw in raw_specs]
+    merged_oof, model_columns = load_merged_oof_matrix(specs, target_column=OOF_TARGET_COLUMN)
+
+    reference_weights = _load_weights(args.reference_weights_json)
+    challenger_weights = _load_weights(args.challenger_weights_json)
+
+    if any(f"pred_{name}" not in merged_oof.columns for name in challenger_weights):
+        missing = [name for name in challenger_weights if f"pred_{name}" not in merged_oof.columns]
+        raise ValueError(f"Missing OOF predictions for challenger weights: {missing}")
+    if any(f"pred_{name}" not in merged_oof.columns for name in reference_weights):
+        missing = [name for name in reference_weights if f"pred_{name}" not in merged_oof.columns]
+        raise ValueError(f"Missing OOF predictions for reference weights: {missing}")
+
+    analysis = _build_analysis_frame(args.train_csv, merged_oof)
+    analysis[OOF_TARGET_COLUMN] = analysis[OOF_TARGET_COLUMN].astype(int)
+
+    analysis["pred_reference"] = 0.0
+    for name, weight in reference_weights.items():
+        analysis["pred_reference"] += float(weight) * analysis[f"pred_{name}"].astype("float64")
+
+    analysis["pred_challenger"] = 0.0
+    for name, weight in challenger_weights.items():
+        analysis["pred_challenger"] += float(weight) * analysis[f"pred_{name}"].astype("float64")
+
+    analysis["loss_reference"] = _logloss_vector(analysis[OOF_TARGET_COLUMN], analysis["pred_reference"])
+    analysis["loss_challenger"] = _logloss_vector(analysis[OOF_TARGET_COLUMN], analysis["pred_challenger"])
+
+    hard_quantile = float(args.hard_loss_quantile)
+    if not (0.5 < hard_quantile < 1.0):
+        raise ValueError("hard-loss-quantile must be in (0.5, 1.0)")
+
+    hard_threshold_reference = float(analysis["loss_reference"].quantile(hard_quantile))
+    hard_threshold_challenger = float(analysis["loss_challenger"].quantile(hard_quantile))
+    analysis["hard_reference"] = (analysis["loss_reference"] >= hard_threshold_reference).astype("int8")
+    analysis["hard_challenger"] = (analysis["loss_challenger"] >= hard_threshold_challenger).astype("int8")
+
+    group_specs = (
+        ("contract", "Contract", 1000),
+        ("payment_method", "PaymentMethod", 1000),
+        ("internet_service", "InternetService", 1000),
+        ("paperless", "PaperlessBilling", 1000),
+        ("senior", "SeniorCitizen", 1000),
+        ("partner", "Partner", 1000),
+        ("dependents", "Dependents", 1000),
+        ("tenure_bin", "tenure_bin", 1000),
+        ("annual_boundary", "annual_boundary_bin", 1000),
+        ("contract_boundary", "contract_boundary_bin", 1000),
+        ("contract_x_boundary", "contract_x_boundary_bin", 2000),
+        ("segment3", "segment3", 5000),
+        ("segment5_support", "segment5_support_bucket", 1),
+        ("segment5", "segment5", 2000),
+    )
+
+    group_rows: list[dict[str, Any]] = []
+    for family, column, min_rows in group_specs:
+        group_rows.extend(
+            _group_metrics(
+                analysis,
+                family=family,
+                column=column,
+                min_rows=min_rows,
+                challenger_col="pred_challenger",
+                reference_col="pred_reference",
+                challenger_loss_col="loss_challenger",
+                reference_loss_col="loss_reference",
+                challenger_hard_col="hard_challenger",
+                reference_hard_col="hard_reference",
+            )
+        )
+
+    groups_df = pd.DataFrame(group_rows)
+    groups_out = Path(args.out_groups_csv)
+    groups_out.parent.mkdir(parents=True, exist_ok=True)
+    groups_df.to_csv(groups_out, index=False)
+
+    hard_cases = groups_df[groups_df["rows"] >= 2000].copy()
+    overall_hard_rate = float(analysis["hard_challenger"].mean())
+    if not hard_cases.empty and overall_hard_rate > 0.0:
+        hard_cases["challenger_hard_case_lift"] = (
+            hard_cases["challenger_hard_case_rate"] / overall_hard_rate
+        )
+    else:
+        hard_cases["challenger_hard_case_lift"] = np.nan
+    hard_cases = hard_cases.sort_values(
+        by=["challenger_hard_case_lift", "rows"],
+        ascending=[False, False],
+    )
+    hard_cases_out = Path(args.out_hard_cases_csv)
+    hard_cases_out.parent.mkdir(parents=True, exist_ok=True)
+    hard_cases.to_csv(hard_cases_out, index=False)
+
+    overall_reference = _compute_overall_metrics(analysis, "pred_reference")
+    overall_challenger = _compute_overall_metrics(analysis, "pred_challenger")
+
+    family_summary_rows: list[dict[str, Any]] = []
+    for family, part in groups_df.groupby("family", dropna=False):
+        valid_auc = part["delta_auc"].dropna()
+        family_summary_rows.append(
+            {
+                "family": str(family),
+                "groups": int(len(part)),
+                "rows_sum": int(part["rows"].sum()),
+                "weighted_delta_logloss": float(np.average(part["delta_logloss"], weights=part["rows"])),
+                "weighted_delta_brier": float(np.average(part["delta_brier"], weights=part["rows"])),
+                "weighted_delta_mae": float(np.average(part["delta_mae"], weights=part["rows"])),
+                "weighted_delta_auc": (
+                    None
+                    if valid_auc.empty
+                    else float(np.average(valid_auc, weights=part.loc[valid_auc.index, "rows"]))
+                ),
+                "weighted_mean_abs_pred_shift": float(
+                    np.average(part["mean_abs_pred_shift"], weights=part["rows"])
+                ),
+                "weighted_delta_hard_case_rate": float(
+                    np.average(part["delta_hard_case_rate"], weights=part["rows"])
+                ),
+            }
+        )
+    family_summary_df = pd.DataFrame(family_summary_rows).sort_values(
+        by="weighted_delta_logloss",
+        ascending=False,
+    )
+
+    top_k = max(int(args.top_k), 1)
+    summary = {
+        "generated_at_utc": utc_now_iso(),
+        "inputs": {
+            "train_csv": args.train_csv,
+            "oof": raw_specs,
+            "reference_weights_json": args.reference_weights_json,
+            "challenger_weights_json": args.challenger_weights_json,
+            "hard_loss_quantile": hard_quantile,
+        },
+        "models_loaded": list(model_columns),
+        "overall_reference": overall_reference,
+        "overall_challenger": overall_challenger,
+        "delta_challenger_vs_reference": {
+            "auc": float(overall_challenger["auc"] - overall_reference["auc"]),
+            "logloss": float(overall_challenger["logloss"] - overall_reference["logloss"]),
+            "brier": float(overall_challenger["brier"] - overall_reference["brier"]),
+            "mae": float(overall_challenger["mae"] - overall_reference["mae"]),
+            "abs_calibration_gap": float(
+                abs(overall_challenger["calibration_gap"]) - abs(overall_reference["calibration_gap"])
+            ),
+        },
+        "hard_case_thresholds": {
+            "reference_logloss_q": hard_threshold_reference,
+            "challenger_logloss_q": hard_threshold_challenger,
+            "reference_rate": float(analysis["hard_reference"].mean()),
+            "challenger_rate": float(analysis["hard_challenger"].mean()),
+        },
+        "family_rollup": family_summary_df.to_dict(orient="records"),
+        "top_degraded_groups_by_logloss": _select_records(
+            groups_df[groups_df["rows"] >= 2000],
+            sort_by="logloss_delta_contribution",
+            ascending=False,
+            top_k=top_k,
+        ),
+        "top_improved_groups_by_logloss": _select_records(
+            groups_df[groups_df["rows"] >= 2000],
+            sort_by="logloss_delta_contribution",
+            ascending=True,
+            top_k=top_k,
+        ),
+        "worst_groups_in_challenger_by_logloss": _select_records(
+            groups_df[groups_df["rows"] >= 2000],
+            sort_by="challenger_logloss",
+            ascending=False,
+            top_k=top_k,
+        ),
+        "worst_groups_in_challenger_by_abs_calibration_gap": _select_records(
+            groups_df.assign(
+                challenger_abs_calibration_gap=groups_df["challenger_calibration_gap"].abs()
+            )[groups_df["rows"] >= 2000],
+            sort_by="challenger_abs_calibration_gap",
+            ascending=False,
+            top_k=top_k,
+        ),
+        "hard_case_hotspots": _select_records(
+            hard_cases,
+            sort_by="challenger_hard_case_lift",
+            ascending=False,
+            top_k=top_k,
+        ),
+        "groups_csv_path": str(groups_out),
+        "hard_cases_csv_path": str(hard_cases_out),
+    }
+    write_json(args.out_json, summary)
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analyze_family_generalization.py
+++ b/scripts/analyze_family_generalization.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Build a family-level generalization compass with leave-one-family-out retraining."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.diagnostics import DEFAULT_REFERENCE_OOF_SPECS, run_family_generalization_compass
+from churn_baseline.feature_engineering import normalize_feature_blocks
+
+
+def _parse_feature_blocks(raw: str) -> list[str]:
+    normalized_raw = raw.strip().lower()
+    if normalized_raw in {"none", "off", "baseline", ""}:
+        return []
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    return list(normalize_feature_blocks(tokens))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Analyze family generalization with leave-one-family-out retraining")
+    parser.add_argument("--train-csv", default="data/raw/train.csv", help="Path to train.csv")
+    parser.add_argument("--test-csv", default="data/raw/test.csv", help="Path to test.csv")
+    parser.add_argument(
+        "--family-level",
+        choices=("segment3", "segment5"),
+        default="segment5",
+        help="Family granularity used for selection and holdout.",
+    )
+    parser.add_argument(
+        "--feature-blocks",
+        default="H,R,V",
+        help="Feature blocks used for leave-one-family-out retraining.",
+    )
+    parser.add_argument(
+        "--reference-oof",
+        default="",
+        help="Optional direct reference OOF spec: <path>[#<prediction_column>]. Overrides --oof + --reference-weights-json.",
+    )
+    parser.add_argument(
+        "--oof",
+        action="append",
+        default=[],
+        help="OOF input spec: <name>=<path>[#<prediction_column>]. Defaults to cb/xgb/lgb/r/rv teacher blend.",
+    )
+    parser.add_argument(
+        "--reference-weights-json",
+        default="artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json",
+        help="Weights JSON for the default weighted teacher reference.",
+    )
+    parser.add_argument("--top-k-families", type=int, default=12, help="Maximum number of families to evaluate with LOFO.")
+    parser.add_argument("--min-train-rows", type=int, default=5000, help="Minimum train rows for a family to be eligible.")
+    parser.add_argument("--min-test-rows", type=int, default=2000, help="Minimum test rows for a family to be eligible.")
+    parser.add_argument("--iterations", type=int, default=400, help="Fixed CatBoost iterations for LOFO retraining.")
+    parser.add_argument("--learning-rate", type=float, default=0.05, help="Learning rate for LOFO retraining.")
+    parser.add_argument("--depth", type=int, default=6, help="Tree depth for LOFO retraining.")
+    parser.add_argument("--l2-leaf-reg", type=float, default=5.0, help="L2 regularization for LOFO retraining.")
+    parser.add_argument("--random-state", type=int, default=42, help="Random seed for LOFO retraining.")
+    parser.add_argument(
+        "--out-json",
+        default="artifacts/reports/diagnostic_family_generalization_summary.json",
+        help="Output JSON summary path.",
+    )
+    parser.add_argument(
+        "--out-csv",
+        default="artifacts/reports/diagnostic_family_generalization_families.csv",
+        help="Output CSV table path.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    feature_blocks = _parse_feature_blocks(args.feature_blocks)
+    oof_specs = args.oof if args.oof else list(DEFAULT_REFERENCE_OOF_SPECS)
+    summary = run_family_generalization_compass(
+        train_csv_path=args.train_csv,
+        test_csv_path=args.test_csv,
+        family_level=args.family_level,
+        feature_blocks=feature_blocks,
+        top_k_families=args.top_k_families,
+        min_train_rows=args.min_train_rows,
+        min_test_rows=args.min_test_rows,
+        iterations=args.iterations,
+        learning_rate=args.learning_rate,
+        depth=args.depth,
+        l2_leaf_reg=args.l2_leaf_reg,
+        random_seed=args.random_state,
+        reference_oof_spec=args.reference_oof.strip() or None,
+        oof_specs=oof_specs,
+        reference_weights_json=args.reference_weights_json,
+        out_json_path=args.out_json,
+        out_csv_path=args.out_csv,
+    )
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analyze_label_noise.py
+++ b/scripts/analyze_label_noise.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Audit label noise, near-duplicates, and hard examples against incumbent v3."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.diagnostics import DEFAULT_REFERENCE_OOF_SPECS
+from churn_baseline.noise_audit import DEFAULT_V3_OOF_SPEC, run_label_noise_audit
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Audit label noise and near-duplicates against incumbent v3")
+    parser.add_argument("--train-csv", default="data/raw/train.csv", help="Path to train.csv")
+    parser.add_argument(
+        "--v3-oof",
+        default=DEFAULT_V3_OOF_SPEC,
+        help="Direct v3 OOF spec: <path>[#<prediction_column>].",
+    )
+    parser.add_argument(
+        "--oof",
+        action="append",
+        default=[],
+        help="Optional teacher OOF component spec: <name>=<path>[#<prediction_column>]. Defaults to cb/xgb/lgb/r/rv.",
+    )
+    parser.add_argument("--high-confidence-upper", type=float, default=0.90, help="Upper threshold for confident wrong negatives.")
+    parser.add_argument("--high-confidence-lower", type=float, default=0.10, help="Lower threshold for confident wrong positives.")
+    parser.add_argument("--hard-loss-quantile", type=float, default=0.995, help="Quantile used to mark hard examples by logloss.")
+    parser.add_argument("--low-disagreement-quantile", type=float, default=0.35, help="Teacher std quantile used to mark low disagreement.")
+    parser.add_argument("--high-disagreement-quantile", type=float, default=0.75, help="Teacher std quantile used as instability proxy.")
+    parser.add_argument(
+        "--max-near-duplicate-group-size",
+        type=int,
+        default=5,
+        help="Maximum coarse duplicate group size still considered a near-duplicate conflict.",
+    )
+    parser.add_argument("--top-n-families", type=int, default=15, help="How many top segment3/segment5 groups to report.")
+    parser.add_argument(
+        "--out-json",
+        default="artifacts/reports/label_noise_audit_summary.json",
+        help="Output JSON summary path.",
+    )
+    parser.add_argument(
+        "--out-rows-csv",
+        default="artifacts/reports/label_noise_audit_suspicious_rows.csv",
+        help="Output CSV path for suspicious rows.",
+    )
+    parser.add_argument(
+        "--out-duplicate-csv",
+        default="artifacts/reports/label_noise_audit_duplicate_groups.csv",
+        help="Output CSV path for duplicate groups.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    teacher_specs = args.oof if args.oof else list(DEFAULT_REFERENCE_OOF_SPECS)
+    summary = run_label_noise_audit(
+        train_csv_path=args.train_csv,
+        v3_oof_spec=args.v3_oof,
+        teacher_oof_specs=teacher_specs,
+        high_confidence_upper=args.high_confidence_upper,
+        high_confidence_lower=args.high_confidence_lower,
+        hard_loss_quantile=args.hard_loss_quantile,
+        low_disagreement_quantile=args.low_disagreement_quantile,
+        high_disagreement_quantile=args.high_disagreement_quantile,
+        max_near_duplicate_group_size=args.max_near_duplicate_group_size,
+        top_n_families=args.top_n_families,
+        out_json_path=args.out_json,
+        out_rows_csv_path=args.out_rows_csv,
+        out_duplicate_csv_path=args.out_duplicate_csv,
+    )
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analyze_submission_forensics.py
+++ b/scripts/analyze_submission_forensics.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Join Kaggle submission history with local submission artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.submission_forensics import write_submission_forensics_outputs
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Join Kaggle submission history with local submission artifacts")
+    parser.add_argument("--competition", default="playground-series-s6e3")
+    parser.add_argument("--reports-dir", default="artifacts/reports")
+    parser.add_argument(
+        "--submissions-dir",
+        default="artifacts/submissions",
+        help="Local directory scanned for submission CSV existence. Report linking uses the CSV basename referenced inside report JSONs.",
+    )
+    parser.add_argument("--out-summary-json", default="artifacts/reports/submission_forensics_summary.json")
+    parser.add_argument("--out-ledger-csv", default="artifacts/reports/submission_forensics_ledger.csv")
+    parser.add_argument("--out-reports-csv", default="artifacts/reports/submission_forensics_report_links.csv")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    summary = write_submission_forensics_outputs(
+        competition=args.competition,
+        reports_dir=args.reports_dir,
+        submissions_dir=args.submissions_dir,
+        out_summary_json=args.out_summary_json,
+        out_ledger_csv=args.out_ledger_csv,
+        out_reports_csv=args.out_reports_csv,
+    )
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analyze_train_test_drift.py
+++ b/scripts/analyze_train_test_drift.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Analyze train/test drift and adversarial validation diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.artifacts import write_json
+from churn_baseline.data import load_csv, prepare_test_features, prepare_train_features
+from churn_baseline.diagnostics import (
+    build_categorical_drift_table,
+    build_numeric_drift_table,
+    parse_feature_blocks_arg,
+    run_adversarial_validation,
+    utc_now_iso,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run train/test drift diagnostics")
+    parser.add_argument("--train-csv", default="data/raw/train.csv", help="Path to train.csv")
+    parser.add_argument("--test-csv", default="data/raw/test.csv", help="Path to test.csv")
+    parser.add_argument(
+        "--feature-blocks",
+        default="none",
+        help="Optional feature blocks (A,B,C,O,P) or none.",
+    )
+    parser.add_argument(
+        "--psi-bins",
+        type=int,
+        default=10,
+        help="Quantile bins used for numeric PSI.",
+    )
+    parser.add_argument("--adv-folds", type=int, default=3, help="Adversarial CV folds.")
+    parser.add_argument(
+        "--adv-sample-frac",
+        type=float,
+        default=0.35,
+        help="Sample fraction per split for adversarial training.",
+    )
+    parser.add_argument(
+        "--adv-iterations",
+        type=int,
+        default=500,
+        help="CatBoost max iterations for adversarial validation.",
+    )
+    parser.add_argument(
+        "--adv-learning-rate",
+        type=float,
+        default=0.05,
+        help="Learning rate for adversarial validation.",
+    )
+    parser.add_argument("--adv-depth", type=int, default=6, help="Tree depth for adversarial model.")
+    parser.add_argument(
+        "--adv-early-stopping-rounds",
+        type=int,
+        default=80,
+        help="Early stopping rounds for adversarial folds.",
+    )
+    parser.add_argument("--random-state", type=int, default=42, help="Random seed.")
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=20,
+        help="How many top drift columns/features to include in summary.",
+    )
+    parser.add_argument(
+        "--out-json",
+        default="artifacts/reports/diagnostic_train_test_drift.json",
+        help="Output summary JSON path.",
+    )
+    parser.add_argument(
+        "--out-numeric-csv",
+        default="artifacts/reports/diagnostic_train_test_numeric_drift.csv",
+        help="Output numeric drift CSV path.",
+    )
+    parser.add_argument(
+        "--out-categorical-csv",
+        default="artifacts/reports/diagnostic_train_test_categorical_drift.csv",
+        help="Output categorical drift CSV path.",
+    )
+    return parser.parse_args()
+
+
+def _adv_severity(auc: float) -> str:
+    if auc >= 0.75:
+        return "severe"
+    if auc >= 0.65:
+        return "high"
+    if auc >= 0.58:
+        return "moderate"
+    return "low"
+
+
+def main() -> int:
+    args = parse_args()
+    feature_blocks = parse_feature_blocks_arg(args.feature_blocks)
+
+    train_df = load_csv(args.train_csv)
+    test_df = load_csv(args.test_csv)
+    x_train, _ = prepare_train_features(train_df, drop_id=True, feature_blocks=feature_blocks)
+    x_test = prepare_test_features(test_df, drop_id=True, feature_blocks=feature_blocks)
+
+    numeric_drift = build_numeric_drift_table(x_train, x_test, psi_bins=args.psi_bins)
+    categorical_drift = build_categorical_drift_table(x_train, x_test)
+    adversarial = run_adversarial_validation(
+        x_train,
+        x_test,
+        folds=args.adv_folds,
+        random_state=args.random_state,
+        iterations=args.adv_iterations,
+        learning_rate=args.adv_learning_rate,
+        depth=args.adv_depth,
+        early_stopping_rounds=args.adv_early_stopping_rounds,
+        sample_frac=args.adv_sample_frac,
+    )
+
+    numeric_out = Path(args.out_numeric_csv)
+    numeric_out.parent.mkdir(parents=True, exist_ok=True)
+    numeric_drift.to_csv(numeric_out, index=False)
+
+    categorical_out = Path(args.out_categorical_csv)
+    categorical_out.parent.mkdir(parents=True, exist_ok=True)
+    categorical_drift.to_csv(categorical_out, index=False)
+
+    top_k = max(int(args.top_k), 1)
+    top_numeric = numeric_drift.head(top_k).to_dict(orient="records")
+    top_categorical = categorical_drift.head(top_k).to_dict(orient="records")
+
+    high_psi_count = int((numeric_drift["psi"].fillna(0.0) >= 0.2).sum()) if not numeric_drift.empty else 0
+    high_tvd_count = (
+        int((categorical_drift["tvd"].fillna(0.0) >= 0.2).sum()) if not categorical_drift.empty else 0
+    )
+    adv_auc = float(adversarial["cv_mean_auc"])
+
+    summary = {
+        "generated_at_utc": utc_now_iso(),
+        "inputs": {
+            "train_csv": args.train_csv,
+            "test_csv": args.test_csv,
+            "feature_blocks": feature_blocks,
+            "psi_bins": int(args.psi_bins),
+            "adv_folds": int(args.adv_folds),
+            "adv_sample_frac": float(args.adv_sample_frac),
+            "adv_iterations": int(args.adv_iterations),
+            "adv_learning_rate": float(args.adv_learning_rate),
+            "adv_depth": int(args.adv_depth),
+            "adv_early_stopping_rounds": int(args.adv_early_stopping_rounds),
+            "random_state": int(args.random_state),
+        },
+        "dataset": {
+            "train_rows": int(x_train.shape[0]),
+            "test_rows": int(x_test.shape[0]),
+            "feature_count": int(x_train.shape[1]),
+        },
+        "adversarial_validation": {
+            **adversarial,
+            "severity": _adv_severity(adv_auc),
+        },
+        "numeric_drift": {
+            "row_count": int(numeric_drift.shape[0]),
+            "high_psi_count_ge_0_2": high_psi_count,
+            "top_rows": top_numeric,
+            "csv_path": str(numeric_out),
+        },
+        "categorical_drift": {
+            "row_count": int(categorical_drift.shape[0]),
+            "high_tvd_count_ge_0_2": high_tvd_count,
+            "top_rows": top_categorical,
+            "csv_path": str(categorical_out),
+        },
+    }
+    write_json(args.out_json, summary)
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analyze_train_test_drift.py
+++ b/scripts/analyze_train_test_drift.py
@@ -29,7 +29,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="none",
-        help="Optional feature blocks (A,B,C,O,P) or none.",
+        help="Optional feature blocks (A,B,C,H,R,S,V,O,P) or none.",
     )
     parser.add_argument(
         "--psi-bins",

--- a/scripts/analyze_train_test_drift.py
+++ b/scripts/analyze_train_test_drift.py
@@ -29,7 +29,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="none",
-        help="Optional feature blocks (A,B,C,H,R,S,V,O,P) or none.",
+        help="Optional feature blocks (A,B,C,F,H,R,S,V,O,P) or none.",
     )
     parser.add_argument(
         "--psi-bins",

--- a/scripts/analyze_v3_dominance.py
+++ b/scripts/analyze_v3_dominance.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Analyze why incumbent v3 dominates a curated challenger set."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.v3_dominance import (
+    DEFAULT_CHALLENGERS,
+    DEFAULT_V3_OOF_SPEC,
+    ChallengerSpec,
+    run_v3_dominance_diagnostic,
+)
+
+
+def _parse_challenger(raw: str) -> ChallengerSpec:
+    parts = [part.strip() for part in raw.split("|")]
+    if len(parts) not in {2, 3, 4}:
+        raise ValueError(
+            "Each --challenger must use '<name>|<path>' or '<name>|<path>|<prediction_column>|<family>'"
+        )
+    name = parts[0]
+    path = parts[1]
+    prediction_column = parts[2] if len(parts) >= 3 and parts[2] else "oof_pred"
+    family = parts[3] if len(parts) >= 4 and parts[3] else "custom"
+    return ChallengerSpec(name=name, path=path, prediction_column=prediction_column, family=family)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Analyze why incumbent v3 dominates failed challengers")
+    parser.add_argument("--train-csv", default="data/raw/train.csv")
+    parser.add_argument("--reference-v3-oof", default=DEFAULT_V3_OOF_SPEC)
+    parser.add_argument(
+        "--challenger",
+        action="append",
+        default=[],
+        help="Optional challenger override: <name>|<path>|<prediction_column>|<family>",
+    )
+    parser.add_argument("--label", default="v3_dominance")
+    parser.add_argument("--out-dir", default="artifacts/reports")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    challengers = tuple(_parse_challenger(raw) for raw in args.challenger) if args.challenger else DEFAULT_CHALLENGERS
+    result = run_v3_dominance_diagnostic(
+        train_csv_path=args.train_csv,
+        reference_oof_spec=args.reference_v3_oof,
+        challengers=challengers,
+        out_dir=args.out_dir,
+        label=args.label,
+    )
+    print(json.dumps(result["summary"], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_submission_parity.py
+++ b/scripts/audit_submission_parity.py
@@ -38,7 +38,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="none",
-        help="Optional feature blocks (A,B,C,O,P) or none.",
+        help="Optional feature blocks (A,B,C,H,R,S,V,O,P) or none.",
     )
     parser.add_argument(
         "--metrics-path",

--- a/scripts/audit_submission_parity.py
+++ b/scripts/audit_submission_parity.py
@@ -38,7 +38,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="none",
-        help="Optional feature blocks (A,B,C,H,R,S,V,O,P) or none.",
+        help="Optional feature blocks (A,B,C,F,H,R,S,V,O,P) or none.",
     )
     parser.add_argument(
         "--metrics-path",

--- a/scripts/audit_submission_parity.py
+++ b/scripts/audit_submission_parity.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""Audit train/inference parity for submission generation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.artifacts import write_json
+from churn_baseline.config import ID_COLUMN, TARGET_COLUMN
+from churn_baseline.data import infer_categorical_columns, load_csv, prepare_test_features, prepare_train_features
+from churn_baseline.diagnostics import (
+    FAIL_STATUS,
+    PASS_STATUS,
+    WARN_STATUS,
+    make_check,
+    parse_feature_blocks_arg,
+    summarize_checks,
+    utc_now_iso,
+)
+
+
+def _cap(items: list[str], limit: int = 25) -> list[str]:
+    if len(items) <= limit:
+        return items
+    return [*items[:limit], f"... (+{len(items) - limit} more)"]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Audit submission parity and artifact consistency")
+    parser.add_argument("--train-csv", default="data/raw/train.csv", help="Path to train.csv")
+    parser.add_argument("--test-csv", default="data/raw/test.csv", help="Path to test.csv")
+    parser.add_argument(
+        "--feature-blocks",
+        default="none",
+        help="Optional feature blocks (A,B,C,O,P) or none.",
+    )
+    parser.add_argument(
+        "--metrics-path",
+        default="artifacts/reports/train_cv_multiseed_metrics.json",
+        help="Metrics JSON used to produce submission.",
+    )
+    parser.add_argument(
+        "--submission-csv",
+        default="",
+        help="Optional submission CSV to validate.",
+    )
+    parser.add_argument(
+        "--reference-submission-csv",
+        default="",
+        help="Optional reference submission CSV for prediction-delta checks.",
+    )
+    parser.add_argument(
+        "--out-json",
+        default="artifacts/reports/diagnostic_submission_parity.json",
+        help="Output audit report JSON path.",
+    )
+    return parser.parse_args()
+
+
+def _load_metrics_if_present(metrics_path: Path) -> dict | None:
+    if not metrics_path.exists():
+        return None
+    with metrics_path.open("r", encoding="utf-8") as fh:
+        payload = json.load(fh)
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected object JSON in metrics file: {metrics_path}")
+    return payload
+
+
+def _extract_model_paths(metrics: dict) -> list[str]:
+    paths: list[str] = []
+    if "model_path" in metrics and isinstance(metrics["model_path"], str):
+        paths.append(metrics["model_path"])
+    model_paths = metrics.get("model_paths")
+    if isinstance(model_paths, list):
+        for item in model_paths:
+            if isinstance(item, str):
+                paths.append(item)
+    deduped = []
+    seen = set()
+    for path in paths:
+        if path not in seen:
+            seen.add(path)
+            deduped.append(path)
+    return deduped
+
+
+def main() -> int:
+    args = parse_args()
+    feature_blocks = parse_feature_blocks_arg(args.feature_blocks)
+
+    train_df = load_csv(args.train_csv)
+    test_df = load_csv(args.test_csv)
+    x_train, _ = prepare_train_features(train_df, drop_id=True, feature_blocks=feature_blocks)
+    x_test = prepare_test_features(test_df, drop_id=True, feature_blocks=feature_blocks)
+
+    checks = []
+
+    train_raw_feature_cols = [col for col in train_df.columns if col != TARGET_COLUMN]
+    test_raw_cols = list(test_df.columns)
+    missing_raw_in_test = sorted(set(train_raw_feature_cols) - set(test_raw_cols))
+    extra_raw_in_test = sorted(set(test_raw_cols) - set(train_raw_feature_cols))
+    raw_status = PASS_STATUS if not missing_raw_in_test and not extra_raw_in_test else FAIL_STATUS
+    checks.append(
+        make_check(
+            "raw_columns_train_vs_test",
+            raw_status,
+            {
+                "train_feature_column_count": len(train_raw_feature_cols),
+                "test_column_count": len(test_raw_cols),
+                "missing_in_test": _cap(missing_raw_in_test),
+                "extra_in_test": _cap(extra_raw_in_test),
+            },
+        )
+    )
+
+    train_cols = list(x_train.columns)
+    test_cols = list(x_test.columns)
+    missing_engineered_in_test = sorted(set(train_cols) - set(test_cols))
+    extra_engineered_in_test = sorted(set(test_cols) - set(train_cols))
+    engineered_set_status = (
+        PASS_STATUS if not missing_engineered_in_test and not extra_engineered_in_test else FAIL_STATUS
+    )
+    checks.append(
+        make_check(
+            "engineered_columns_set_match",
+            engineered_set_status,
+            {
+                "train_feature_count": len(train_cols),
+                "test_feature_count": len(test_cols),
+                "missing_in_test": _cap(missing_engineered_in_test),
+                "extra_in_test": _cap(extra_engineered_in_test),
+            },
+        )
+    )
+
+    order_match = train_cols == test_cols
+    checks.append(
+        make_check(
+            "engineered_columns_order_match",
+            PASS_STATUS if order_match else FAIL_STATUS,
+            {
+                "order_match": bool(order_match),
+                "first_train_columns": train_cols[:10],
+                "first_test_columns": test_cols[:10],
+            },
+        )
+    )
+
+    common_cols = [column for column in train_cols if column in x_test.columns]
+    dtype_mismatches = []
+    for column in common_cols:
+        train_dtype = str(x_train[column].dtype)
+        test_dtype = str(x_test[column].dtype)
+        if train_dtype != test_dtype:
+            dtype_mismatches.append(
+                {"column": column, "train_dtype": train_dtype, "test_dtype": test_dtype}
+            )
+    dtype_status = PASS_STATUS if not dtype_mismatches else WARN_STATUS
+    checks.append(
+        make_check(
+            "engineered_dtype_match",
+            dtype_status,
+            {
+                "mismatch_count": len(dtype_mismatches),
+                "examples": dtype_mismatches[:20],
+            },
+        )
+    )
+
+    train_cat = set(infer_categorical_columns(x_train))
+    test_cat = set(infer_categorical_columns(x_test))
+    missing_cat_in_test = sorted(train_cat - test_cat)
+    extra_cat_in_test = sorted(test_cat - train_cat)
+    cat_status = PASS_STATUS if not missing_cat_in_test and not extra_cat_in_test else WARN_STATUS
+    checks.append(
+        make_check(
+            "categorical_columns_match",
+            cat_status,
+            {
+                "train_categorical_count": len(train_cat),
+                "test_categorical_count": len(test_cat),
+                "missing_in_test": _cap(missing_cat_in_test),
+                "extra_in_test": _cap(extra_cat_in_test),
+            },
+        )
+    )
+
+    metrics_path = Path(args.metrics_path)
+    metrics_payload = _load_metrics_if_present(metrics_path)
+    if metrics_payload is None:
+        checks.append(
+            make_check(
+                "metrics_file_presence",
+                WARN_STATUS,
+                {
+                    "metrics_path": str(metrics_path),
+                    "exists": False,
+                },
+            )
+        )
+    else:
+        checks.append(
+            make_check(
+                "metrics_file_presence",
+                PASS_STATUS,
+                {
+                    "metrics_path": str(metrics_path),
+                    "exists": True,
+                },
+            )
+        )
+
+        metric_blocks = metrics_payload.get("feature_blocks")
+        block_status = PASS_STATUS
+        if metric_blocks is None:
+            if feature_blocks:
+                block_status = WARN_STATUS
+        elif isinstance(metric_blocks, list):
+            if list(metric_blocks) != feature_blocks:
+                block_status = FAIL_STATUS
+        else:
+            block_status = WARN_STATUS
+        checks.append(
+            make_check(
+                "metrics_feature_blocks_match",
+                block_status,
+                {
+                    "requested_feature_blocks": feature_blocks,
+                    "metrics_feature_blocks": metric_blocks,
+                },
+            )
+        )
+
+        metric_feature_count = metrics_payload.get("feature_count")
+        feature_count_status = PASS_STATUS
+        if isinstance(metric_feature_count, int):
+            if int(metric_feature_count) != int(x_train.shape[1]):
+                feature_count_status = FAIL_STATUS
+        else:
+            feature_count_status = WARN_STATUS
+        checks.append(
+            make_check(
+                "metrics_feature_count_match",
+                feature_count_status,
+                {
+                    "prepared_feature_count": int(x_train.shape[1]),
+                    "metrics_feature_count": metric_feature_count,
+                },
+            )
+        )
+
+        model_paths = _extract_model_paths(metrics_payload)
+        missing_model_paths = [path for path in model_paths if not Path(path).exists()]
+        model_status = PASS_STATUS if not missing_model_paths else FAIL_STATUS
+        checks.append(
+            make_check(
+                "metrics_model_paths_exist",
+                model_status,
+                {
+                    "model_path_count": len(model_paths),
+                    "missing_model_paths": _cap(missing_model_paths),
+                },
+            )
+        )
+
+    submission_path = Path(args.submission_csv) if args.submission_csv else None
+    if submission_path is None:
+        checks.append(
+            make_check(
+                "submission_csv_provided",
+                WARN_STATUS,
+                {
+                    "provided": False,
+                },
+            )
+        )
+    else:
+        if not submission_path.exists():
+            checks.append(
+                make_check(
+                    "submission_csv_exists",
+                    FAIL_STATUS,
+                    {
+                        "submission_csv": str(submission_path),
+                        "exists": False,
+                    },
+                )
+            )
+        else:
+            submission_df = load_csv(submission_path)
+            required = {ID_COLUMN, TARGET_COLUMN}
+            missing_submission_cols = sorted(required - set(submission_df.columns))
+            checks.append(
+                make_check(
+                    "submission_required_columns",
+                    PASS_STATUS if not missing_submission_cols else FAIL_STATUS,
+                    {
+                        "columns": list(submission_df.columns),
+                        "missing_required_columns": missing_submission_cols,
+                    },
+                )
+            )
+
+            row_match = len(submission_df) == len(test_df)
+            checks.append(
+                make_check(
+                    "submission_row_count_match_test",
+                    PASS_STATUS if row_match else FAIL_STATUS,
+                    {
+                        "submission_rows": int(len(submission_df)),
+                        "test_rows": int(len(test_df)),
+                    },
+                )
+            )
+
+            if ID_COLUMN in submission_df.columns and ID_COLUMN in test_df.columns:
+                id_match = submission_df[ID_COLUMN].equals(test_df[ID_COLUMN])
+                checks.append(
+                    make_check(
+                        "submission_id_order_match_test",
+                        PASS_STATUS if id_match else FAIL_STATUS,
+                        {
+                            "id_order_match": bool(id_match),
+                        },
+                    )
+                )
+
+            if TARGET_COLUMN in submission_df.columns:
+                pred_series = submission_df[TARGET_COLUMN]
+                pred_min = float(pred_series.min())
+                pred_max = float(pred_series.max())
+                in_range = pred_min >= 0.0 and pred_max <= 1.0
+                checks.append(
+                    make_check(
+                        "submission_prediction_range",
+                        PASS_STATUS if in_range else WARN_STATUS,
+                        {
+                            "prediction_min": pred_min,
+                            "prediction_max": pred_max,
+                            "expected_range": "[0,1]",
+                        },
+                    )
+                )
+
+            reference_path = Path(args.reference_submission_csv) if args.reference_submission_csv else None
+            if reference_path is None:
+                checks.append(
+                    make_check(
+                        "reference_submission_provided",
+                        WARN_STATUS,
+                        {"provided": False},
+                    )
+                )
+            elif not reference_path.exists():
+                checks.append(
+                    make_check(
+                        "reference_submission_exists",
+                        FAIL_STATUS,
+                        {"reference_submission_csv": str(reference_path), "exists": False},
+                    )
+                )
+            else:
+                reference_df = load_csv(reference_path)
+                if ID_COLUMN in reference_df.columns and TARGET_COLUMN in reference_df.columns:
+                    aligned = (
+                        len(reference_df) == len(submission_df)
+                        and submission_df[ID_COLUMN].equals(reference_df[ID_COLUMN])
+                    )
+                    if not aligned:
+                        checks.append(
+                            make_check(
+                                "reference_submission_alignment",
+                                FAIL_STATUS,
+                                {
+                                    "aligned_on_id_and_rows": False,
+                                    "reference_rows": int(len(reference_df)),
+                                    "submission_rows": int(len(submission_df)),
+                                },
+                            )
+                        )
+                    else:
+                        delta = (submission_df[TARGET_COLUMN] - reference_df[TARGET_COLUMN]).astype("float64")
+                        corr = float(submission_df[TARGET_COLUMN].corr(reference_df[TARGET_COLUMN]))
+                        mae = float(delta.abs().mean())
+                        max_abs_delta = float(delta.abs().max())
+                        status = PASS_STATUS if corr >= 0.95 else WARN_STATUS
+                        checks.append(
+                            make_check(
+                                "reference_submission_delta",
+                                status,
+                                {
+                                    "reference_submission_csv": str(reference_path),
+                                    "pearson_correlation": corr,
+                                    "mean_absolute_delta": mae,
+                                    "max_absolute_delta": max_abs_delta,
+                                },
+                            )
+                        )
+                else:
+                    checks.append(
+                        make_check(
+                            "reference_submission_required_columns",
+                            FAIL_STATUS,
+                            {
+                                "reference_submission_csv": str(reference_path),
+                                "columns": list(reference_df.columns),
+                            },
+                        )
+                    )
+
+    summary = summarize_checks(checks)
+    report = {
+        "generated_at_utc": utc_now_iso(),
+        "inputs": {
+            "train_csv": args.train_csv,
+            "test_csv": args.test_csv,
+            "feature_blocks": feature_blocks,
+            "metrics_path": args.metrics_path,
+            "submission_csv": args.submission_csv or None,
+            "reference_submission_csv": args.reference_submission_csv or None,
+        },
+        "prepared_features": {
+            "train_rows": int(x_train.shape[0]),
+            "test_rows": int(x_test.shape[0]),
+            "feature_count": int(x_train.shape[1]),
+            "categorical_column_count": int(len(train_cat)),
+        },
+        **summary,
+        "checks": checks,
+    }
+    write_json(args.out_json, report)
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_teacher_component_frame.py
+++ b/scripts/build_teacher_component_frame.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Build a teacher reference component frame for teacher-aware residual inference."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.diagnostics import parse_feature_blocks_arg
+from churn_baseline.specialist import build_teacher_reference_component_frame
+
+
+def _load_weights(path: str | Path) -> dict[str, float]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    weights = payload.get("weights")
+    if not isinstance(weights, dict) or not weights:
+        raise ValueError(f"Could not find weights in {path}")
+    return {str(name): float(value) for name, value in weights.items()}
+
+
+def _load_model_paths(metrics_path: str | Path) -> list[str]:
+    payload = json.loads(Path(metrics_path).read_text(encoding="utf-8"))
+    model_paths = payload.get("model_paths")
+    if not isinstance(model_paths, list) or not model_paths:
+        raise ValueError(f"Could not find model_paths in {metrics_path}")
+    return [str(path) for path in model_paths]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build teacher reference component frame from incumbent blend artifacts"
+    )
+    parser.add_argument("--test-csv", default="data/raw/test.csv")
+    parser.add_argument(
+        "--cb-metrics-json",
+        default="artifacts/reports/train_cv_multiseed_gate_s5_hiiter_metrics.json",
+        help="Metrics JSON with cb model_paths.",
+    )
+    parser.add_argument(
+        "--cb-feature-blocks",
+        default="none",
+        help="Feature blocks used by the cb ensemble models.",
+    )
+    parser.add_argument(
+        "--r-model-path",
+        default="artifacts/models/fe_blockR_hiiter.cbm",
+        help="CatBoost model path for the R component.",
+    )
+    parser.add_argument(
+        "--r-feature-blocks",
+        default="R",
+        help="Feature blocks used by the R component model.",
+    )
+    parser.add_argument(
+        "--cbxgblgb-submission",
+        default="artifacts/submissions/playground-series-s6e3.csv",
+        help="Validated submission for the cb+xgb+lgb blend.",
+    )
+    parser.add_argument(
+        "--cbxgblgb-weights-json",
+        default="artifacts/reports/submission_candidate_cb5_xgb3_lgb_weights.json",
+        help="Weights JSON for the cb+xgb+lgb blend.",
+    )
+    parser.add_argument(
+        "--cbr-submission",
+        default="artifacts/submissions/playground-series-s6e3-rblend.csv",
+        help="Validated submission for the cb+xgb+lgb+r blend.",
+    )
+    parser.add_argument(
+        "--cbr-weights-json",
+        default="artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_weights.json",
+        help="Weights JSON for the cb+xgb+lgb+r blend.",
+    )
+    parser.add_argument(
+        "--cbrv-submission",
+        default="artifacts/submissions/playground-series-s6e3-rvblend.csv",
+        help="Validated submission for the cb+xgb+lgb+r+rv blend.",
+    )
+    parser.add_argument(
+        "--cbrv-weights-json",
+        default="artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json",
+        help="Weights JSON for the cb+xgb+lgb+r+rv blend.",
+    )
+    parser.add_argument(
+        "--output-csv",
+        default="artifacts/reports/reference_component_frame_rvblend_test.csv",
+        help="Output CSV with id + pred_* columns.",
+    )
+    parser.add_argument(
+        "--report-json",
+        default="artifacts/reports/reference_component_frame_rvblend_test_report.json",
+        help="Output JSON report path.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    component_frame, report = build_teacher_reference_component_frame(
+        test_csv_path=args.test_csv,
+        cb_model_paths=_load_model_paths(args.cb_metrics_json),
+        cb_feature_blocks=parse_feature_blocks_arg(args.cb_feature_blocks),
+        r_model_path=args.r_model_path,
+        r_feature_blocks=parse_feature_blocks_arg(args.r_feature_blocks),
+        cbxgblgb_submission_path=args.cbxgblgb_submission,
+        cbxgblgb_weights=_load_weights(args.cbxgblgb_weights_json),
+        cbr_submission_path=args.cbr_submission,
+        cbr_weights=_load_weights(args.cbr_weights_json),
+        cbrv_submission_path=args.cbrv_submission,
+        cbrv_weights=_load_weights(args.cbrv_weights_json),
+    )
+
+    output_path = Path(args.output_csv)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    component_frame.to_csv(output_path, index=False)
+
+    report = {
+        **report,
+        "output_csv_path": str(output_path),
+        "report_json_path": str(args.report_json),
+    }
+    Path(args.report_json).write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evaluate_against_v3.py
+++ b/scripts/evaluate_against_v3.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Evaluate a residual-chain challenger directly against incumbent v3."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.incumbent_v3 import evaluate_candidate_chain_against_v3
+from churn_baseline.validation_protocol import DOMINANT_MACROFAMILY, SUPPORTED_STAGES
+
+
+def _parse_candidate_step(raw: str) -> tuple[str, str]:
+    parts = [part.strip() for part in raw.split("|", maxsplit=1)]
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise ValueError("Each --candidate-step must use '<preset>|<oof_path>'")
+    return parts[0], parts[1]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate a residual-chain challenger directly against incumbent v3"
+    )
+    parser.add_argument("--stage", choices=SUPPORTED_STAGES, default="smoke")
+    parser.add_argument("--train-csv", default="data/raw/train.csv")
+    parser.add_argument("--test-csv", default="data/raw/test.csv")
+    parser.add_argument(
+        "--candidate-order",
+        required=True,
+        help="Comma-separated step order for the challenger chain.",
+    )
+    parser.add_argument(
+        "--candidate-step",
+        action="append",
+        default=[],
+        help="Optional challenger step OOF override: <preset>|<oof_path>.",
+    )
+    parser.add_argument(
+        "--target-family-level",
+        choices=["segment3", "segment5"],
+        default="segment3",
+    )
+    parser.add_argument(
+        "--target-family-value",
+        default=DOMINANT_MACROFAMILY,
+        help="Family key used as the target-family guardrail.",
+    )
+    parser.add_argument(
+        "--dominant-family-value",
+        default=DOMINANT_MACROFAMILY,
+        help="Dominant macrofamily key for Split B.",
+    )
+    parser.add_argument("--label", default="candidate")
+    parser.add_argument("--out-dir", default="artifacts/reports")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    candidate_order = [token.strip() for token in args.candidate_order.split(",") if token.strip()]
+    candidate_step_oof_paths = dict(_parse_candidate_step(raw) for raw in args.candidate_step)
+    summary = evaluate_candidate_chain_against_v3(
+        candidate_order=candidate_order,
+        candidate_step_oof_paths=candidate_step_oof_paths,
+        stage=args.stage,
+        train_csv_path=args.train_csv,
+        test_csv_path=args.test_csv,
+        target_family_level=args.target_family_level,
+        target_family_value=args.target_family_value,
+        dominant_family_value=args.dominant_family_value,
+        label=args.label,
+        out_dir=args.out_dir,
+    )
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evaluate_ensemble_robustness.py
+++ b/scripts/evaluate_ensemble_robustness.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Evaluate ensemble robustness with repeated split validation on OOF matrix."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.artifacts import write_json
+from churn_baseline.diagnostics import (
+    OOF_TARGET_COLUMN,
+    evaluate_ensemble_robustness,
+    load_json_if_exists,
+    load_merged_oof_matrix,
+    parse_oof_input_spec,
+    utc_now_iso,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate equal/rank/weighted ensemble robustness")
+    parser.add_argument(
+        "--oof",
+        action="append",
+        required=True,
+        help="OOF input spec: <name>=<path>[#<prediction_column>]. Repeat for each model.",
+    )
+    parser.add_argument("--repeats", type=int, default=3, help="Number of repeated CV runs.")
+    parser.add_argument("--folds", type=int, default=5, help="Folds per repeat.")
+    parser.add_argument("--random-state", type=int, default=42, help="Base random seed.")
+    parser.add_argument(
+        "--weighted-step",
+        type=float,
+        default=0.02,
+        help="Coordinate descent step for weighted blend.",
+    )
+    parser.add_argument(
+        "--weighted-rounds",
+        type=int,
+        default=25,
+        help="Max coordinate descent rounds for weighted blend.",
+    )
+    parser.add_argument(
+        "--baseline-metrics-path",
+        default="artifacts/reports/train_cv_multiseed_full_hiiter_metrics.json",
+        help="Optional baseline metrics JSON for delta reporting.",
+    )
+    parser.add_argument(
+        "--skip-baseline",
+        action="store_true",
+        help="Do not load baseline metrics.",
+    )
+    parser.add_argument(
+        "--out-json",
+        default="artifacts/reports/diagnostic_ensemble_robustness.json",
+        help="Output summary JSON path.",
+    )
+    return parser.parse_args()
+
+
+def _load_baseline_auc(metrics_path: str) -> tuple[float, str] | None:
+    payload = load_json_if_exists(metrics_path)
+    if payload is None:
+        return None
+    for key in ("ensemble_oof_auc", "oof_auc", "holdout_auc"):
+        value = payload.get(key)
+        if value is not None:
+            return float(value), key
+    return None
+
+
+def main() -> int:
+    args = parse_args()
+    specs = [parse_oof_input_spec(raw) for raw in args.oof]
+    merged, model_columns = load_merged_oof_matrix(specs, target_column=OOF_TARGET_COLUMN)
+
+    results = evaluate_ensemble_robustness(
+        merged,
+        model_columns,
+        target_column=OOF_TARGET_COLUMN,
+        repeats=args.repeats,
+        folds=args.folds,
+        random_state=args.random_state,
+        weighted_step=args.weighted_step,
+        weighted_rounds=args.weighted_rounds,
+    )
+
+    baseline_auc = None
+    baseline_key = None
+    if not args.skip_baseline:
+        baseline = _load_baseline_auc(args.baseline_metrics_path)
+        if baseline is not None:
+            baseline_auc, baseline_key = baseline
+
+    if baseline_auc is not None:
+        for method_name, method_payload in results["methods"].items():
+            method_payload["delta_full_vs_baseline_auc"] = float(
+                method_payload["full_auc"] - baseline_auc
+            )
+            method_payload["delta_cv_mean_vs_baseline_auc"] = float(
+                method_payload["cv_mean_auc"] - baseline_auc
+            )
+
+    summary = {
+        "generated_at_utc": utc_now_iso(),
+        "inputs": {
+            "oof": args.oof,
+            "repeats": int(args.repeats),
+            "folds": int(args.folds),
+            "random_state": int(args.random_state),
+            "weighted_step": float(args.weighted_step),
+            "weighted_rounds": int(args.weighted_rounds),
+            "baseline_metrics_path": None if args.skip_baseline else args.baseline_metrics_path,
+        },
+        "baseline_auc": baseline_auc,
+        "baseline_auc_metric": baseline_key,
+        **results,
+    }
+    write_json(args.out_json, summary)
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evaluate_validation_protocol.py
+++ b/scripts/evaluate_validation_protocol.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Evaluate a candidate OOF artifact under the validation reset protocol."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.config import ID_COLUMN
+from churn_baseline.diagnostics import DEFAULT_REFERENCE_OOF_SPECS
+from churn_baseline.diagnostics import OOF_TARGET_COLUMN
+from churn_baseline.validation_protocol import DOMINANT_MACROFAMILY, SUPPORTED_STAGES, SUPPORTED_TARGET_LEVELS, evaluate_validation_protocol
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate a candidate under the validation reset protocol")
+    parser.add_argument("--stage", choices=SUPPORTED_STAGES, default="smoke", help="Protocol stage to evaluate.")
+    parser.add_argument("--train-csv", default="data/raw/train.csv", help="Path to train.csv")
+    parser.add_argument("--test-csv", default="data/raw/test.csv", help="Path to test.csv")
+    parser.add_argument(
+        "--analysis-oof",
+        default="",
+        help=(
+            "Optional prebuilt analysis OOF CSV containing "
+            f"{ID_COLUMN},{OOF_TARGET_COLUMN},reference_pred,candidate_pred."
+        ),
+    )
+    parser.add_argument(
+        "--candidate-oof",
+        default="",
+        help="Optional candidate OOF spec: <path>[#<prediction_column>]. Used when --analysis-oof is not provided.",
+    )
+    parser.add_argument(
+        "--reference-oof",
+        default="",
+        help="Optional direct reference OOF spec: <path>[#<prediction_column>]. Overrides --oof + --reference-weights-json.",
+    )
+    parser.add_argument(
+        "--oof",
+        action="append",
+        default=[],
+        help="OOF input spec for weighted reference: <name>=<path>[#<prediction_column>]. Defaults to cb/xgb/lgb/r/rv.",
+    )
+    parser.add_argument(
+        "--reference-weights-json",
+        default="artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json",
+        help="Weights JSON for the default weighted reference.",
+    )
+    parser.add_argument(
+        "--target-family-level",
+        choices=SUPPORTED_TARGET_LEVELS,
+        default="segment5",
+        help="Family granularity for the declared target family.",
+    )
+    parser.add_argument("--target-family-value", default="", help="Target family key under the chosen family level.")
+    parser.add_argument("--sister-family-value", default="", help="Optional explicit sister family override.")
+    parser.add_argument(
+        "--dominant-family-value",
+        default=DOMINANT_MACROFAMILY,
+        help="Dominant macrofamily key (segment3) used for the guardrail check.",
+    )
+    parser.add_argument("--candidate-metrics-json", default="", help="Optional candidate metrics JSON, used for midcap/submission cv_std checks.")
+    parser.add_argument("--reference-metrics-json", default="", help="Optional reference metrics JSON, used for midcap/submission cv_std checks.")
+    parser.add_argument("--submission-csv", default="", help="Optional submission CSV path, required for submission-stage artifact trace checks.")
+    parser.add_argument(
+        "--out-json",
+        default="artifacts/reports/validation_protocol_verdict.json",
+        help="Output JSON verdict path.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    oof_specs = args.oof if args.oof else list(DEFAULT_REFERENCE_OOF_SPECS)
+    result = evaluate_validation_protocol(
+        train_csv_path=args.train_csv,
+        test_csv_path=args.test_csv,
+        stage=args.stage,
+        analysis_oof_path=args.analysis_oof.strip() or None,
+        candidate_oof_spec=args.candidate_oof.strip() or None,
+        reference_oof_spec=args.reference_oof.strip() or None,
+        oof_specs=oof_specs,
+        reference_weights_json=args.reference_weights_json,
+        target_family_level=args.target_family_level,
+        target_family_value=args.target_family_value.strip() or None,
+        sister_family_value=args.sister_family_value.strip() or None,
+        dominant_family_value=args.dominant_family_value.strip() or DOMINANT_MACROFAMILY,
+        candidate_metrics_json=args.candidate_metrics_json.strip() or None,
+        reference_metrics_json=args.reference_metrics_json.strip() or None,
+        submission_csv_path=args.submission_csv.strip() or None,
+        out_json_path=args.out_json,
+    )
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment_cleanroom_baselines.py
+++ b/scripts/experiment_cleanroom_baselines.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Run the minimal clean-room baseline smoke suite directly against v3."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.artifacts import write_json
+from churn_baseline.cleanroom_baseline import run_cleanroom_baseline_suite
+from churn_baseline.config import CatBoostHyperParams
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the minimal clean-room baseline smoke suite")
+    parser.add_argument("--train-csv", default="data/raw/train.csv")
+    parser.add_argument("--v3-oof", default="artifacts/reports/validation_protocol_v3_chain_oof.csv#candidate_pred")
+    parser.add_argument("--out-dir", default="artifacts/reports")
+    parser.add_argument("--model-dir", default="artifacts/models")
+    parser.add_argument("--folds", type=int, default=2)
+    parser.add_argument("--random-state", type=int, default=42)
+    parser.add_argument("--iterations", type=int, default=150)
+    parser.add_argument("--learning-rate", type=float, default=0.05)
+    parser.add_argument("--depth", type=int, default=6)
+    parser.add_argument("--l2-leaf-reg", type=float, default=5.0)
+    parser.add_argument("--early-stopping-rounds", type=int, default=60)
+    parser.add_argument("--verbose", type=int, default=0)
+    parser.add_argument("--out-summary-json", default="artifacts/reports/cleanroom_baseline_suite_summary.json")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    params = CatBoostHyperParams(
+        iterations=args.iterations,
+        learning_rate=args.learning_rate,
+        depth=args.depth,
+        l2_leaf_reg=args.l2_leaf_reg,
+        random_seed=args.random_state,
+    )
+    summary = run_cleanroom_baseline_suite(
+        train_csv_path=args.train_csv,
+        v3_oof_spec=args.v3_oof,
+        out_dir=args.out_dir,
+        model_dir=args.model_dir,
+        params=params,
+        folds=args.folds,
+        random_state=args.random_state,
+        early_stopping_rounds=args.early_stopping_rounds,
+        verbose=args.verbose,
+    )
+    write_json(Path(args.out_summary_json), summary)
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment_counterfactual_sensitivity.py
+++ b/scripts/experiment_counterfactual_sensitivity.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Run counterfactual teacher-sensitivity smoke directly against incumbent v3."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.counterfactual_sensitivity import (
+    DEFAULT_COMPONENT_WEIGHTS_JSON,
+    SUPPORTED_COUNTERFACTUALS,
+    SUPPORTED_SIGNALS,
+    run_counterfactual_sensitivity_smoke,
+)
+from churn_baseline.uncertainty_band import DEFAULT_V3_OOF_SPEC
+from churn_baseline.validation_protocol import DOMINANT_MACROFAMILY, SUPPORTED_STAGES, evaluate_validation_protocol
+
+
+def _parse_csv_tokens(raw: str, *, allowed: tuple[str, ...], argument_name: str) -> list[str]:
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    if not tokens:
+        raise ValueError(f"{argument_name} must contain at least one value")
+    invalid = [token for token in tokens if token not in allowed]
+    if invalid:
+        raise ValueError(
+            f"Unsupported values for {argument_name}: {invalid}. Supported: {list(allowed)}"
+        )
+    return tokens
+
+
+def _parse_alpha_grid(raw: str) -> list[float]:
+    values: list[float] = []
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        values.append(float(token))
+    if not values:
+        raise ValueError("alpha grid must contain at least one value")
+    return values
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run counterfactual teacher sensitivity directly against v3")
+    parser.add_argument("--stage", choices=SUPPORTED_STAGES, default="smoke")
+    parser.add_argument("--train-csv", default="data/raw/train.csv")
+    parser.add_argument("--test-csv", default="data/raw/test.csv")
+    parser.add_argument(
+        "--reference-v3-oof",
+        default=DEFAULT_V3_OOF_SPEC,
+        help="Direct OOF spec for incumbent v3 (<path>[#prediction_column]).",
+    )
+    parser.add_argument(
+        "--component-weights-json",
+        default=DEFAULT_COMPONENT_WEIGHTS_JSON,
+        help="Weights JSON used to select and normalize the teacher component subset.",
+    )
+    parser.add_argument(
+        "--target-family-level",
+        choices=["segment3", "segment5"],
+        default="segment3",
+    )
+    parser.add_argument(
+        "--target-family-value",
+        default=DOMINANT_MACROFAMILY,
+        help="Family key used to localize the counterfactual correction.",
+    )
+    parser.add_argument(
+        "--reference-band-half-width",
+        type=float,
+        default=None,
+        help="Optional extra filter: only rows with abs(v3 - 0.5) <= this width are corrected.",
+    )
+    parser.add_argument(
+        "--counterfactuals",
+        default="auto_payment,paperless_off,contract_upgrade,stability_bundle",
+        help="Comma-separated counterfactual scenarios to evaluate.",
+    )
+    parser.add_argument(
+        "--signal-names",
+        default="stable_bundle_drop,mean_positive_drop,max_positive_drop",
+        help="Comma-separated aggregate sensitivity signals to scan.",
+    )
+    parser.add_argument(
+        "--alpha-grid",
+        default="-0.20,-0.10,-0.05,0.00,0.05,0.10,0.15,0.20,0.30",
+        help="Comma-separated additive scales applied over the selected signal.",
+    )
+    parser.add_argument(
+        "--metrics-path",
+        default="artifacts/reports/counterfactual_teacher_smoke_metrics.json",
+    )
+    parser.add_argument(
+        "--oof-path",
+        default="artifacts/reports/counterfactual_teacher_smoke_analysis_oof.csv",
+    )
+    parser.add_argument(
+        "--gate-path",
+        default="artifacts/reports/validation_protocol_counterfactual_teacher_smoke_vs_v3.json",
+        help="Validation reset report written after the smoke run.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    counterfactuals = _parse_csv_tokens(
+        args.counterfactuals,
+        allowed=SUPPORTED_COUNTERFACTUALS,
+        argument_name="--counterfactuals",
+    )
+    signal_names = _parse_csv_tokens(
+        args.signal_names,
+        allowed=SUPPORTED_SIGNALS,
+        argument_name="--signal-names",
+    )
+    alpha_grid = _parse_alpha_grid(args.alpha_grid)
+
+    metrics = run_counterfactual_sensitivity_smoke(
+        train_csv_path=args.train_csv,
+        reference_v3_oof=args.reference_v3_oof,
+        component_weights_json=args.component_weights_json,
+        target_family_level=args.target_family_level,
+        target_family_value=args.target_family_value,
+        reference_band_half_width=args.reference_band_half_width,
+        alpha_grid=alpha_grid,
+        counterfactuals=counterfactuals,
+        signal_names=signal_names,
+        metrics_path=args.metrics_path,
+        oof_path=args.oof_path,
+    )
+
+    gate = evaluate_validation_protocol(
+        train_csv_path=args.train_csv,
+        test_csv_path=args.test_csv,
+        stage=args.stage,
+        analysis_oof_path=args.oof_path,
+        target_family_level=args.target_family_level,
+        target_family_value=args.target_family_value,
+        dominant_family_value=DOMINANT_MACROFAMILY,
+        candidate_metrics_json=args.metrics_path,
+        out_json_path=args.gate_path,
+    )
+
+    summary = {
+        "metrics_path": str(Path(args.metrics_path)),
+        "oof_path": str(Path(args.oof_path)),
+        "gate_path": str(Path(args.gate_path)),
+        "metrics": metrics,
+        "gate": gate,
+    }
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment_features.py
+++ b/scripts/experiment_features.py
@@ -37,6 +37,27 @@ def _load_baseline_auc(metrics_path: str | Path) -> tuple[float, str]:
     )
 
 
+def _normalize_monotonic_option(raw: str) -> str:
+    value = str(raw or "none").strip().lower()
+    if value in {"", "none", "off", "false", "0"}:
+        return "none"
+    if value != "minimal":
+        raise ValueError(f"Unsupported monotonic option '{raw}'. Supported: none, minimal.")
+    return value
+
+
+def _monotonic_constraints_from_preset(preset: str) -> dict[str, int] | None:
+    normalized = _normalize_monotonic_option(preset)
+    if normalized == "none":
+        return None
+    return {
+        "tenure": -1,
+        "payment_friction_index": 1,
+        "contract_commitment_ordinal": -1,
+        "is_manual_payment": 1,
+    }
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run CV experiment with feature blocks")
     parser.add_argument("--train-csv", default="data/raw/train.csv", help="Path to train.csv")
@@ -72,6 +93,16 @@ def parse_args() -> argparse.Namespace:
         default="target",
         help="CV stratification: target only, or target plus family fallback.",
     )
+    parser.add_argument(
+        "--monotonic-feature-set",
+        default="none",
+        help="Optional monotonic helper features to append (supported: none, minimal).",
+    )
+    parser.add_argument(
+        "--monotonic-preset",
+        default="none",
+        help="Optional CatBoost monotonic preset (supported: none, minimal).",
+    )
     parser.add_argument("--random-state", type=int, default=42, help="Random seed")
     parser.add_argument("--iterations", type=int, default=2200, help="Max boosting rounds")
     parser.add_argument("--learning-rate", type=float, default=0.05, help="Learning rate")
@@ -90,12 +121,19 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     feature_blocks = _parse_feature_blocks(args.feature_blocks)
+    monotonic_feature_set = _normalize_monotonic_option(args.monotonic_feature_set)
+    monotonic_preset = _normalize_monotonic_option(args.monotonic_preset)
+    if monotonic_feature_set == "none" and monotonic_preset != "none":
+        monotonic_feature_set = monotonic_preset
+    include_monotonic_features = monotonic_feature_set != "none"
+    monotonic_constraints = _monotonic_constraints_from_preset(monotonic_preset)
     params = CatBoostHyperParams(
         iterations=args.iterations,
         learning_rate=args.learning_rate,
         depth=args.depth,
         l2_leaf_reg=args.l2_leaf_reg,
         random_seed=args.random_state,
+        monotone_constraints=monotonic_constraints,
     )
 
     metrics = train_baseline_cv(
@@ -110,6 +148,7 @@ def main() -> int:
         verbose=args.verbose,
         feature_blocks=feature_blocks,
         stratify_mode=args.stratify_mode,
+        include_monotonic_features=include_monotonic_features,
     )
 
     baseline_auc, baseline_key = _load_baseline_auc(args.baseline_metrics_path)
@@ -118,6 +157,8 @@ def main() -> int:
     metrics["baseline_metrics_path"] = args.baseline_metrics_path
     metrics["delta_vs_baseline_auc"] = float(metrics["oof_auc"] - baseline_auc)
     metrics["experiment_name"] = f"blocks_{'_'.join(feature_blocks) if feature_blocks else 'none'}"
+    metrics["monotonic_feature_set"] = monotonic_feature_set
+    metrics["monotonic_preset"] = monotonic_preset
 
     with Path(args.metrics_path).open("w", encoding="utf-8") as fh:
         json.dump(metrics, fh, indent=2)

--- a/scripts/experiment_features.py
+++ b/scripts/experiment_features.py
@@ -64,7 +64,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="A",
-        help="Comma-separated feature blocks to enable (supported: A,B,C,F,G,H,R,S,V,O,P). Use 'none' for baseline.",
+        help="Comma-separated feature blocks to enable (supported: A,B,C,F,G,T,H,R,S,V,O,P). Use 'none' for baseline.",
     )
     parser.add_argument(
         "--model-path",

--- a/scripts/experiment_features.py
+++ b/scripts/experiment_features.py
@@ -43,7 +43,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="A",
-        help="Comma-separated feature blocks to enable (supported: A,B,C,O,P). Use 'none' for baseline.",
+        help="Comma-separated feature blocks to enable (supported: A,B,C,G,H,R,S,V,O,P). Use 'none' for baseline.",
     )
     parser.add_argument(
         "--model-path",
@@ -66,6 +66,12 @@ def parse_args() -> argparse.Namespace:
         help="JSON path with incumbent metric (ensemble_oof_auc/oof_auc/holdout_auc)",
     )
     parser.add_argument("--folds", type=int, default=5, help="Number of Stratified K folds")
+    parser.add_argument(
+        "--stratify-mode",
+        choices=("target", "composite"),
+        default="target",
+        help="CV stratification: target only, or target plus family fallback.",
+    )
     parser.add_argument("--random-state", type=int, default=42, help="Random seed")
     parser.add_argument("--iterations", type=int, default=2200, help="Max boosting rounds")
     parser.add_argument("--learning-rate", type=float, default=0.05, help="Learning rate")
@@ -103,6 +109,7 @@ def main() -> int:
         early_stopping_rounds=args.early_stopping_rounds,
         verbose=args.verbose,
         feature_blocks=feature_blocks,
+        stratify_mode=args.stratify_mode,
     )
 
     baseline_auc, baseline_key = _load_baseline_auc(args.baseline_metrics_path)

--- a/scripts/experiment_features.py
+++ b/scripts/experiment_features.py
@@ -64,7 +64,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="A",
-        help="Comma-separated feature blocks to enable (supported: A,B,C,G,H,R,S,V,O,P). Use 'none' for baseline.",
+        help="Comma-separated feature blocks to enable (supported: A,B,C,F,G,H,R,S,V,O,P). Use 'none' for baseline.",
     )
     parser.add_argument(
         "--model-path",

--- a/scripts/experiment_fm_probe.py
+++ b/scripts/experiment_fm_probe.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Run River FM/FFM smoke tests and compare them with the incumbent blend."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.diagnostics import load_merged_oof_matrix, parse_feature_blocks_arg, parse_oof_input_spec
+from churn_baseline.fm_probe import list_fm_probe_families, run_fm_probe_cv
+from churn_baseline.specialist import build_reference_prediction
+
+
+def _parse_alpha_grid(raw: str) -> list[float]:
+    values = []
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        value = float(token)
+        if value < 0.0 or value > 1.0:
+            raise ValueError(f"alpha values must be in [0, 1], got {value}")
+        values.append(value)
+    if not values:
+        raise ValueError("alpha grid must contain at least one value")
+    return values
+
+
+def _load_weights(path: str | Path) -> dict[str, float]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    weights = payload.get("weights")
+    if not isinstance(weights, dict) or not weights:
+        raise ValueError(f"Could not find weights in {path}")
+    return {str(name): float(value) for name, value in weights.items()}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run River FM/FFM probe smoke test")
+    parser.add_argument("--train-csv", default="data/raw/train.csv")
+    parser.add_argument(
+        "--feature-blocks",
+        default="H,R,S,V",
+        help="Comma-separated feature blocks for the FM probe.",
+    )
+    parser.add_argument("--folds", type=int, default=2)
+    parser.add_argument("--random-state", type=int, default=42)
+    parser.add_argument(
+        "--model-family",
+        default="ffm",
+        choices=list(list_fm_probe_families()),
+        help="Factorization model family to evaluate.",
+    )
+    parser.add_argument("--n-factors", type=int, default=10)
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--weight-lr", type=float, default=0.05)
+    parser.add_argument("--latent-lr", type=float, default=0.03)
+    parser.add_argument("--l2-weight", type=float, default=1e-6)
+    parser.add_argument("--l2-latent", type=float, default=1e-6)
+    parser.add_argument(
+        "--no-sample-normalization",
+        action="store_true",
+        help="Disable River sample normalization.",
+    )
+    parser.add_argument(
+        "--model-path",
+        default="artifacts/models/fm_probe_smoke.pkl",
+        help="Output pickle path for the full-train FM probe.",
+    )
+    parser.add_argument(
+        "--metrics-path",
+        default="artifacts/reports/fm_probe_smoke_metrics.json",
+        help="Output metrics JSON path.",
+    )
+    parser.add_argument(
+        "--oof-path",
+        default="artifacts/reports/fm_probe_smoke_oof.csv",
+        help="Output OOF CSV path.",
+    )
+    parser.add_argument(
+        "--reference-weights-json",
+        default="",
+        help="Optional weights JSON for incumbent reference blend.",
+    )
+    parser.add_argument(
+        "--oof",
+        action="append",
+        default=[],
+        help="OOF input spec: <name>=<path>[#<prediction_column>]. Required when using --reference-weights-json.",
+    )
+    parser.add_argument(
+        "--alpha-grid",
+        default="0.00,0.05,0.10,0.15,0.20,0.30,0.40,0.50",
+        help="Blend alphas for probe-vs-incumbent scan.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    reference_pred = None
+    if args.reference_weights_json:
+        if not args.oof:
+            raise ValueError("--oof is required when --reference-weights-json is provided.")
+        specs = [parse_oof_input_spec(raw) for raw in args.oof]
+        merged_oof, _ = load_merged_oof_matrix(specs)
+        reference_pred = build_reference_prediction(merged_oof, _load_weights(args.reference_weights_json))
+
+    metrics = run_fm_probe_cv(
+        train_csv_path=args.train_csv,
+        model_path=args.model_path,
+        metrics_path=args.metrics_path,
+        oof_path=args.oof_path,
+        feature_blocks=parse_feature_blocks_arg(args.feature_blocks),
+        folds=args.folds,
+        random_state=args.random_state,
+        model_family=args.model_family,
+        n_factors=args.n_factors,
+        epochs=args.epochs,
+        weight_lr=args.weight_lr,
+        latent_lr=args.latent_lr,
+        l2_weight=args.l2_weight,
+        l2_latent=args.l2_latent,
+        sample_normalization=not args.no_sample_normalization,
+        reference_pred=reference_pred,
+        alpha_grid=_parse_alpha_grid(args.alpha_grid),
+    )
+    print(json.dumps(metrics, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment_gnn_probe.py
+++ b/scripts/experiment_gnn_probe.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Run the minimal GraphSAGE probe experiment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.gnn_probe import GNNProbeParams, train_gnn_probe_cv
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run minimal transductive GraphSAGE smoke")
+    parser.add_argument("--train-csv", default="data/raw/train.csv")
+    parser.add_argument("--test-csv", default="data/raw/test.csv")
+    parser.add_argument("--folds", type=int, default=2)
+    parser.add_argument("--random-state", type=int, default=42)
+    parser.add_argument("--device", default="auto", help="auto, cuda or cpu")
+    parser.add_argument("--hidden-dim", type=int, default=32)
+    parser.add_argument("--dropout", type=float, default=0.15)
+    parser.add_argument("--learning-rate", type=float, default=1e-3)
+    parser.add_argument("--weight-decay", type=float, default=3e-4)
+    parser.add_argument("--epochs", type=int, default=8)
+    parser.add_argument("--patience", type=int, default=3)
+    parser.add_argument("--k-neighbors", type=int, default=8)
+    parser.add_argument("--graph-numeric-multiplier", type=float, default=3.0)
+    parser.add_argument("--metrics-path", default="artifacts/reports/gnn_probe_smoke_metrics.json")
+    parser.add_argument("--oof-path", default="artifacts/reports/gnn_probe_smoke_oof.csv")
+    parser.add_argument("--test-pred-path", default="")
+    parser.add_argument("--reference-v3-oof", default="")
+    parser.add_argument("--analysis-oof-path", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    params = GNNProbeParams(
+        hidden_dim=args.hidden_dim,
+        dropout=args.dropout,
+        learning_rate=args.learning_rate,
+        weight_decay=args.weight_decay,
+        epochs=args.epochs,
+        patience=args.patience,
+        k_neighbors=args.k_neighbors,
+        graph_numeric_multiplier=args.graph_numeric_multiplier,
+        random_state=args.random_state,
+    )
+    metrics = train_gnn_probe_cv(
+        train_csv_path=args.train_csv,
+        test_csv_path=args.test_csv,
+        metrics_path=args.metrics_path,
+        oof_path=args.oof_path,
+        test_pred_path=args.test_pred_path.strip() or None,
+        analysis_oof_path=args.analysis_oof_path.strip() or None,
+        reference_v3_oof_path=args.reference_v3_oof.strip() or None,
+        params=params,
+        folds=args.folds,
+        random_state=args.random_state,
+        device=args.device,
+    )
+    Path(args.metrics_path).write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+    print(json.dumps(metrics, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment_hard_example_stability.py
+++ b/scripts/experiment_hard_example_stability.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Run hard-example stability smoke directly against incumbent v3."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.config import CatBoostHyperParams, ID_COLUMN
+from churn_baseline.diagnostics import DEFAULT_REFERENCE_OOF_SPECS, load_merged_oof_matrix, load_reference_prediction_frame, parse_oof_input_spec
+from churn_baseline.feature_engineering import normalize_feature_blocks
+from churn_baseline.hard_example_stability import run_hard_example_stability_reranker_cv
+from churn_baseline.uncertainty_band import DEFAULT_V3_OOF_SPEC
+from churn_baseline.validation_protocol import DOMINANT_MACROFAMILY, SUPPORTED_STAGES, evaluate_validation_protocol
+
+
+def _parse_feature_blocks(raw: str) -> list[str]:
+    normalized_raw = raw.strip().lower()
+    if normalized_raw in {"none", "off", "baseline", ""}:
+        return []
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    return list(normalize_feature_blocks(tokens))
+
+
+def _parse_alpha_grid(raw: str) -> list[float]:
+    values: list[float] = []
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        value = float(token)
+        if value < 0.0 or value > 1.0:
+            raise ValueError(f"alpha values must be in [0, 1], got {value}")
+        values.append(value)
+    if not values:
+        raise ValueError("alpha grid must contain at least one value")
+    return values
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run hard-example stability reranker directly against v3")
+    parser.add_argument("--stage", choices=SUPPORTED_STAGES, default="smoke")
+    parser.add_argument("--train-csv", default="data/raw/train.csv")
+    parser.add_argument("--test-csv", default="data/raw/test.csv")
+    parser.add_argument(
+        "--reference-v3-oof",
+        default=DEFAULT_V3_OOF_SPEC,
+        help="Direct OOF spec for incumbent v3 (<path>[#prediction_column]).",
+    )
+    parser.add_argument(
+        "--oof",
+        action="append",
+        default=[],
+        help="Teacher component OOF input spec: <name>=<path>[#<prediction_column>]. Defaults to cb/xgb/lgb/r/rv.",
+    )
+    parser.add_argument(
+        "--stability-feature-blocks",
+        default="R,V",
+        help="Comma-separated feature blocks used to generate repeated stability OOFs.",
+    )
+    parser.add_argument(
+        "--reranker-feature-blocks",
+        default="H,R,S,V",
+        help="Comma-separated feature blocks used by the local residual reranker.",
+    )
+    parser.add_argument(
+        "--family-level",
+        choices=["segment3", "segment5"],
+        default="segment3",
+    )
+    parser.add_argument(
+        "--family-value",
+        default=DOMINANT_MACROFAMILY,
+        help="Family key used to constrain the hard-example mask.",
+    )
+    parser.add_argument(
+        "--hard-score-quantile",
+        type=float,
+        default=0.80,
+        help="Keep only rows above this within-family hard-example-score quantile.",
+    )
+    parser.add_argument(
+        "--reference-band-half-width",
+        type=float,
+        default=None,
+        help="Optional additional gate: abs(v3 - 0.5) <= width.",
+    )
+    parser.add_argument("--folds", type=int, default=2)
+    parser.add_argument("--stability-repeats", type=int, default=3)
+    parser.add_argument("--random-state", type=int, default=42)
+    parser.add_argument("--stability-iterations", type=int, default=120)
+    parser.add_argument("--stability-learning-rate", type=float, default=0.05)
+    parser.add_argument("--stability-depth", type=int, default=4)
+    parser.add_argument("--stability-l2-leaf-reg", type=float, default=8.0)
+    parser.add_argument("--reranker-iterations", type=int, default=180)
+    parser.add_argument("--reranker-learning-rate", type=float, default=0.04)
+    parser.add_argument("--reranker-depth", type=int, default=5)
+    parser.add_argument("--reranker-l2-leaf-reg", type=float, default=8.0)
+    parser.add_argument("--early-stopping-rounds", type=int, default=40)
+    parser.add_argument("--verbose", type=int, default=0)
+    parser.add_argument(
+        "--alpha-grid",
+        default="0.00,0.05,0.10,0.15,0.20,0.30,0.40,0.50",
+        help="Comma-separated alphas for local residual injection.",
+    )
+    parser.add_argument("--model-path", default="artifacts/models/hard_example_stability_smoke.cbm")
+    parser.add_argument("--metrics-path", default="artifacts/reports/hard_example_stability_smoke_metrics.json")
+    parser.add_argument("--oof-path", default="artifacts/reports/hard_example_stability_smoke_oof.csv")
+    parser.add_argument(
+        "--gate-path",
+        default="artifacts/reports/validation_protocol_hard_example_stability_smoke_vs_v3.json",
+        help="Validation reset report written after training.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    alpha_grid = _parse_alpha_grid(args.alpha_grid)
+    stability_blocks = _parse_feature_blocks(args.stability_feature_blocks)
+    reranker_blocks = _parse_feature_blocks(args.reranker_feature_blocks)
+
+    reference_frame, reference_source = load_reference_prediction_frame(
+        reference_oof_spec=args.reference_v3_oof,
+        id_column=ID_COLUMN,
+        target_column="target",
+    )
+
+    raw_specs = args.oof if args.oof else list(DEFAULT_REFERENCE_OOF_SPECS)
+    specs = [parse_oof_input_spec(raw) for raw in raw_specs]
+    merged_oof, _ = load_merged_oof_matrix(specs, id_column=ID_COLUMN, target_column="target")
+    component_columns = [column for column in merged_oof.columns if column.startswith("pred_")]
+    reference_component_frame = merged_oof[[ID_COLUMN, *component_columns]].copy()
+
+    stability_params = CatBoostHyperParams(
+        iterations=args.stability_iterations,
+        learning_rate=args.stability_learning_rate,
+        depth=args.stability_depth,
+        l2_leaf_reg=args.stability_l2_leaf_reg,
+        random_seed=args.random_state,
+    )
+    reranker_params = CatBoostHyperParams(
+        iterations=args.reranker_iterations,
+        learning_rate=args.reranker_learning_rate,
+        depth=args.reranker_depth,
+        l2_leaf_reg=args.reranker_l2_leaf_reg,
+        random_seed=args.random_state,
+    )
+
+    metrics = run_hard_example_stability_reranker_cv(
+        train_csv_path=args.train_csv,
+        reference_frame=reference_frame,
+        reference_component_frame=reference_component_frame,
+        stability_feature_blocks=stability_blocks,
+        stability_params=stability_params,
+        stability_repeats=args.stability_repeats,
+        reranker_feature_blocks=reranker_blocks,
+        reranker_params=reranker_params,
+        folds=args.folds,
+        random_state=args.random_state,
+        early_stopping_rounds=args.early_stopping_rounds,
+        verbose=args.verbose,
+        alpha_grid=alpha_grid,
+        family_level=args.family_level,
+        family_value=args.family_value,
+        hard_score_quantile=args.hard_score_quantile,
+        reference_band_half_width=args.reference_band_half_width,
+        model_path=args.model_path,
+        metrics_path=args.metrics_path,
+        oof_path=args.oof_path,
+    )
+
+    gate = evaluate_validation_protocol(
+        train_csv_path=args.train_csv,
+        test_csv_path=args.test_csv,
+        stage=args.stage,
+        analysis_oof_path=args.oof_path,
+        target_family_level=args.family_level,
+        target_family_value=args.family_value,
+        dominant_family_value=DOMINANT_MACROFAMILY,
+        candidate_metrics_json=args.metrics_path,
+        out_json_path=args.gate_path,
+    )
+
+    summary = {
+        "metrics_path": str(Path(args.metrics_path)),
+        "oof_path": str(Path(args.oof_path)),
+        "gate_path": str(Path(args.gate_path)),
+        "reference_source": reference_source,
+        "component_specs": raw_specs,
+        "metrics": metrics,
+        "gate": gate,
+    }
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment_hierarchical_priors.py
+++ b/scripts/experiment_hierarchical_priors.py
@@ -74,7 +74,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--base-feature-blocks",
         default="none",
-        help="Optional base stateless blocks before priors (A,B,C,H,R,S,V,O,P or none).",
+        help="Optional base stateless blocks before priors (A,B,C,F,H,R,S,V,O,P or none).",
     )
     parser.add_argument(
         "--feature-mode",

--- a/scripts/experiment_hierarchical_priors.py
+++ b/scripts/experiment_hierarchical_priors.py
@@ -74,7 +74,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--base-feature-blocks",
         default="none",
-        help="Optional base stateless blocks before priors (A,B,C,F,H,R,S,V,O,P or none).",
+        help="Optional base stateless blocks before priors (A,B,C,F,H,R,S,V,O,P or none). Stateful blocks G/T are not supported here.",
     )
     parser.add_argument(
         "--feature-mode",

--- a/scripts/experiment_hierarchical_priors.py
+++ b/scripts/experiment_hierarchical_priors.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Run CV experiments with fold-safe hierarchical target priors."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import StratifiedKFold
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.artifacts import write_json
+from churn_baseline.config import CatBoostHyperParams, ID_COLUMN
+from churn_baseline.data import infer_categorical_columns, load_csv, prepare_train_features
+from churn_baseline.evaluation import binary_auc
+from churn_baseline.feature_engineering import normalize_feature_blocks
+from churn_baseline.modeling import (
+    best_iteration_or_default,
+    fit_full_train,
+    fit_with_validation,
+    predict_proba,
+    save_model,
+)
+from churn_baseline.target_priors import (
+    HierarchicalTargetPriorEncoder,
+    build_default_prior_specs,
+    build_default_numeric_deviation_columns,
+    save_target_prior_encoder,
+)
+
+
+def _parse_feature_blocks(raw: str) -> list[str]:
+    normalized_raw = raw.strip().lower()
+    if normalized_raw in {"none", "off", "baseline", ""}:
+        return []
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    return list(normalize_feature_blocks(tokens))
+
+
+def _load_baseline_auc(metrics_path: str | Path) -> tuple[float, str]:
+    with Path(metrics_path).open("r", encoding="utf-8") as fh:
+        payload = json.load(fh)
+    for key in ("ensemble_oof_auc", "oof_auc", "holdout_auc"):
+        if key in payload:
+            return float(payload[key]), key
+    raise ValueError(f"Could not find baseline AUC in {metrics_path}")
+
+
+def _combine_features(
+    base_features: pd.DataFrame,
+    prior_features: pd.DataFrame,
+    *,
+    feature_mode: str,
+) -> pd.DataFrame:
+    if feature_mode == "priors_only":
+        return prior_features.copy()
+    if feature_mode == "raw_plus_priors":
+        return pd.concat(
+            [base_features.reset_index(drop=True), prior_features.reset_index(drop=True)],
+            axis=1,
+        )
+    raise ValueError(f"Unsupported feature mode: {feature_mode}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run CV experiment with hierarchical target priors")
+    parser.add_argument("--train-csv", default="data/raw/train.csv", help="Path to train.csv")
+    parser.add_argument(
+        "--base-feature-blocks",
+        default="none",
+        help="Optional base stateless blocks before priors (A,B,C,H,R,S,V,O,P or none).",
+    )
+    parser.add_argument(
+        "--feature-mode",
+        choices=("raw_plus_priors", "priors_only"),
+        default="raw_plus_priors",
+        help="Use raw features plus priors, or only prior features.",
+    )
+    parser.add_argument(
+        "--include-deviation-features",
+        action="store_true",
+        help="Add fold-safe cohort means and customer-vs-cohort deviations using the same hierarchy.",
+    )
+    parser.add_argument(
+        "--model-path",
+        default="artifacts/models/hierarchical_priors_cv.cbm",
+        help="Output model path",
+    )
+    parser.add_argument(
+        "--prior-encoder-path",
+        default="artifacts/models/hierarchical_priors_encoder.json",
+        help="Output path for fitted prior encoder metadata",
+    )
+    parser.add_argument(
+        "--metrics-path",
+        default="artifacts/reports/hierarchical_priors_cv_metrics.json",
+        help="Output metrics JSON path",
+    )
+    parser.add_argument(
+        "--oof-path",
+        default="artifacts/reports/hierarchical_priors_cv_oof.csv",
+        help="Output OOF predictions CSV path",
+    )
+    parser.add_argument(
+        "--baseline-metrics-path",
+        default="artifacts/reports/train_cv_multiseed_gate_s5_hiiter_metrics.json",
+        help="JSON path with incumbent metric (ensemble_oof_auc/oof_auc/holdout_auc).",
+    )
+    parser.add_argument("--folds", type=int, default=5, help="Number of Stratified K folds")
+    parser.add_argument("--random-state", type=int, default=42, help="Random seed")
+    parser.add_argument("--iterations", type=int, default=2200, help="Max boosting rounds")
+    parser.add_argument("--learning-rate", type=float, default=0.05, help="Learning rate")
+    parser.add_argument("--depth", type=int, default=6, help="Tree depth")
+    parser.add_argument("--l2-leaf-reg", type=float, default=5.0, help="L2 regularization")
+    parser.add_argument(
+        "--early-stopping-rounds",
+        type=int,
+        default=120,
+        help="Early stopping rounds per fold",
+    )
+    parser.add_argument("--verbose", type=int, default=200, help="CatBoost verbose frequency")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.folds < 2:
+        raise ValueError("folds must be >= 2")
+
+    feature_blocks = _parse_feature_blocks(args.base_feature_blocks)
+    params = CatBoostHyperParams(
+        iterations=args.iterations,
+        learning_rate=args.learning_rate,
+        depth=args.depth,
+        l2_leaf_reg=args.l2_leaf_reg,
+        random_seed=args.random_state,
+    )
+
+    train_df = load_csv(args.train_csv)
+    x_base, y = prepare_train_features(train_df, drop_id=True, feature_blocks=feature_blocks)
+
+    splitter = StratifiedKFold(n_splits=args.folds, shuffle=True, random_state=args.random_state)
+    oof_pred = pd.Series(index=x_base.index, dtype="float64", name="oof_pred")
+    fold_rows: list[dict[str, float | int | None]] = []
+    fold_iterations: list[int] = []
+    prior_feature_columns: list[str] | None = None
+
+    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x_base, y), start=1):
+        x_train_base = x_base.iloc[train_idx].reset_index(drop=True)
+        y_train = y.iloc[train_idx].reset_index(drop=True)
+        x_valid_base = x_base.iloc[valid_idx].reset_index(drop=True)
+        y_valid = y.iloc[valid_idx].reset_index(drop=True)
+
+        encoder = HierarchicalTargetPriorEncoder(
+            specs=build_default_prior_specs(),
+            include_numeric_deviation=args.include_deviation_features,
+        )
+        x_train_prior = encoder.fit_transform(x_train_base, y_train)
+        x_valid_prior = encoder.transform(x_valid_base)
+        prior_feature_columns = list(x_train_prior.columns)
+
+        x_train_model = _combine_features(
+            x_train_base,
+            x_train_prior,
+            feature_mode=args.feature_mode,
+        )
+        x_valid_model = _combine_features(
+            x_valid_base,
+            x_valid_prior,
+            feature_mode=args.feature_mode,
+        )
+        cat_columns = infer_categorical_columns(x_train_model)
+
+        fold_params = CatBoostHyperParams(
+            iterations=params.iterations,
+            learning_rate=params.learning_rate,
+            depth=params.depth,
+            l2_leaf_reg=params.l2_leaf_reg,
+            random_seed=args.random_state,
+            loss_function=params.loss_function,
+            eval_metric=params.eval_metric,
+        )
+        fold_model = fit_with_validation(
+            x_train=x_train_model,
+            y_train=y_train,
+            x_valid=x_valid_model,
+            y_valid=y_valid,
+            cat_columns=cat_columns,
+            params=fold_params,
+            early_stopping_rounds=args.early_stopping_rounds,
+            verbose=args.verbose,
+        )
+        fold_pred = predict_proba(fold_model, x_valid_model)
+        oof_pred.iloc[valid_idx] = fold_pred.values
+
+        fold_auc = binary_auc(y_valid, fold_pred)
+        fold_final_iterations = best_iteration_or_default(fold_model, params.iterations)
+        fold_iterations.append(fold_final_iterations)
+        fold_rows.append(
+            {
+                "fold": int(fold_number),
+                "valid_rows": int(len(valid_idx)),
+                "auc": float(fold_auc),
+                "best_iteration": int(fold_model.get_best_iteration()),
+                "final_iterations": int(fold_final_iterations),
+                "seed": int(args.random_state),
+            }
+        )
+
+    if oof_pred.isna().any():
+        raise RuntimeError("OOF predictions contain missing values.")
+
+    final_iterations = max(int(round(float(np.mean(fold_iterations)))), 1)
+    full_encoder = HierarchicalTargetPriorEncoder(
+        specs=build_default_prior_specs(),
+        include_numeric_deviation=args.include_deviation_features,
+    )
+    x_full_prior = full_encoder.fit_transform(x_base.reset_index(drop=True), y.reset_index(drop=True))
+    x_full_model = _combine_features(
+        x_base.reset_index(drop=True),
+        x_full_prior,
+        feature_mode=args.feature_mode,
+    )
+    full_cat_columns = infer_categorical_columns(x_full_model)
+    full_params = CatBoostHyperParams(
+        iterations=final_iterations,
+        learning_rate=params.learning_rate,
+        depth=params.depth,
+        l2_leaf_reg=params.l2_leaf_reg,
+        random_seed=args.random_state,
+        loss_function=params.loss_function,
+        eval_metric=params.eval_metric,
+    )
+    full_model = fit_full_train(
+        x_train=x_full_model,
+        y_train=y.reset_index(drop=True),
+        cat_columns=full_cat_columns,
+        params=full_params,
+        verbose=args.verbose,
+    )
+    save_model(full_model, args.model_path)
+    save_target_prior_encoder(full_encoder, args.prior_encoder_path)
+
+    oof_output = pd.DataFrame(
+        {
+            ID_COLUMN: train_df[ID_COLUMN].values,
+            "target": y.astype(int).values,
+            "oof_pred": oof_pred.values,
+        }
+    )
+    oof_out_path = Path(args.oof_path)
+    oof_out_path.parent.mkdir(parents=True, exist_ok=True)
+    oof_output.to_csv(oof_out_path, index=False)
+
+    baseline_auc, baseline_key = _load_baseline_auc(args.baseline_metrics_path)
+    cv_fold_aucs = [row["auc"] for row in fold_rows]
+    metrics = {
+        "train_rows": int(len(train_df)),
+        "base_feature_count": int(x_base.shape[1]),
+        "prior_feature_count": int(0 if prior_feature_columns is None else len(prior_feature_columns)),
+        "feature_count": int(x_full_model.shape[1]),
+        "base_feature_blocks": feature_blocks,
+        "feature_mode": args.feature_mode,
+        "include_deviation_features": bool(args.include_deviation_features),
+        "deviation_numeric_columns": (
+            list(build_default_numeric_deviation_columns()) if args.include_deviation_features else []
+        ),
+        "prior_specs": [spec.to_dict() for spec in build_default_prior_specs()],
+        "categorical_columns": full_cat_columns,
+        "cv_folds": int(args.folds),
+        "cv_fold_metrics": fold_rows,
+        "cv_mean_auc": float(np.mean(cv_fold_aucs)),
+        "cv_std_auc": float(np.std(cv_fold_aucs)),
+        "oof_auc": float(binary_auc(y, oof_pred)),
+        "fold_final_iterations": [int(v) for v in fold_iterations],
+        "final_iterations": int(final_iterations),
+        "params_cv": params.to_catboost_kwargs(),
+        "params_full_train": full_params.to_catboost_kwargs(),
+        "model_path": str(args.model_path),
+        "prior_encoder_path": str(args.prior_encoder_path),
+        "oof_path": str(oof_out_path),
+        "baseline_auc": float(baseline_auc),
+        "baseline_auc_metric": baseline_key,
+        "baseline_metrics_path": str(args.baseline_metrics_path),
+        "delta_vs_baseline_auc": float(binary_auc(y, oof_pred) - baseline_auc),
+        "target_column": "Churn",
+        "id_column": ID_COLUMN,
+    }
+    write_json(args.metrics_path, metrics)
+    print(json.dumps(metrics, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment_linear_probe.py
+++ b/scripts/experiment_linear_probe.py
@@ -11,8 +11,13 @@ from _bootstrap import add_src_to_path
 
 add_src_to_path()
 
+from churn_baseline.config import ID_COLUMN
 from churn_baseline.diagnostics import load_merged_oof_matrix, parse_feature_blocks_arg, parse_oof_input_spec
-from churn_baseline.linear_probe import list_linear_probe_families, run_linear_probe_cv
+from churn_baseline.linear_probe import (
+    list_linear_probe_families,
+    list_linear_probe_feature_modes,
+    run_linear_probe_cv,
+)
 from churn_baseline.specialist import build_reference_prediction
 
 
@@ -55,11 +60,37 @@ def parse_args() -> argparse.Namespace:
         choices=list(list_linear_probe_families()),
         help="Linear probe family to evaluate.",
     )
+    parser.add_argument(
+        "--feature-mode",
+        default="raw",
+        choices=list(list_linear_probe_feature_modes()),
+        help="Feature mode: raw engineered matrix or compact teacher meta features.",
+    )
     parser.add_argument("--c-value", type=float, default=0.5, help="Inverse regularization strength.")
     parser.add_argument("--max-iter", type=int, default=150, help="Maximum logistic iterations.")
     parser.add_argument("--tol", type=float, default=0.001, help="Optimization tolerance for logistic regression.")
     parser.add_argument("--spline-n-knots", type=int, default=6, help="Knots for spline_logistic numeric basis.")
     parser.add_argument("--spline-degree", type=int, default=3, help="Degree for spline_logistic numeric basis.")
+    parser.add_argument("--tree-iterations", type=int, default=300, help="Boosting iterations for catboost_meta.")
+    parser.add_argument("--tree-depth", type=int, default=4, help="Tree depth for catboost_meta.")
+    parser.add_argument(
+        "--tree-learning-rate",
+        type=float,
+        default=0.05,
+        help="Learning rate for catboost_meta.",
+    )
+    parser.add_argument(
+        "--tree-l2-leaf-reg",
+        type=float,
+        default=8.0,
+        help="L2 leaf regularization for catboost_meta.",
+    )
+    parser.add_argument(
+        "--tree-early-stopping-rounds",
+        type=int,
+        default=50,
+        help="Early stopping rounds for catboost_meta CV folds.",
+    )
     parser.add_argument("--verbose", type=int, default=0)
     parser.add_argument(
         "--model-path",
@@ -79,13 +110,21 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--reference-weights-json",
         default="",
-        help="Optional weights JSON for incumbent reference blend.",
+        help="Optional weights JSON for incumbent OOF reference blend. Required by --feature-mode teacher_meta.",
+    )
+    parser.add_argument(
+        "--reference-is-oof",
+        action="store_true",
+        help="Acknowledge that --reference-weights-json and --oof point to true OOF predictions aligned by id.",
     )
     parser.add_argument(
         "--oof",
         action="append",
         default=[],
-        help="OOF input spec: <name>=<path>[#<prediction_column>]. Required when using --reference-weights-json.",
+        help=(
+            "OOF input spec: <name>=<path>[#<prediction_column>]. "
+            "Required whenever --reference-weights-json is provided; teacher_meta also needs pred_* teacher components."
+        ),
     )
     parser.add_argument(
         "--alpha-grid",
@@ -98,12 +137,21 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     reference_pred = None
+    teacher_component_frame = None
     if args.reference_weights_json:
+        if not args.reference_is_oof:
+            raise ValueError("--reference-is-oof is required when --reference-weights-json is provided.")
         if not args.oof:
             raise ValueError("--oof is required when --reference-weights-json is provided.")
         specs = [parse_oof_input_spec(raw) for raw in args.oof]
         merged_oof, _ = load_merged_oof_matrix(specs)
         reference_pred = build_reference_prediction(merged_oof, _load_weights(args.reference_weights_json))
+        pred_columns = [column for column in merged_oof.columns if column.startswith("pred_")]
+        if args.feature_mode == "teacher_meta" and not pred_columns:
+            raise ValueError("--feature-mode teacher_meta requires OOF inputs that merge into pred_* columns.")
+        teacher_component_frame = merged_oof[[ID_COLUMN, *pred_columns]].copy()
+    elif args.feature_mode == "teacher_meta":
+        raise ValueError("--reference-weights-json and --oof are required when --feature-mode teacher_meta.")
 
     metrics = run_linear_probe_cv(
         train_csv_path=args.train_csv,
@@ -118,10 +166,18 @@ def main() -> int:
         tol=args.tol,
         verbose=args.verbose,
         model_family=args.model_family,
+        feature_mode=args.feature_mode,
         spline_n_knots=args.spline_n_knots,
         spline_degree=args.spline_degree,
         reference_pred=reference_pred,
+        teacher_component_frame=teacher_component_frame,
         alpha_grid=_parse_alpha_grid(args.alpha_grid),
+        reference_is_oof=bool(args.reference_weights_json and args.reference_is_oof),
+        tree_iterations=args.tree_iterations,
+        tree_depth=args.tree_depth,
+        tree_learning_rate=args.tree_learning_rate,
+        tree_l2_leaf_reg=args.tree_l2_leaf_reg,
+        tree_early_stopping_rounds=args.tree_early_stopping_rounds,
     )
     print(json.dumps(metrics, indent=2))
     return 0

--- a/scripts/experiment_linear_probe.py
+++ b/scripts/experiment_linear_probe.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Run a sparse linear probe and compare it with the incumbent blend."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.diagnostics import load_merged_oof_matrix, parse_feature_blocks_arg, parse_oof_input_spec
+from churn_baseline.linear_probe import list_linear_probe_families, run_linear_probe_cv
+from churn_baseline.specialist import build_reference_prediction
+
+
+def _parse_alpha_grid(raw: str) -> list[float]:
+    values = []
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        value = float(token)
+        if value < 0.0 or value > 1.0:
+            raise ValueError(f"alpha values must be in [0, 1], got {value}")
+        values.append(value)
+    if not values:
+        raise ValueError("alpha grid must contain at least one value")
+    return values
+
+
+def _load_weights(path: str | Path) -> dict[str, float]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    weights = payload.get("weights")
+    if not isinstance(weights, dict) or not weights:
+        raise ValueError(f"Could not find weights in {path}")
+    return {str(name): float(value) for name, value in weights.items()}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run sparse linear probe smoke test")
+    parser.add_argument("--train-csv", default="data/raw/train.csv")
+    parser.add_argument(
+        "--feature-blocks",
+        default="H,R,S,V",
+        help="Comma-separated feature blocks for the linear probe.",
+    )
+    parser.add_argument("--folds", type=int, default=2)
+    parser.add_argument("--random-state", type=int, default=42)
+    parser.add_argument(
+        "--model-family",
+        default="logistic",
+        choices=list(list_linear_probe_families()),
+        help="Linear probe family to evaluate.",
+    )
+    parser.add_argument("--c-value", type=float, default=0.5, help="Inverse regularization strength.")
+    parser.add_argument("--max-iter", type=int, default=150, help="Maximum logistic iterations.")
+    parser.add_argument("--tol", type=float, default=0.001, help="Optimization tolerance for logistic regression.")
+    parser.add_argument("--spline-n-knots", type=int, default=6, help="Knots for spline_logistic numeric basis.")
+    parser.add_argument("--spline-degree", type=int, default=3, help="Degree for spline_logistic numeric basis.")
+    parser.add_argument("--verbose", type=int, default=0)
+    parser.add_argument(
+        "--model-path",
+        default="artifacts/models/linear_probe_smoke.pkl",
+        help="Output pickle path for the full-train linear probe.",
+    )
+    parser.add_argument(
+        "--metrics-path",
+        default="artifacts/reports/linear_probe_smoke_metrics.json",
+        help="Output metrics JSON path.",
+    )
+    parser.add_argument(
+        "--oof-path",
+        default="artifacts/reports/linear_probe_smoke_oof.csv",
+        help="Output OOF CSV path.",
+    )
+    parser.add_argument(
+        "--reference-weights-json",
+        default="",
+        help="Optional weights JSON for incumbent reference blend.",
+    )
+    parser.add_argument(
+        "--oof",
+        action="append",
+        default=[],
+        help="OOF input spec: <name>=<path>[#<prediction_column>]. Required when using --reference-weights-json.",
+    )
+    parser.add_argument(
+        "--alpha-grid",
+        default="0.00,0.05,0.10,0.15,0.20,0.30,0.40,0.50",
+        help="Blend alphas for probe-vs-incumbent scan.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    reference_pred = None
+    if args.reference_weights_json:
+        if not args.oof:
+            raise ValueError("--oof is required when --reference-weights-json is provided.")
+        specs = [parse_oof_input_spec(raw) for raw in args.oof]
+        merged_oof, _ = load_merged_oof_matrix(specs)
+        reference_pred = build_reference_prediction(merged_oof, _load_weights(args.reference_weights_json))
+
+    metrics = run_linear_probe_cv(
+        train_csv_path=args.train_csv,
+        model_path=args.model_path,
+        metrics_path=args.metrics_path,
+        oof_path=args.oof_path,
+        feature_blocks=parse_feature_blocks_arg(args.feature_blocks),
+        folds=args.folds,
+        random_state=args.random_state,
+        c_value=args.c_value,
+        max_iter=args.max_iter,
+        tol=args.tol,
+        verbose=args.verbose,
+        model_family=args.model_family,
+        spline_n_knots=args.spline_n_knots,
+        spline_degree=args.spline_degree,
+        reference_pred=reference_pred,
+        alpha_grid=_parse_alpha_grid(args.alpha_grid),
+    )
+    print(json.dumps(metrics, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment_local_calibrator.py
+++ b/scripts/experiment_local_calibrator.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Run a local calibrator over the incumbent blend inside a hard cohort preset."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.diagnostics import load_merged_oof_matrix, parse_oof_input_spec
+from churn_baseline.specialist import (
+    build_reference_prediction,
+    list_calibration_methods,
+    list_specialist_presets,
+    run_local_calibrator_cv,
+)
+
+
+DEFAULT_OOF_SPECS = (
+    "cb=artifacts/reports/train_cv_multiseed_gate_s5_hiiter_oof.csv#oof_ensemble",
+    "xgb=artifacts/reports/train_xgboost_cv_multiseed_hiiter_oof.csv#oof_ensemble",
+    "lgb=artifacts/reports/train_lightgbm_cv_full_hiiter_oof.csv#oof_pred",
+    "r=artifacts/reports/fe_blockR_hiiter_oof.csv#oof_pred",
+    "rv=artifacts/reports/fe_blockRV_hiiter_oof.csv#oof_pred",
+)
+
+
+def _parse_alpha_grid(raw: str) -> list[float]:
+    values = []
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        value = float(token)
+        if value < 0.0 or value > 1.0:
+            raise ValueError(f"alpha values must be in [0, 1], got {value}")
+        values.append(value)
+    if not values:
+        raise ValueError("alpha grid must contain at least one value")
+    return values
+
+
+def _load_weights(path: str | Path) -> dict[str, float]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    weights = payload.get("weights")
+    if not isinstance(weights, dict) or not weights:
+        raise ValueError(f"Could not find weights in {path}")
+    return {str(name): float(value) for name, value in weights.items()}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run local calibrator experiment")
+    parser.add_argument("--train-csv", default="data/raw/train.csv", help="Path to train.csv")
+    parser.add_argument(
+        "--preset",
+        default="early_manual_internet",
+        choices=sorted(list_specialist_presets().keys()),
+        help="Hard cohort preset to calibrate.",
+    )
+    parser.add_argument(
+        "--method",
+        default="platt",
+        choices=list(list_calibration_methods()),
+        help="Local calibration method.",
+    )
+    parser.add_argument(
+        "--oof",
+        action="append",
+        default=[],
+        help="OOF input spec: <name>=<path>[#<prediction_column>]. Defaults to incumbent cb/xgb/lgb/r/rv.",
+    )
+    parser.add_argument(
+        "--reference-weights-json",
+        default="artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json",
+        help="Weights JSON for the incumbent blend.",
+    )
+    parser.add_argument(
+        "--alpha-grid",
+        default="0.25,0.50,0.75,1.00",
+        help="Comma-separated alpha values for local override scan.",
+    )
+    parser.add_argument(
+        "--model-path",
+        default="artifacts/models/local_calibrator_smoke.pkl",
+        help="Output calibrator bundle path.",
+    )
+    parser.add_argument(
+        "--metrics-path",
+        default="artifacts/reports/local_calibrator_smoke_metrics.json",
+        help="Output metrics JSON path.",
+    )
+    parser.add_argument(
+        "--oof-path",
+        default="artifacts/reports/local_calibrator_smoke_oof.csv",
+        help="Output OOF CSV path.",
+    )
+    parser.add_argument("--folds", type=int, default=5, help="Number of Stratified K folds.")
+    parser.add_argument("--random-state", type=int, default=42, help="Random seed.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    alpha_grid = _parse_alpha_grid(args.alpha_grid)
+
+    raw_specs = args.oof if args.oof else list(DEFAULT_OOF_SPECS)
+    specs = [parse_oof_input_spec(raw) for raw in raw_specs]
+    merged_oof, _ = load_merged_oof_matrix(specs)
+    reference_pred = build_reference_prediction(merged_oof, _load_weights(args.reference_weights_json))
+
+    metrics = run_local_calibrator_cv(
+        train_csv_path=args.train_csv,
+        preset=args.preset,
+        reference_pred=reference_pred,
+        method=args.method,
+        folds=args.folds,
+        random_state=args.random_state,
+        alpha_grid=alpha_grid,
+        model_path=args.model_path,
+        metrics_path=args.metrics_path,
+        oof_path=args.oof_path,
+    )
+    print(json.dumps(metrics, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment_mlp_probe.py
+++ b/scripts/experiment_mlp_probe.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Run a shallow tabular MLP probe and compare it with the incumbent blend."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.diagnostics import load_merged_oof_matrix, parse_feature_blocks_arg, parse_oof_input_spec
+from churn_baseline.mlp_probe import MLPProbeParams, run_mlp_probe_cv
+from churn_baseline.specialist import build_reference_prediction
+
+
+def _parse_alpha_grid(raw: str) -> list[float]:
+    values = []
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        value = float(token)
+        if value < 0.0 or value > 1.0:
+            raise ValueError(f"alpha values must be in [0, 1], got {value}")
+        values.append(value)
+    if not values:
+        raise ValueError("alpha grid must contain at least one value")
+    return values
+
+
+def _parse_hidden_dims(raw: str) -> tuple[int, ...]:
+    parts = [part.strip() for part in raw.split(",") if part.strip()]
+    if not parts:
+        raise ValueError("hidden dims must contain at least one integer")
+    return tuple(int(part) for part in parts)
+
+
+def _load_weights(path: str | Path) -> dict[str, float]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    weights = payload.get("weights")
+    if not isinstance(weights, dict) or not weights:
+        raise ValueError(f"Could not find weights in {path}")
+    return {str(name): float(value) for name, value in weights.items()}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run tabular embedding MLP probe smoke test")
+    parser.add_argument("--train-csv", default="data/raw/train.csv")
+    parser.add_argument(
+        "--feature-blocks",
+        default="H,R,S,V",
+        help="Comma-separated feature blocks for the MLP probe.",
+    )
+    parser.add_argument("--folds", type=int, default=2)
+    parser.add_argument("--random-state", type=int, default=42)
+    parser.add_argument("--hidden-dims", default="128,64")
+    parser.add_argument("--dropout", type=float, default=0.1)
+    parser.add_argument("--learning-rate", type=float, default=1e-3)
+    parser.add_argument("--weight-decay", type=float, default=1e-5)
+    parser.add_argument("--batch-size", type=int, default=4096)
+    parser.add_argument("--epochs", type=int, default=6)
+    parser.add_argument("--max-embedding-dim", type=int, default=32)
+    parser.add_argument("--device", default="auto", help="auto, cpu, cuda, cuda:0, etc.")
+    parser.add_argument(
+        "--model-path",
+        default="artifacts/models/mlp_probe_smoke.pt",
+        help="Output torch bundle path for the full-train MLP probe.",
+    )
+    parser.add_argument(
+        "--metrics-path",
+        default="artifacts/reports/mlp_probe_smoke_metrics.json",
+        help="Output metrics JSON path.",
+    )
+    parser.add_argument(
+        "--oof-path",
+        default="artifacts/reports/mlp_probe_smoke_oof.csv",
+        help="Output OOF CSV path.",
+    )
+    parser.add_argument(
+        "--reference-weights-json",
+        default="",
+        help="Optional weights JSON for incumbent reference blend.",
+    )
+    parser.add_argument(
+        "--oof",
+        action="append",
+        default=[],
+        help="OOF input spec: <name>=<path>[#<prediction_column>]. Required when using --reference-weights-json.",
+    )
+    parser.add_argument(
+        "--alpha-grid",
+        default="0.00,0.05,0.10,0.15,0.20,0.30,0.40,0.50",
+        help="Blend alphas for probe-vs-incumbent scan.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    reference_pred = None
+    if args.reference_weights_json:
+        if not args.oof:
+            raise ValueError("--oof is required when --reference-weights-json is provided.")
+        specs = [parse_oof_input_spec(raw) for raw in args.oof]
+        merged_oof, _ = load_merged_oof_matrix(specs)
+        reference_pred = build_reference_prediction(merged_oof, _load_weights(args.reference_weights_json))
+
+    params = MLPProbeParams(
+        hidden_dims=_parse_hidden_dims(args.hidden_dims),
+        dropout=float(args.dropout),
+        learning_rate=float(args.learning_rate),
+        weight_decay=float(args.weight_decay),
+        batch_size=int(args.batch_size),
+        epochs=int(args.epochs),
+        max_embedding_dim=int(args.max_embedding_dim),
+        device=str(args.device),
+    )
+    metrics = run_mlp_probe_cv(
+        train_csv_path=args.train_csv,
+        model_path=args.model_path,
+        metrics_path=args.metrics_path,
+        oof_path=args.oof_path,
+        feature_blocks=parse_feature_blocks_arg(args.feature_blocks),
+        folds=args.folds,
+        random_state=args.random_state,
+        params=params,
+        reference_pred=reference_pred,
+        alpha_grid=_parse_alpha_grid(args.alpha_grid),
+    )
+    print(json.dumps(metrics, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment_noise_mitigation.py
+++ b/scripts/experiment_noise_mitigation.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Run a minimal near-duplicate mitigation smoke and gate it directly against v3."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.artifacts import ensure_parent_dir, write_json
+from churn_baseline.config import CatBoostHyperParams, ID_COLUMN
+from churn_baseline.diagnostics import OOF_TARGET_COLUMN, load_reference_prediction_frame
+from churn_baseline.feature_engineering import normalize_feature_blocks
+from churn_baseline.incumbent_v3 import compute_repeated_cv_auc_stats
+from churn_baseline.noise_audit import DEFAULT_V3_OOF_SPEC, DOMINANT_MACROFAMILY
+from churn_baseline.noise_mitigation import run_noise_mitigation_smoke
+from churn_baseline.validation_protocol import evaluate_validation_protocol
+
+
+def _parse_feature_blocks(raw: str) -> list[str]:
+    normalized_raw = raw.strip().lower()
+    if normalized_raw in {"none", "off", "baseline", ""}:
+        return []
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    return list(normalize_feature_blocks(tokens))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a minimal near-duplicate mitigation smoke against v3")
+    parser.add_argument("--train-csv", default="data/raw/train.csv", help="Path to train.csv")
+    parser.add_argument("--test-csv", default="data/raw/test.csv", help="Path to test.csv")
+    parser.add_argument("--v3-oof", default=DEFAULT_V3_OOF_SPEC, help="Direct v3 OOF spec: <path>[#<prediction_column>].")
+    parser.add_argument("--feature-blocks", default="R,V", help="Feature blocks for the challenger.")
+    parser.add_argument("--mode", choices=("downweight", "drop"), default="downweight", help="Mitigation mode.")
+    parser.add_argument("--suspect-weight", type=float, default=0.25, help="Training weight for suspect rows in downweight mode.")
+    parser.add_argument("--folds", type=int, default=2, help="Number of smoke CV folds.")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed.")
+    parser.add_argument("--iterations", type=int, default=150, help="Max CatBoost iterations.")
+    parser.add_argument("--learning-rate", type=float, default=0.05, help="Learning rate.")
+    parser.add_argument("--depth", type=int, default=6, help="Tree depth.")
+    parser.add_argument("--l2-leaf-reg", type=float, default=5.0, help="L2 regularization.")
+    parser.add_argument("--early-stopping-rounds", type=int, default=60, help="Early stopping rounds.")
+    parser.add_argument("--verbose", type=int, default=0, help="CatBoost verbosity.")
+    parser.add_argument("--stratify-mode", choices=("target", "composite"), default="target", help="Smoke stratification mode.")
+    parser.add_argument("--dominant-only", action="store_true", default=True, help="Restrict mitigation to the dominant macrofamily.")
+    parser.add_argument("--no-dominant-only", dest="dominant_only", action="store_false", help="Disable dominant macrofamily restriction.")
+    parser.add_argument("--min-group-size", type=int, default=3, help="Minimum mixed coarse group size.")
+    parser.add_argument("--max-group-size", type=int, default=5, help="Maximum mixed coarse group size.")
+    parser.add_argument("--majority-share-min", type=float, default=0.75, help="Minimum majority share to flag minority rows.")
+    parser.add_argument("--label", default="noise_mitigation_smoke", help="Label prefix for report artifacts.")
+    parser.add_argument("--out-dir", default="artifacts/reports", help="Output directory for reports.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    feature_blocks = _parse_feature_blocks(args.feature_blocks)
+    params = CatBoostHyperParams(
+        iterations=args.iterations,
+        learning_rate=args.learning_rate,
+        depth=args.depth,
+        l2_leaf_reg=args.l2_leaf_reg,
+        random_seed=args.seed,
+    )
+
+    metrics = run_noise_mitigation_smoke(
+        train_csv_path=args.train_csv,
+        params=params,
+        feature_blocks=feature_blocks,
+        folds=args.folds,
+        seed=args.seed,
+        early_stopping_rounds=args.early_stopping_rounds,
+        verbose=args.verbose,
+        stratify_mode=args.stratify_mode,
+        mitigation_mode=args.mode,
+        suspect_weight=args.suspect_weight,
+        dominant_only=args.dominant_only,
+        dominant_family_value=DOMINANT_MACROFAMILY,
+        min_group_size=args.min_group_size,
+        max_group_size=args.max_group_size,
+        majority_share_min=args.majority_share_min,
+    )
+
+    out_dir = Path(args.out_dir)
+    metrics_path = ensure_parent_dir(out_dir / f"{args.label}_metrics.json")
+    oof_path = ensure_parent_dir(out_dir / f"{args.label}_oof.csv")
+    analysis_oof_path = ensure_parent_dir(out_dir / f"{args.label}_analysis_oof.csv")
+    candidate_metrics_path = ensure_parent_dir(out_dir / f"{args.label}_candidate_metrics.json")
+    reference_metrics_path = ensure_parent_dir(out_dir / f"{args.label}_reference_v3_metrics.json")
+    verdict_path = ensure_parent_dir(out_dir / f"validation_protocol_{args.label}_vs_v3_smoke.json")
+
+    oof_frame = pd.read_csv(args.train_csv, usecols=[ID_COLUMN, "Churn"])
+    oof_frame[OOF_TARGET_COLUMN] = (oof_frame["Churn"].astype(str).str.lower() == "yes").astype("int8")
+    oof_frame = oof_frame.drop(columns=["Churn"])
+    oof_frame["oof_pred"] = metrics["oof_pred"].astype(float).values
+    oof_frame.to_csv(oof_path, index=False)
+
+    reference_frame, _ = load_reference_prediction_frame(
+        reference_oof_spec=args.v3_oof,
+        id_column=ID_COLUMN,
+        target_column=OOF_TARGET_COLUMN,
+    )
+    analysis_frame = reference_frame[[ID_COLUMN, OOF_TARGET_COLUMN, "reference_pred"]].merge(
+        oof_frame[[ID_COLUMN, OOF_TARGET_COLUMN, "oof_pred"]].rename(columns={"oof_pred": "candidate_pred"}),
+        how="inner",
+        on=[ID_COLUMN, OOF_TARGET_COLUMN],
+        validate="one_to_one",
+    )
+    analysis_frame.to_csv(analysis_oof_path, index=False)
+
+    candidate_metrics = compute_repeated_cv_auc_stats(
+        analysis_frame[OOF_TARGET_COLUMN],
+        analysis_frame["candidate_pred"],
+    )
+    reference_metrics = compute_repeated_cv_auc_stats(
+        analysis_frame[OOF_TARGET_COLUMN],
+        analysis_frame["reference_pred"],
+    )
+    write_json(candidate_metrics_path, candidate_metrics)
+    write_json(reference_metrics_path, reference_metrics)
+
+    verdict = evaluate_validation_protocol(
+        train_csv_path=args.train_csv,
+        test_csv_path=args.test_csv,
+        stage="smoke",
+        analysis_oof_path=analysis_oof_path,
+        target_family_level="segment3",
+        target_family_value=DOMINANT_MACROFAMILY,
+        dominant_family_value=DOMINANT_MACROFAMILY,
+        candidate_metrics_json=candidate_metrics_path,
+        reference_metrics_json=reference_metrics_path,
+        out_json_path=verdict_path,
+    )
+
+    metrics["oof_path"] = str(oof_path)
+    metrics["analysis_oof_path"] = str(analysis_oof_path)
+    metrics["candidate_metrics_path"] = str(candidate_metrics_path)
+    metrics["reference_metrics_path"] = str(reference_metrics_path)
+    metrics["validation_verdict_path"] = str(verdict_path)
+    metrics["validation_verdict"] = verdict["verdict"]
+    metrics["validation_overall_metrics"] = verdict["overall_metrics"]
+    metrics.pop("oof_pred", None)
+    write_json(metrics_path, metrics)
+
+    print(json.dumps(metrics, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment_pseudo_label_family.py
+++ b/scripts/experiment_pseudo_label_family.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Run offline family-level pseudo-labeling experiments."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.config import CatBoostHyperParams, ID_COLUMN
+from churn_baseline.diagnostics import load_merged_oof_matrix, parse_oof_input_spec
+from churn_baseline.feature_engineering import normalize_feature_blocks
+from churn_baseline.pseudo_labeling import (
+    DEFAULT_FAMILY_KEY,
+    list_supported_label_modes,
+    run_family_pseudo_label_experiment,
+)
+from churn_baseline.specialist import build_reference_prediction
+
+
+DEFAULT_OOF_SPECS = (
+    "cb=artifacts/reports/train_cv_multiseed_gate_s5_hiiter_oof.csv#oof_ensemble",
+    "xgb=artifacts/reports/train_xgboost_cv_multiseed_hiiter_oof.csv#oof_ensemble",
+    "lgb=artifacts/reports/train_lightgbm_cv_full_hiiter_oof.csv#oof_pred",
+    "r=artifacts/reports/fe_blockR_hiiter_oof.csv#oof_pred",
+    "rv=artifacts/reports/fe_blockRV_hiiter_oof.csv#oof_pred",
+)
+
+
+def _parse_feature_blocks(raw: str) -> list[str]:
+    normalized_raw = raw.strip().lower()
+    if normalized_raw in {"none", "off", "baseline", ""}:
+        return []
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    return list(normalize_feature_blocks(tokens))
+
+
+def _parse_float_grid(raw: str, *, allow_zero: bool = False, upper_inclusive: float | None = None) -> list[float]:
+    values: list[float] = []
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        value = float(token)
+        if allow_zero:
+            if value < 0.0:
+                raise ValueError(f"Grid values must be >= 0, got {value}")
+        else:
+            if value <= 0.0:
+                raise ValueError(f"Grid values must be > 0, got {value}")
+        if upper_inclusive is not None and value > upper_inclusive:
+            raise ValueError(f"Grid values must be <= {upper_inclusive}, got {value}")
+        values.append(value)
+    if not values:
+        raise ValueError("Grid must contain at least one value")
+    return values
+
+
+def _load_weights(path: str | Path) -> dict[str, float]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    weights = payload.get("weights")
+    if not isinstance(weights, dict) or not weights:
+        raise ValueError(f"Could not find weights in {path}")
+    return {str(name): float(value) for name, value in weights.items()}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run offline pseudo-labeling by family")
+    parser.add_argument("--train-csv", default="data/raw/train.csv", help="Path to train.csv")
+    parser.add_argument(
+        "--family-key",
+        default=DEFAULT_FAMILY_KEY,
+        help="Exact segment5 family key: PaymentMethod__Contract__InternetService__PaperlessBilling__tenure_bin",
+    )
+    parser.add_argument(
+        "--feature-blocks",
+        default="H,R,S,V",
+        help="Comma-separated feature blocks for the student model.",
+    )
+    parser.add_argument(
+        "--oof",
+        action="append",
+        default=[],
+        help="OOF input spec: <name>=<path>[#<prediction_column>]. Defaults to incumbent cb/xgb/lgb/r/rv.",
+    )
+    parser.add_argument(
+        "--reference-weights-json",
+        default="artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json",
+        help="Weights JSON for the teacher blend used to pseudo-label train rows.",
+    )
+    parser.add_argument(
+        "--holdout-size",
+        type=float,
+        default=0.15,
+        help="Global offline holdout fraction.",
+    )
+    parser.add_argument(
+        "--valid-size",
+        type=float,
+        default=0.15,
+        help="Inner validation fraction used for early stopping.",
+    )
+    parser.add_argument(
+        "--pseudo-pool-fraction",
+        type=float,
+        default=0.50,
+        help="Fraction of target family rows hidden as pseudo pool inside each repeat.",
+    )
+    parser.add_argument("--repeats", type=int, default=3, help="Number of repeated splits.")
+    parser.add_argument("--random-state", type=int, default=42, help="Base random seed.")
+    parser.add_argument(
+        "--upper-thresholds",
+        default="0.995,0.99,0.98",
+        help="Comma-separated positive pseudo-label thresholds.",
+    )
+    parser.add_argument(
+        "--lower-thresholds",
+        default="0.005,0.01,0.02",
+        help="Comma-separated negative pseudo-label thresholds.",
+    )
+    parser.add_argument(
+        "--pseudo-weights",
+        default="0.05,0.10,0.20,0.35,0.50",
+        help="Comma-separated pseudo-row sample weights.",
+    )
+    parser.add_argument(
+        "--label-mode",
+        default="hard",
+        choices=list(list_supported_label_modes()),
+        help="Pseudo-label target mode: hard thresholded labels or soft duplicated labels.",
+    )
+    parser.add_argument(
+        "--scale-pseudo-weight-by-confidence",
+        action="store_true",
+        help="Scale each pseudo-row weight by teacher confidence |p-0.5|*2.",
+    )
+    parser.add_argument(
+        "--require-teacher-agreement",
+        action="store_true",
+        help="Require all teacher components to agree on the pseudo-label side of 0.5.",
+    )
+    parser.add_argument(
+        "--max-teacher-std",
+        type=float,
+        default=None,
+        help="Optional maximum std across teacher components for selected pseudo rows.",
+    )
+    parser.add_argument(
+        "--min-selected-rows",
+        type=int,
+        default=100,
+        help="Minimum selected pseudo rows per config/repeat before training.",
+    )
+    parser.add_argument("--iterations", type=int, default=150, help="Max boosting rounds.")
+    parser.add_argument("--learning-rate", type=float, default=0.05, help="Learning rate.")
+    parser.add_argument("--depth", type=int, default=6, help="Tree depth.")
+    parser.add_argument("--l2-leaf-reg", type=float, default=5.0, help="L2 regularization.")
+    parser.add_argument(
+        "--early-stopping-rounds",
+        type=int,
+        default=40,
+        help="Early stopping rounds.",
+    )
+    parser.add_argument("--verbose", type=int, default=0, help="CatBoost verbose frequency.")
+    parser.add_argument(
+        "--metrics-path",
+        default="artifacts/reports/pseudo_label_family_smoke_metrics.json",
+        help="Output metrics JSON path.",
+    )
+    parser.add_argument(
+        "--results-csv-path",
+        default="artifacts/reports/pseudo_label_family_smoke_results.csv",
+        help="Output detailed results CSV path.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    feature_blocks = _parse_feature_blocks(args.feature_blocks)
+    upper_thresholds = _parse_float_grid(args.upper_thresholds, upper_inclusive=1.0)
+    lower_thresholds = _parse_float_grid(args.lower_thresholds, allow_zero=True, upper_inclusive=0.5)
+    pseudo_weights = _parse_float_grid(args.pseudo_weights, upper_inclusive=1.0)
+    params = CatBoostHyperParams(
+        iterations=args.iterations,
+        learning_rate=args.learning_rate,
+        depth=args.depth,
+        l2_leaf_reg=args.l2_leaf_reg,
+        random_seed=args.random_state,
+    )
+
+    raw_specs = args.oof if args.oof else list(DEFAULT_OOF_SPECS)
+    specs = [parse_oof_input_spec(raw) for raw in raw_specs]
+    merged_oof, _ = load_merged_oof_matrix(specs)
+    reference_pred = build_reference_prediction(merged_oof, _load_weights(args.reference_weights_json))
+    component_columns = [column for column in merged_oof.columns if column.startswith("pred_")]
+    reference_component_frame = None
+    if component_columns:
+        reference_component_frame = merged_oof[[ID_COLUMN, *component_columns]].copy()
+
+    metrics = run_family_pseudo_label_experiment(
+        train_csv_path=args.train_csv,
+        family_key=args.family_key,
+        reference_pred=reference_pred,
+        reference_component_frame=reference_component_frame,
+        feature_blocks=feature_blocks,
+        params=params,
+        holdout_size=args.holdout_size,
+        valid_size=args.valid_size,
+        pseudo_pool_fraction=args.pseudo_pool_fraction,
+        repeats=args.repeats,
+        random_state=args.random_state,
+        early_stopping_rounds=args.early_stopping_rounds,
+        verbose=args.verbose,
+        upper_thresholds=upper_thresholds,
+        lower_thresholds=lower_thresholds,
+        pseudo_weights=pseudo_weights,
+        label_mode=args.label_mode,
+        scale_weight_by_confidence=args.scale_pseudo_weight_by_confidence,
+        require_teacher_agreement=args.require_teacher_agreement,
+        max_teacher_std=args.max_teacher_std,
+        min_selected_rows=args.min_selected_rows,
+        metrics_path=args.metrics_path,
+        results_csv_path=args.results_csv_path,
+    )
+    print(json.dumps(metrics, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment_rank_reranker.py
+++ b/scripts/experiment_rank_reranker.py
@@ -15,7 +15,7 @@ from churn_baseline.config import CatBoostHyperParams, ID_COLUMN
 from churn_baseline.diagnostics import load_merged_oof_matrix, parse_feature_blocks_arg, parse_oof_input_spec
 from churn_baseline.pipeline import SUPPORTED_STRATIFY_MODES
 from churn_baseline.rank_reranker import list_rank_reranker_losses, run_rank_reranker_cv
-from churn_baseline.specialist import build_reference_prediction
+from churn_baseline.specialist import build_reference_prediction, list_specialist_presets
 
 
 DEFAULT_OOF_SPECS = (
@@ -53,6 +53,12 @@ def _load_weights(path: str | Path) -> dict[str, float]:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run ranking-aware teacher reranker experiment")
     parser.add_argument("--train-csv", default="data/raw/train.csv", help="Path to train.csv")
+    parser.add_argument(
+        "--preset",
+        default="global",
+        choices=["global", *sorted(list_specialist_presets().keys())],
+        help="Optional local rerank mask. Use 'global' to rerank every row.",
+    )
     parser.add_argument(
         "--feature-blocks",
         default="H,R,S,V",
@@ -154,6 +160,7 @@ def main() -> int:
         feature_blocks=feature_blocks,
         reference_pred=reference_pred,
         reference_component_frame=reference_component_frame,
+        preset=None if args.preset == "global" else args.preset,
         folds=args.folds,
         random_state=args.random_state,
         early_stopping_rounds=args.early_stopping_rounds,

--- a/scripts/experiment_rank_reranker.py
+++ b/scripts/experiment_rank_reranker.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Train and evaluate a ranking-aware teacher reranker."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.config import CatBoostHyperParams, ID_COLUMN
+from churn_baseline.diagnostics import load_merged_oof_matrix, parse_feature_blocks_arg, parse_oof_input_spec
+from churn_baseline.pipeline import SUPPORTED_STRATIFY_MODES
+from churn_baseline.rank_reranker import list_rank_reranker_losses, run_rank_reranker_cv
+from churn_baseline.specialist import build_reference_prediction
+
+
+DEFAULT_OOF_SPECS = (
+    "cb=artifacts/reports/train_cv_multiseed_gate_s5_hiiter_oof.csv#oof_ensemble",
+    "xgb=artifacts/reports/train_xgboost_cv_multiseed_hiiter_oof.csv#oof_ensemble",
+    "lgb=artifacts/reports/train_lightgbm_cv_full_hiiter_oof.csv#oof_pred",
+    "r=artifacts/reports/fe_blockR_hiiter_oof.csv#oof_pred",
+    "rv=artifacts/reports/fe_blockRV_hiiter_oof.csv#oof_pred",
+)
+
+
+def _parse_alpha_grid(raw: str) -> list[float]:
+    values = []
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        value = float(token)
+        if value < 0.0 or value > 1.0:
+            raise ValueError(f"alpha values must be in [0, 1], got {value}")
+        values.append(value)
+    if not values:
+        raise ValueError("alpha grid must contain at least one value")
+    return values
+
+
+def _load_weights(path: str | Path) -> dict[str, float]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    weights = payload.get("weights")
+    if not isinstance(weights, dict) or not weights:
+        raise ValueError(f"Could not find weights in {path}")
+    return {str(name): float(value) for name, value in weights.items()}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run ranking-aware teacher reranker experiment")
+    parser.add_argument("--train-csv", default="data/raw/train.csv", help="Path to train.csv")
+    parser.add_argument(
+        "--feature-blocks",
+        default="H,R,S,V",
+        help="Comma-separated feature blocks for the ranker (supported: A,B,C,G,H,R,S,V,O,P).",
+    )
+    parser.add_argument(
+        "--oof",
+        action="append",
+        default=[],
+        help="OOF input spec: <name>=<path>[#<prediction_column>]. Defaults to incumbent cb/xgb/lgb/r/rv.",
+    )
+    parser.add_argument(
+        "--reference-weights-json",
+        default="artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json",
+        help="Weights JSON for the incumbent blend.",
+    )
+    parser.add_argument(
+        "--loss-function",
+        default="PairLogitPairwise",
+        choices=list(list_rank_reranker_losses()),
+        help="CatBoostRanker loss function.",
+    )
+    parser.add_argument(
+        "--alpha-grid",
+        default="0.00,0.05,0.10,0.15,0.20,0.30,0.40,0.50,0.60,0.70,0.80,0.90,1.00",
+        help="Comma-separated alpha values for rank-blend scan.",
+    )
+    parser.add_argument(
+        "--stratify-mode",
+        default="target",
+        choices=list(SUPPORTED_STRATIFY_MODES),
+        help="Outer CV stratification mode.",
+    )
+    parser.add_argument("--min-query-rows", type=int, default=50, help="Minimum rows per query level.")
+    parser.add_argument("--min-query-positive-rows", type=int, default=3, help="Minimum positive rows per query.")
+    parser.add_argument("--min-query-negative-rows", type=int, default=10, help="Minimum negative rows per query.")
+    parser.add_argument(
+        "--max-pairs-per-group",
+        type=int,
+        default=1000,
+        help="Cap sampled positive-vs-negative pairs per query group.",
+    )
+    parser.add_argument(
+        "--model-path",
+        default="artifacts/models/rank_reranker_smoke.cbm",
+        help="Output ranker model path.",
+    )
+    parser.add_argument(
+        "--metrics-path",
+        default="artifacts/reports/rank_reranker_smoke_metrics.json",
+        help="Output metrics JSON path.",
+    )
+    parser.add_argument(
+        "--oof-path",
+        default="artifacts/reports/rank_reranker_smoke_oof.csv",
+        help="Output OOF CSV path.",
+    )
+    parser.add_argument("--folds", type=int, default=2, help="Number of CV folds.")
+    parser.add_argument("--random-state", type=int, default=42, help="Random seed.")
+    parser.add_argument("--iterations", type=int, default=150, help="Max boosting rounds.")
+    parser.add_argument("--learning-rate", type=float, default=0.05, help="Learning rate.")
+    parser.add_argument("--depth", type=int, default=6, help="Tree depth.")
+    parser.add_argument("--l2-leaf-reg", type=float, default=5.0, help="L2 regularization.")
+    parser.add_argument(
+        "--early-stopping-rounds",
+        type=int,
+        default=40,
+        help="Early stopping rounds for the ranker.",
+    )
+    parser.add_argument("--verbose", type=int, default=0, help="CatBoost verbose frequency.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    feature_blocks = parse_feature_blocks_arg(args.feature_blocks)
+    alpha_grid = _parse_alpha_grid(args.alpha_grid)
+    params = CatBoostHyperParams(
+        iterations=args.iterations,
+        learning_rate=args.learning_rate,
+        depth=args.depth,
+        l2_leaf_reg=args.l2_leaf_reg,
+        random_seed=args.random_state,
+    )
+
+    raw_specs = args.oof if args.oof else list(DEFAULT_OOF_SPECS)
+    specs = [parse_oof_input_spec(raw) for raw in raw_specs]
+    merged_oof, _ = load_merged_oof_matrix(specs)
+    reference_pred = build_reference_prediction(merged_oof, _load_weights(args.reference_weights_json))
+    component_columns = [column for column in merged_oof.columns if column.startswith("pred_")]
+    reference_component_frame = merged_oof[[ID_COLUMN, *component_columns]].copy()
+
+    metrics = run_rank_reranker_cv(
+        train_csv_path=args.train_csv,
+        model_path=args.model_path,
+        metrics_path=args.metrics_path,
+        oof_path=args.oof_path,
+        params=params,
+        feature_blocks=feature_blocks,
+        reference_pred=reference_pred,
+        reference_component_frame=reference_component_frame,
+        folds=args.folds,
+        random_state=args.random_state,
+        early_stopping_rounds=args.early_stopping_rounds,
+        verbose=args.verbose,
+        loss_function=args.loss_function,
+        alpha_grid=alpha_grid,
+        stratify_mode=args.stratify_mode,
+        min_query_rows=args.min_query_rows,
+        min_query_positive_rows=args.min_query_positive_rows,
+        min_query_negative_rows=args.min_query_negative_rows,
+        max_pairs_per_group=args.max_pairs_per_group,
+    )
+    print(json.dumps(metrics, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment_rank_reranker.py
+++ b/scripts/experiment_rank_reranker.py
@@ -62,7 +62,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="H,R,S,V",
-        help="Comma-separated feature blocks for the ranker (supported: A,B,C,G,H,R,S,V,O,P).",
+        help="Comma-separated feature blocks for the ranker (supported: A,B,C,F,G,H,R,S,V,O,P).",
     )
     parser.add_argument(
         "--oof",

--- a/scripts/experiment_rank_reranker.py
+++ b/scripts/experiment_rank_reranker.py
@@ -62,7 +62,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="H,R,S,V",
-        help="Comma-separated feature blocks for the ranker (supported: A,B,C,F,G,H,R,S,V,O,P).",
+        help="Comma-separated feature blocks for the ranker (supported: A,B,C,F,G,T,H,R,S,V,O,P).",
     )
     parser.add_argument(
         "--oof",

--- a/scripts/experiment_specialist_model.py
+++ b/scripts/experiment_specialist_model.py
@@ -19,6 +19,7 @@ from churn_baseline.specialist import (
     list_specialist_approaches,
     list_specialist_presets,
     run_family_feature_challenger_cv,
+    run_gated_challenger_cv,
     run_residual_reranker_cv,
     run_specialist_override_cv,
 )
@@ -77,7 +78,7 @@ def parse_args() -> argparse.Namespace:
         "--approach",
         default="classifier",
         choices=list(list_specialist_approaches()),
-        help="Specialist approach: direct local classifier, residual reranker, or family-prediction-as-feature challenger.",
+        help="Specialist approach: direct local classifier, residual reranker, family-prediction-as-feature challenger, or global gated challenger.",
     )
     parser.add_argument(
         "--feature-blocks",
@@ -104,6 +105,12 @@ def parse_args() -> argparse.Namespace:
         "--alpha-grid",
         default="0.00,0.05,0.10,0.15,0.20,0.30,0.40,0.50,0.60,0.70,0.80,0.90,1.00",
         help="Comma-separated alpha values for local override scan.",
+    )
+    parser.add_argument(
+        "--family-weight",
+        type=float,
+        default=2.0,
+        help="Training/eval weight applied to rows inside the target family for approach=gated.",
     )
     parser.add_argument(
         "--model-path",
@@ -187,6 +194,24 @@ def main() -> int:
             early_stopping_rounds=args.early_stopping_rounds,
             verbose=args.verbose,
             alpha_grid=alpha_grid,
+            model_path=args.model_path,
+            metrics_path=args.metrics_path,
+            oof_path=args.oof_path,
+        )
+    elif args.approach == "gated":
+        metrics = run_gated_challenger_cv(
+            train_csv_path=args.train_csv,
+            preset=args.preset,
+            reference_pred=reference_pred,
+            reference_component_frame=reference_component_frame,
+            params=params,
+            feature_blocks=feature_blocks,
+            folds=args.folds,
+            random_state=args.random_state,
+            early_stopping_rounds=args.early_stopping_rounds,
+            verbose=args.verbose,
+            alpha_grid=alpha_grid,
+            family_weight=args.family_weight,
             model_path=args.model_path,
             metrics_path=args.metrics_path,
             oof_path=args.oof_path,

--- a/scripts/experiment_specialist_model.py
+++ b/scripts/experiment_specialist_model.py
@@ -81,7 +81,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="H,R,S,V",
-        help="Comma-separated feature blocks for the specialist model (supported: A,B,C,F,H,R,S,V,O,P).",
+        help="Comma-separated feature blocks for the specialist model (supported: A,B,C,F,G,T,H,R,S,V,O,P).",
     )
     parser.add_argument(
         "--oof",

--- a/scripts/experiment_specialist_model.py
+++ b/scripts/experiment_specialist_model.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Train and evaluate a local specialist override over the incumbent blend."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.config import CatBoostHyperParams, ID_COLUMN
+from churn_baseline.diagnostics import load_merged_oof_matrix, parse_oof_input_spec
+from churn_baseline.feature_engineering import normalize_feature_blocks
+from churn_baseline.specialist import (
+    build_reference_prediction,
+    list_specialist_approaches,
+    list_specialist_presets,
+    run_residual_reranker_cv,
+    run_specialist_override_cv,
+)
+
+
+DEFAULT_OOF_SPECS = (
+    "cb=artifacts/reports/train_cv_multiseed_gate_s5_hiiter_oof.csv#oof_ensemble",
+    "xgb=artifacts/reports/train_xgboost_cv_multiseed_hiiter_oof.csv#oof_ensemble",
+    "lgb=artifacts/reports/train_lightgbm_cv_full_hiiter_oof.csv#oof_pred",
+    "r=artifacts/reports/fe_blockR_hiiter_oof.csv#oof_pred",
+    "rv=artifacts/reports/fe_blockRV_hiiter_oof.csv#oof_pred",
+)
+
+
+def _parse_feature_blocks(raw: str) -> list[str]:
+    normalized_raw = raw.strip().lower()
+    if normalized_raw in {"none", "off", "baseline", ""}:
+        return []
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    return list(normalize_feature_blocks(tokens))
+
+
+def _parse_alpha_grid(raw: str) -> list[float]:
+    values = []
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        value = float(token)
+        if value < 0.0 or value > 1.0:
+            raise ValueError(f"alpha values must be in [0, 1], got {value}")
+        values.append(value)
+    if not values:
+        raise ValueError("alpha grid must contain at least one value")
+    return values
+
+
+def _load_weights(path: str | Path) -> dict[str, float]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    weights = payload.get("weights")
+    if not isinstance(weights, dict) or not weights:
+        raise ValueError(f"Could not find weights in {path}")
+    return {str(name): float(value) for name, value in weights.items()}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run specialist override experiment")
+    parser.add_argument("--train-csv", default="data/raw/train.csv", help="Path to train.csv")
+    parser.add_argument(
+        "--preset",
+        default="early_manual_internet",
+        choices=sorted(list_specialist_presets().keys()),
+        help="Specialist cohort preset to target.",
+    )
+    parser.add_argument(
+        "--approach",
+        default="classifier",
+        choices=list(list_specialist_approaches()),
+        help="Specialist approach: direct local classifier or residual reranker.",
+    )
+    parser.add_argument(
+        "--feature-blocks",
+        default="H,R,S,V",
+        help="Comma-separated feature blocks for the specialist model (supported: A,B,C,H,R,S,V,O,P).",
+    )
+    parser.add_argument(
+        "--oof",
+        action="append",
+        default=[],
+        help="OOF input spec: <name>=<path>[#<prediction_column>]. Defaults to incumbent cb/xgb/lgb/r/rv.",
+    )
+    parser.add_argument(
+        "--reference-weights-json",
+        default="artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json",
+        help="Weights JSON for the incumbent blend.",
+    )
+    parser.add_argument(
+        "--include-teacher-disagreement-features",
+        action="store_true",
+        help="Append teacher component predictions and disagreement stats as reranker features.",
+    )
+    parser.add_argument(
+        "--alpha-grid",
+        default="0.00,0.05,0.10,0.15,0.20,0.30,0.40,0.50,0.60,0.70,0.80,0.90,1.00",
+        help="Comma-separated alpha values for local override scan.",
+    )
+    parser.add_argument(
+        "--model-path",
+        default="artifacts/models/specialist_override_smoke.cbm",
+        help="Output specialist model path.",
+    )
+    parser.add_argument(
+        "--metrics-path",
+        default="artifacts/reports/specialist_override_smoke_metrics.json",
+        help="Output metrics JSON path.",
+    )
+    parser.add_argument(
+        "--oof-path",
+        default="artifacts/reports/specialist_override_smoke_oof.csv",
+        help="Output OOF CSV path.",
+    )
+    parser.add_argument("--folds", type=int, default=2, help="Number of Stratified K folds.")
+    parser.add_argument("--random-state", type=int, default=42, help="Random seed.")
+    parser.add_argument("--iterations", type=int, default=150, help="Max boosting rounds.")
+    parser.add_argument("--learning-rate", type=float, default=0.05, help="Learning rate.")
+    parser.add_argument("--depth", type=int, default=6, help="Tree depth.")
+    parser.add_argument("--l2-leaf-reg", type=float, default=5.0, help="L2 regularization.")
+    parser.add_argument(
+        "--early-stopping-rounds",
+        type=int,
+        default=40,
+        help="Early stopping rounds on the specialist validation subset.",
+    )
+    parser.add_argument("--verbose", type=int, default=0, help="CatBoost verbose frequency.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    feature_blocks = _parse_feature_blocks(args.feature_blocks)
+    alpha_grid = _parse_alpha_grid(args.alpha_grid)
+    params = CatBoostHyperParams(
+        iterations=args.iterations,
+        learning_rate=args.learning_rate,
+        depth=args.depth,
+        l2_leaf_reg=args.l2_leaf_reg,
+        random_seed=args.random_state,
+    )
+
+    raw_specs = args.oof if args.oof else list(DEFAULT_OOF_SPECS)
+    specs = [parse_oof_input_spec(raw) for raw in raw_specs]
+    merged_oof, _ = load_merged_oof_matrix(specs)
+    reference_pred = build_reference_prediction(merged_oof, _load_weights(args.reference_weights_json))
+    reference_component_frame = None
+    if args.include_teacher_disagreement_features:
+        component_columns = [column for column in merged_oof.columns if column.startswith("pred_")]
+        reference_component_frame = merged_oof[[ID_COLUMN, *component_columns]].copy()
+
+    if args.approach == "classifier":
+        metrics = run_specialist_override_cv(
+            train_csv_path=args.train_csv,
+            preset=args.preset,
+            reference_pred=reference_pred,
+            reference_component_frame=reference_component_frame,
+            params=params,
+            feature_blocks=feature_blocks,
+            folds=args.folds,
+            random_state=args.random_state,
+            early_stopping_rounds=args.early_stopping_rounds,
+            verbose=args.verbose,
+            alpha_grid=alpha_grid,
+            model_path=args.model_path,
+            metrics_path=args.metrics_path,
+            oof_path=args.oof_path,
+        )
+    else:
+        metrics = run_residual_reranker_cv(
+            train_csv_path=args.train_csv,
+            preset=args.preset,
+            reference_pred=reference_pred,
+            reference_component_frame=reference_component_frame,
+            params=params,
+            feature_blocks=feature_blocks,
+            folds=args.folds,
+            random_state=args.random_state,
+            early_stopping_rounds=args.early_stopping_rounds,
+            verbose=args.verbose,
+            alpha_grid=alpha_grid,
+            model_path=args.model_path,
+            metrics_path=args.metrics_path,
+            oof_path=args.oof_path,
+        )
+    print(json.dumps(metrics, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment_specialist_model.py
+++ b/scripts/experiment_specialist_model.py
@@ -18,6 +18,7 @@ from churn_baseline.specialist import (
     build_reference_prediction,
     list_specialist_approaches,
     list_specialist_presets,
+    run_family_feature_challenger_cv,
     run_residual_reranker_cv,
     run_specialist_override_cv,
 )
@@ -76,7 +77,7 @@ def parse_args() -> argparse.Namespace:
         "--approach",
         default="classifier",
         choices=list(list_specialist_approaches()),
-        help="Specialist approach: direct local classifier or residual reranker.",
+        help="Specialist approach: direct local classifier, residual reranker, or family-prediction-as-feature challenger.",
     )
     parser.add_argument(
         "--feature-blocks",
@@ -158,6 +159,23 @@ def main() -> int:
 
     if args.approach == "classifier":
         metrics = run_specialist_override_cv(
+            train_csv_path=args.train_csv,
+            preset=args.preset,
+            reference_pred=reference_pred,
+            reference_component_frame=reference_component_frame,
+            params=params,
+            feature_blocks=feature_blocks,
+            folds=args.folds,
+            random_state=args.random_state,
+            early_stopping_rounds=args.early_stopping_rounds,
+            verbose=args.verbose,
+            alpha_grid=alpha_grid,
+            model_path=args.model_path,
+            metrics_path=args.metrics_path,
+            oof_path=args.oof_path,
+        )
+    elif args.approach == "feature":
+        metrics = run_family_feature_challenger_cv(
             train_csv_path=args.train_csv,
             preset=args.preset,
             reference_pred=reference_pred,

--- a/scripts/experiment_specialist_model.py
+++ b/scripts/experiment_specialist_model.py
@@ -81,7 +81,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="H,R,S,V",
-        help="Comma-separated feature blocks for the specialist model (supported: A,B,C,H,R,S,V,O,P).",
+        help="Comma-separated feature blocks for the specialist model (supported: A,B,C,F,H,R,S,V,O,P).",
     )
     parser.add_argument(
         "--oof",

--- a/scripts/experiment_telco_joint_training.py
+++ b/scripts/experiment_telco_joint_training.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Run source-aware joint training with the original Telco rows against v3."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.artifacts import ensure_parent_dir, write_json
+from churn_baseline.config import CatBoostHyperParams, ID_COLUMN
+from churn_baseline.diagnostics import OOF_TARGET_COLUMN, load_reference_prediction_frame
+from churn_baseline.feature_engineering import normalize_feature_blocks
+from churn_baseline.incumbent_v3 import compute_repeated_cv_auc_stats
+from churn_baseline.noise_audit import DEFAULT_V3_OOF_SPEC, DOMINANT_MACROFAMILY
+from churn_baseline.telco_transfer import DEFAULT_ORIGINAL_CSV, run_telco_joint_training_smoke
+from churn_baseline.validation_protocol import evaluate_validation_protocol
+
+
+def _parse_feature_blocks(raw: str) -> list[str]:
+    normalized_raw = raw.strip().lower()
+    if normalized_raw in {"none", "off", "baseline", ""}:
+        return []
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    return list(normalize_feature_blocks(tokens))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run source-aware joint training with the original Telco rows against v3"
+    )
+    parser.add_argument("--train-csv", default="data/raw/train.csv")
+    parser.add_argument("--test-csv", default="data/raw/test.csv")
+    parser.add_argument("--original-csv", default=DEFAULT_ORIGINAL_CSV)
+    parser.add_argument("--v3-oof", default=DEFAULT_V3_OOF_SPEC)
+    parser.add_argument("--feature-blocks", default="R,V")
+    parser.add_argument("--folds", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--stratify-mode", choices=("target", "composite"), default="target")
+    parser.add_argument("--external-weight", type=float, default=0.25)
+    parser.add_argument("--iterations", type=int, default=150)
+    parser.add_argument("--learning-rate", type=float, default=0.05)
+    parser.add_argument("--depth", type=int, default=6)
+    parser.add_argument("--l2-leaf-reg", type=float, default=5.0)
+    parser.add_argument("--early-stopping-rounds", type=int, default=60)
+    parser.add_argument("--verbose", type=int, default=0)
+    parser.add_argument("--label", default="telco_joint_training_smoke")
+    parser.add_argument("--out-dir", default="artifacts/reports")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    feature_blocks = _parse_feature_blocks(args.feature_blocks)
+    challenger_params = CatBoostHyperParams(
+        iterations=args.iterations,
+        learning_rate=args.learning_rate,
+        depth=args.depth,
+        l2_leaf_reg=args.l2_leaf_reg,
+        random_seed=args.seed,
+    )
+
+    metrics = run_telco_joint_training_smoke(
+        train_csv_path=args.train_csv,
+        test_csv_path=args.test_csv,
+        original_csv_path=args.original_csv,
+        challenger_params=challenger_params,
+        feature_blocks=feature_blocks,
+        folds=args.folds,
+        seed=args.seed,
+        stratify_mode=args.stratify_mode,
+        external_weight=args.external_weight,
+        challenger_early_stopping_rounds=args.early_stopping_rounds,
+        verbose=args.verbose,
+    )
+
+    out_dir = Path(args.out_dir)
+    metrics_path = ensure_parent_dir(out_dir / f"{args.label}_metrics.json")
+    oof_path = ensure_parent_dir(out_dir / f"{args.label}_oof.csv")
+    analysis_oof_path = ensure_parent_dir(out_dir / f"{args.label}_analysis_oof.csv")
+    candidate_metrics_path = ensure_parent_dir(out_dir / f"{args.label}_candidate_metrics.json")
+    reference_metrics_path = ensure_parent_dir(out_dir / f"{args.label}_reference_v3_metrics.json")
+    verdict_path = ensure_parent_dir(out_dir / f"validation_protocol_{args.label}_vs_v3_smoke.json")
+
+    train_frame = pd.read_csv(args.train_csv, usecols=[ID_COLUMN, "Churn"])
+    train_frame[OOF_TARGET_COLUMN] = (train_frame["Churn"].astype(str).str.lower() == "yes").astype("int8")
+    train_frame = train_frame.drop(columns=["Churn"])
+    train_frame["oof_pred"] = metrics["oof_pred"].astype(float).values
+    train_frame.to_csv(oof_path, index=False)
+
+    reference_frame, _ = load_reference_prediction_frame(
+        reference_oof_spec=args.v3_oof,
+        id_column=ID_COLUMN,
+        target_column=OOF_TARGET_COLUMN,
+    )
+    analysis_frame = reference_frame[[ID_COLUMN, OOF_TARGET_COLUMN, "reference_pred"]].merge(
+        train_frame[[ID_COLUMN, OOF_TARGET_COLUMN, "oof_pred"]].rename(columns={"oof_pred": "candidate_pred"}),
+        how="inner",
+        on=[ID_COLUMN, OOF_TARGET_COLUMN],
+        validate="one_to_one",
+    )
+    analysis_frame.to_csv(analysis_oof_path, index=False)
+
+    candidate_metrics = compute_repeated_cv_auc_stats(
+        analysis_frame[OOF_TARGET_COLUMN],
+        analysis_frame["candidate_pred"],
+    )
+    reference_metrics = compute_repeated_cv_auc_stats(
+        analysis_frame[OOF_TARGET_COLUMN],
+        analysis_frame["reference_pred"],
+    )
+    write_json(candidate_metrics_path, candidate_metrics)
+    write_json(reference_metrics_path, reference_metrics)
+
+    verdict = evaluate_validation_protocol(
+        train_csv_path=args.train_csv,
+        test_csv_path=args.test_csv,
+        stage="smoke",
+        analysis_oof_path=analysis_oof_path,
+        target_family_level="segment3",
+        target_family_value=DOMINANT_MACROFAMILY,
+        dominant_family_value=DOMINANT_MACROFAMILY,
+        candidate_metrics_json=candidate_metrics_path,
+        reference_metrics_json=reference_metrics_path,
+        out_json_path=verdict_path,
+    )
+
+    metrics["oof_path"] = str(oof_path)
+    metrics["analysis_oof_path"] = str(analysis_oof_path)
+    metrics["candidate_metrics_path"] = str(candidate_metrics_path)
+    metrics["reference_metrics_path"] = str(reference_metrics_path)
+    metrics["validation_verdict_path"] = str(verdict_path)
+    metrics["validation_verdict"] = verdict["verdict"]
+    metrics["validation_overall_metrics"] = verdict["overall_metrics"]
+    metrics.pop("oof_pred", None)
+    write_json(metrics_path, metrics)
+
+    print(json.dumps(metrics, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment_telco_transfer.py
+++ b/scripts/experiment_telco_transfer.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Run the minimal external Telco transfer-feature smoke against v3."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.artifacts import ensure_parent_dir, write_json
+from churn_baseline.config import CatBoostHyperParams, ID_COLUMN
+from churn_baseline.diagnostics import OOF_TARGET_COLUMN, load_reference_prediction_frame
+from churn_baseline.feature_engineering import normalize_feature_blocks
+from churn_baseline.incumbent_v3 import compute_repeated_cv_auc_stats
+from churn_baseline.noise_audit import DEFAULT_V3_OOF_SPEC, DOMINANT_MACROFAMILY
+from churn_baseline.telco_transfer import DEFAULT_ORIGINAL_CSV, run_telco_transfer_smoke
+from churn_baseline.validation_protocol import evaluate_validation_protocol
+
+
+def _parse_feature_blocks(raw: str) -> list[str]:
+    normalized_raw = raw.strip().lower()
+    if normalized_raw in {"none", "off", "baseline", ""}:
+        return []
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    return list(normalize_feature_blocks(tokens))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the minimal external Telco transfer-feature smoke against v3")
+    parser.add_argument("--train-csv", default="data/raw/train.csv")
+    parser.add_argument("--test-csv", default="data/raw/test.csv")
+    parser.add_argument("--original-csv", default=DEFAULT_ORIGINAL_CSV)
+    parser.add_argument("--v3-oof", default=DEFAULT_V3_OOF_SPEC)
+    parser.add_argument("--feature-blocks", default="R,V")
+    parser.add_argument("--folds", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--stratify-mode", choices=("target", "composite"), default="target")
+    parser.add_argument("--teacher-valid-size", type=float, default=0.2)
+    parser.add_argument("--teacher-iterations", type=int, default=800)
+    parser.add_argument("--teacher-learning-rate", type=float, default=0.05)
+    parser.add_argument("--teacher-depth", type=int, default=6)
+    parser.add_argument("--teacher-l2-leaf-reg", type=float, default=5.0)
+    parser.add_argument("--teacher-early-stopping-rounds", type=int, default=80)
+    parser.add_argument("--iterations", type=int, default=150)
+    parser.add_argument("--learning-rate", type=float, default=0.05)
+    parser.add_argument("--depth", type=int, default=6)
+    parser.add_argument("--l2-leaf-reg", type=float, default=5.0)
+    parser.add_argument("--early-stopping-rounds", type=int, default=60)
+    parser.add_argument("--verbose", type=int, default=0)
+    parser.add_argument("--label", default="telco_transfer_smoke")
+    parser.add_argument("--out-dir", default="artifacts/reports")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    feature_blocks = _parse_feature_blocks(args.feature_blocks)
+    teacher_params = CatBoostHyperParams(
+        iterations=args.teacher_iterations,
+        learning_rate=args.teacher_learning_rate,
+        depth=args.teacher_depth,
+        l2_leaf_reg=args.teacher_l2_leaf_reg,
+        random_seed=args.seed,
+    )
+    challenger_params = CatBoostHyperParams(
+        iterations=args.iterations,
+        learning_rate=args.learning_rate,
+        depth=args.depth,
+        l2_leaf_reg=args.l2_leaf_reg,
+        random_seed=args.seed,
+    )
+
+    metrics = run_telco_transfer_smoke(
+        train_csv_path=args.train_csv,
+        test_csv_path=args.test_csv,
+        original_csv_path=args.original_csv,
+        teacher_params=teacher_params,
+        challenger_params=challenger_params,
+        feature_blocks=feature_blocks,
+        folds=args.folds,
+        seed=args.seed,
+        stratify_mode=args.stratify_mode,
+        teacher_valid_size=args.teacher_valid_size,
+        teacher_early_stopping_rounds=args.teacher_early_stopping_rounds,
+        challenger_early_stopping_rounds=args.early_stopping_rounds,
+        verbose=args.verbose,
+    )
+
+    out_dir = Path(args.out_dir)
+    metrics_path = ensure_parent_dir(out_dir / f"{args.label}_metrics.json")
+    oof_path = ensure_parent_dir(out_dir / f"{args.label}_oof.csv")
+    analysis_oof_path = ensure_parent_dir(out_dir / f"{args.label}_analysis_oof.csv")
+    candidate_metrics_path = ensure_parent_dir(out_dir / f"{args.label}_candidate_metrics.json")
+    reference_metrics_path = ensure_parent_dir(out_dir / f"{args.label}_reference_v3_metrics.json")
+    transfer_train_path = ensure_parent_dir(out_dir / f"{args.label}_transfer_train.csv")
+    transfer_test_path = ensure_parent_dir(out_dir / f"{args.label}_transfer_test.csv")
+    verdict_path = ensure_parent_dir(out_dir / f"validation_protocol_{args.label}_vs_v3_smoke.json")
+
+    train_frame = pd.read_csv(args.train_csv, usecols=[ID_COLUMN, "Churn"])
+    train_frame[OOF_TARGET_COLUMN] = (train_frame["Churn"].astype(str).str.lower() == "yes").astype("int8")
+    train_frame = train_frame.drop(columns=["Churn"])
+    train_frame["oof_pred"] = metrics["oof_pred"].astype(float).values
+    train_frame.to_csv(oof_path, index=False)
+
+    metrics["transfer_train"].to_csv(transfer_train_path, index=False)
+    metrics["transfer_test"].to_csv(transfer_test_path, index=False)
+
+    reference_frame, _ = load_reference_prediction_frame(
+        reference_oof_spec=args.v3_oof,
+        id_column=ID_COLUMN,
+        target_column=OOF_TARGET_COLUMN,
+    )
+    analysis_frame = reference_frame[[ID_COLUMN, OOF_TARGET_COLUMN, "reference_pred"]].merge(
+        train_frame[[ID_COLUMN, OOF_TARGET_COLUMN, "oof_pred"]].rename(columns={"oof_pred": "candidate_pred"}),
+        how="inner",
+        on=[ID_COLUMN, OOF_TARGET_COLUMN],
+        validate="one_to_one",
+    )
+    analysis_frame.to_csv(analysis_oof_path, index=False)
+
+    candidate_metrics = compute_repeated_cv_auc_stats(
+        analysis_frame[OOF_TARGET_COLUMN],
+        analysis_frame["candidate_pred"],
+    )
+    reference_metrics = compute_repeated_cv_auc_stats(
+        analysis_frame[OOF_TARGET_COLUMN],
+        analysis_frame["reference_pred"],
+    )
+    write_json(candidate_metrics_path, candidate_metrics)
+    write_json(reference_metrics_path, reference_metrics)
+
+    verdict = evaluate_validation_protocol(
+        train_csv_path=args.train_csv,
+        test_csv_path=args.test_csv,
+        stage="smoke",
+        analysis_oof_path=analysis_oof_path,
+        target_family_level="segment3",
+        target_family_value=DOMINANT_MACROFAMILY,
+        dominant_family_value=DOMINANT_MACROFAMILY,
+        candidate_metrics_json=candidate_metrics_path,
+        reference_metrics_json=reference_metrics_path,
+        out_json_path=verdict_path,
+    )
+
+    metrics["oof_path"] = str(oof_path)
+    metrics["analysis_oof_path"] = str(analysis_oof_path)
+    metrics["candidate_metrics_path"] = str(candidate_metrics_path)
+    metrics["reference_metrics_path"] = str(reference_metrics_path)
+    metrics["transfer_train_path"] = str(transfer_train_path)
+    metrics["transfer_test_path"] = str(transfer_test_path)
+    metrics["validation_verdict_path"] = str(verdict_path)
+    metrics["validation_verdict"] = verdict["verdict"]
+    metrics["validation_overall_metrics"] = verdict["overall_metrics"]
+    metrics.pop("oof_pred", None)
+    metrics.pop("transfer_train", None)
+    metrics.pop("transfer_test", None)
+    write_json(metrics_path, metrics)
+
+    print(json.dumps(metrics, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment_uncertainty_band.py
+++ b/scripts/experiment_uncertainty_band.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Run the uncertainty-band reranker smoke directly against incumbent v3."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.config import CatBoostHyperParams, ID_COLUMN
+from churn_baseline.diagnostics import DEFAULT_REFERENCE_OOF_SPECS, load_merged_oof_matrix, load_reference_prediction_frame, parse_oof_input_spec
+from churn_baseline.feature_engineering import normalize_feature_blocks
+from churn_baseline.uncertainty_band import DEFAULT_V3_OOF_SPEC, run_uncertainty_band_reranker_cv
+from churn_baseline.validation_protocol import DOMINANT_MACROFAMILY, SUPPORTED_STAGES, evaluate_validation_protocol
+
+
+def _parse_feature_blocks(raw: str) -> list[str]:
+    normalized_raw = raw.strip().lower()
+    if normalized_raw in {"none", "off", "baseline", ""}:
+        return []
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    return list(normalize_feature_blocks(tokens))
+
+
+def _parse_alpha_grid(raw: str) -> list[float]:
+    values: list[float] = []
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        value = float(token)
+        if value < 0.0 or value > 1.0:
+            raise ValueError(f"alpha values must be in [0, 1], got {value}")
+        values.append(value)
+    if not values:
+        raise ValueError("alpha grid must contain at least one value")
+    return values
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run uncertainty-band reranker directly against incumbent v3")
+    parser.add_argument("--stage", choices=SUPPORTED_STAGES, default="smoke")
+    parser.add_argument("--train-csv", default="data/raw/train.csv")
+    parser.add_argument("--test-csv", default="data/raw/test.csv")
+    parser.add_argument(
+        "--reference-v3-oof",
+        default=DEFAULT_V3_OOF_SPEC,
+        help="Direct OOF spec for incumbent v3 (<path>[#prediction_column]).",
+    )
+    parser.add_argument(
+        "--oof",
+        action="append",
+        default=[],
+        help="Teacher component OOF input spec: <name>=<path>[#<prediction_column>]. Defaults to cb/xgb/lgb/r/rv.",
+    )
+    parser.add_argument(
+        "--feature-blocks",
+        default="H,R,S,V",
+        help="Comma-separated feature blocks for the local residual model.",
+    )
+    parser.add_argument(
+        "--target-family-level",
+        choices=["segment3", "segment5"],
+        default="segment3",
+    )
+    parser.add_argument(
+        "--target-family-value",
+        default=DOMINANT_MACROFAMILY,
+        help="Family key that defines the dominant uncertainty band target.",
+    )
+    parser.add_argument(
+        "--band-half-width",
+        type=float,
+        default=0.20,
+        help="Rows with abs(v3 - 0.5) <= band_half_width are eligible.",
+    )
+    parser.add_argument(
+        "--min-teacher-std",
+        type=float,
+        default=None,
+        help="Optional minimum teacher component std for a row to stay in the band.",
+    )
+    parser.add_argument(
+        "--max-relative-mask-drift",
+        type=float,
+        default=0.35,
+        help="Abort if additional filters shrink/grow the baseline family+band mask more than this relative fraction.",
+    )
+    parser.add_argument(
+        "--alpha-grid",
+        default="0.00,0.05,0.10,0.15,0.20,0.30,0.40,0.50",
+        help="Comma-separated alphas for local residual injection.",
+    )
+    parser.add_argument("--folds", type=int, default=2)
+    parser.add_argument("--random-state", type=int, default=42)
+    parser.add_argument("--iterations", type=int, default=200)
+    parser.add_argument("--learning-rate", type=float, default=0.04)
+    parser.add_argument("--depth", type=int, default=5)
+    parser.add_argument("--l2-leaf-reg", type=float, default=8.0)
+    parser.add_argument("--early-stopping-rounds", type=int, default=40)
+    parser.add_argument("--verbose", type=int, default=0)
+    parser.add_argument("--model-path", default="artifacts/models/uncertainty_band_smoke.cbm")
+    parser.add_argument("--metrics-path", default="artifacts/reports/uncertainty_band_smoke_metrics.json")
+    parser.add_argument("--oof-path", default="artifacts/reports/uncertainty_band_smoke_oof.csv")
+    parser.add_argument(
+        "--gate-path",
+        default="artifacts/reports/validation_protocol_uncertainty_band_smoke_vs_v3.json",
+        help="Validation reset report written after training.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    params = CatBoostHyperParams(
+        iterations=args.iterations,
+        learning_rate=args.learning_rate,
+        depth=args.depth,
+        l2_leaf_reg=args.l2_leaf_reg,
+        random_seed=args.random_state,
+    )
+    feature_blocks = _parse_feature_blocks(args.feature_blocks)
+    alpha_grid = _parse_alpha_grid(args.alpha_grid)
+
+    reference_frame, reference_source = load_reference_prediction_frame(
+        reference_oof_spec=args.reference_v3_oof,
+        id_column=ID_COLUMN,
+        target_column="target",
+    )
+
+    raw_specs = args.oof if args.oof else list(DEFAULT_REFERENCE_OOF_SPECS)
+    specs = [parse_oof_input_spec(raw) for raw in raw_specs]
+    merged_oof, _ = load_merged_oof_matrix(specs, id_column=ID_COLUMN, target_column="target")
+    component_columns = [column for column in merged_oof.columns if column.startswith("pred_")]
+    reference_component_frame = merged_oof[[ID_COLUMN, *component_columns]].copy()
+
+    metrics = run_uncertainty_band_reranker_cv(
+        train_csv_path=args.train_csv,
+        reference_frame=reference_frame,
+        reference_component_frame=reference_component_frame,
+        params=params,
+        feature_blocks=feature_blocks,
+        folds=args.folds,
+        random_state=args.random_state,
+        early_stopping_rounds=args.early_stopping_rounds,
+        verbose=args.verbose,
+        alpha_grid=alpha_grid,
+        target_family_level=args.target_family_level,
+        target_family_value=args.target_family_value,
+        band_half_width=args.band_half_width,
+        min_teacher_std=args.min_teacher_std,
+        max_relative_mask_drift=args.max_relative_mask_drift,
+        model_path=args.model_path,
+        metrics_path=args.metrics_path,
+        oof_path=args.oof_path,
+    )
+
+    gate = evaluate_validation_protocol(
+        train_csv_path=args.train_csv,
+        test_csv_path=args.test_csv,
+        stage=args.stage,
+        analysis_oof_path=args.oof_path,
+        target_family_level=args.target_family_level,
+        target_family_value=args.target_family_value,
+        dominant_family_value=DOMINANT_MACROFAMILY,
+        candidate_metrics_json=args.metrics_path,
+        out_json_path=args.gate_path,
+    )
+
+    summary = {
+        "metrics_path": str(Path(args.metrics_path)),
+        "oof_path": str(Path(args.oof_path)),
+        "gate_path": str(Path(args.gate_path)),
+        "reference_source": reference_source,
+        "component_specs": raw_specs,
+        "metrics": metrics,
+        "gate": gate,
+    }
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gate_submission_candidate.py
+++ b/scripts/gate_submission_candidate.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Gate a submission candidate using diagnostics thresholds."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.artifacts import write_json
+
+
+PASS = "PASS"
+WARN = "WARN"
+FAIL = "FAIL"
+
+
+def _now_utc_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _load_json(path: str | Path) -> dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as fh:
+        payload = json.load(fh)
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    return payload
+
+
+def _check(
+    name: str,
+    status: str,
+    message: str,
+    *,
+    actual: Any = None,
+    threshold: Any = None,
+) -> dict[str, Any]:
+    if status not in {PASS, WARN, FAIL}:
+        raise ValueError(f"Invalid status: {status}")
+    return {
+        "name": name,
+        "status": status,
+        "message": message,
+        "actual": actual,
+        "threshold": threshold,
+    }
+
+
+def _status_counts(checks: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {PASS: 0, WARN: 0, FAIL: 0}
+    for row in checks:
+        status = str(row.get("status", "")).upper()
+        if status in counts:
+            counts[status] += 1
+    return {
+        "pass": int(counts[PASS]),
+        "warn": int(counts[WARN]),
+        "fail": int(counts[FAIL]),
+        "total": int(sum(counts.values())),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Gate a submission candidate from diagnostics reports")
+    parser.add_argument(
+        "--candidate-name",
+        default="playground-series-s6e3",
+        help="Candidate identifier for report traceability.",
+    )
+    parser.add_argument(
+        "--parity-json",
+        default="artifacts/reports/diagnostic_submission_parity_issue5.json",
+        help="Path to parity report JSON.",
+    )
+    parser.add_argument(
+        "--drift-json",
+        default="artifacts/reports/diagnostic_train_test_drift_issue5.json",
+        help="Path to drift report JSON.",
+    )
+    parser.add_argument(
+        "--robustness-json",
+        default="artifacts/reports/diagnostic_ensemble_robustness_issue5.json",
+        help="Path to robustness report JSON.",
+    )
+    parser.add_argument(
+        "--require-parity-pass",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Require parity overall_status=PASS.",
+    )
+    parser.add_argument(
+        "--max-adv-auc",
+        type=float,
+        default=0.58,
+        help="Max allowed adversarial validation AUC.",
+    )
+    parser.add_argument(
+        "--max-high-psi-count",
+        type=int,
+        default=2,
+        help="Max allowed count of numeric columns with PSI >= 0.2.",
+    )
+    parser.add_argument(
+        "--max-high-tvd-count",
+        type=int,
+        default=2,
+        help="Max allowed count of categorical columns with TVD >= 0.2.",
+    )
+    parser.add_argument(
+        "--min-weighted-delta-vs-baseline",
+        type=float,
+        default=0.0002,
+        help="Minimum required weighted CV mean improvement vs baseline.",
+    )
+    parser.add_argument(
+        "--min-weighted-delta-vs-equal",
+        type=float,
+        default=0.00005,
+        help="Minimum required weighted CV mean improvement vs equal blend.",
+    )
+    parser.add_argument(
+        "--max-weighted-cv-std",
+        type=float,
+        default=0.0015,
+        help="Max allowed weighted CV std.",
+    )
+    parser.add_argument(
+        "--max-weighted-optimism",
+        type=float,
+        default=0.00005,
+        help="Max allowed weighted optimism (full_auc - cv_mean_auc).",
+    )
+    parser.add_argument(
+        "--max-warnings",
+        type=int,
+        default=0,
+        help="Maximum warnings tolerated for GO decision.",
+    )
+    parser.add_argument(
+        "--out-json",
+        default="artifacts/reports/diagnostic_submission_gate_issue5.json",
+        help="Output gating report JSON path.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    parity = _load_json(args.parity_json)
+    drift = _load_json(args.drift_json)
+    robustness = _load_json(args.robustness_json)
+
+    checks: list[dict[str, Any]] = []
+
+    parity_status = str(parity.get("overall_status", "")).upper()
+    if args.require_parity_pass:
+        status = PASS if parity_status == PASS else FAIL
+        checks.append(
+            _check(
+                "parity_overall_status",
+                status,
+                "Parity report must be PASS.",
+                actual=parity_status,
+                threshold=PASS,
+            )
+        )
+    else:
+        checks.append(
+            _check(
+                "parity_overall_status",
+                WARN if parity_status != PASS else PASS,
+                "Parity PASS is recommended.",
+                actual=parity_status,
+                threshold=PASS,
+            )
+        )
+
+    adv_auc = float(drift["adversarial_validation"]["cv_mean_auc"])
+    checks.append(
+        _check(
+            "drift_adversarial_auc",
+            PASS if adv_auc <= args.max_adv_auc else FAIL,
+            "Adversarial AUC should remain below threshold.",
+            actual=adv_auc,
+            threshold=float(args.max_adv_auc),
+        )
+    )
+
+    high_psi_count = int(drift["numeric_drift"]["high_psi_count_ge_0_2"])
+    checks.append(
+        _check(
+            "drift_high_psi_count",
+            PASS if high_psi_count <= args.max_high_psi_count else FAIL,
+            "Count of high-PSI numeric features should remain controlled.",
+            actual=high_psi_count,
+            threshold=int(args.max_high_psi_count),
+        )
+    )
+
+    high_tvd_count = int(drift["categorical_drift"]["high_tvd_count_ge_0_2"])
+    checks.append(
+        _check(
+            "drift_high_tvd_count",
+            PASS if high_tvd_count <= args.max_high_tvd_count else FAIL,
+            "Count of high-TVD categorical features should remain controlled.",
+            actual=high_tvd_count,
+            threshold=int(args.max_high_tvd_count),
+        )
+    )
+
+    methods = robustness.get("methods", {})
+    if "weighted" not in methods or "equal" not in methods:
+        checks.append(
+            _check(
+                "robustness_methods_presence",
+                FAIL,
+                "Robustness report must include 'weighted' and 'equal' methods.",
+                actual=list(methods.keys()),
+                threshold=["weighted", "equal"],
+            )
+        )
+    else:
+        weighted = methods["weighted"]
+        equal = methods["equal"]
+        rank = methods.get("rank")
+
+        weighted_cv_mean = float(weighted["cv_mean_auc"])
+        weighted_cv_std = float(weighted["cv_std_auc"])
+        weighted_optimism = float(weighted["optimism_full_minus_cv_mean"])
+
+        delta_vs_baseline = weighted.get("delta_cv_mean_vs_baseline_auc")
+        if delta_vs_baseline is None:
+            checks.append(
+                _check(
+                    "weighted_delta_vs_baseline_present",
+                    FAIL,
+                    "Weighted delta vs baseline is required; rerun robustness with baseline metrics.",
+                    actual=None,
+                    threshold="float",
+                )
+            )
+        else:
+            delta_vs_baseline = float(delta_vs_baseline)
+            checks.append(
+                _check(
+                    "weighted_delta_vs_baseline",
+                    PASS if delta_vs_baseline >= args.min_weighted_delta_vs_baseline else FAIL,
+                    "Weighted CV mean improvement vs baseline must exceed threshold.",
+                    actual=delta_vs_baseline,
+                    threshold=float(args.min_weighted_delta_vs_baseline),
+                )
+            )
+
+        delta_vs_equal = float(weighted_cv_mean - float(equal["cv_mean_auc"]))
+        checks.append(
+            _check(
+                "weighted_delta_vs_equal",
+                PASS if delta_vs_equal >= args.min_weighted_delta_vs_equal else WARN,
+                "Weighted CV mean should improve over equal blend.",
+                actual=delta_vs_equal,
+                threshold=float(args.min_weighted_delta_vs_equal),
+            )
+        )
+
+        if rank is not None:
+            delta_vs_rank = float(weighted_cv_mean - float(rank["cv_mean_auc"]))
+            checks.append(
+                _check(
+                    "weighted_delta_vs_rank",
+                    PASS if delta_vs_rank >= 0.0 else WARN,
+                    "Weighted CV mean should not underperform rank blend.",
+                    actual=delta_vs_rank,
+                    threshold=">= 0.0",
+                )
+            )
+
+        checks.append(
+            _check(
+                "weighted_cv_std",
+                PASS if weighted_cv_std <= args.max_weighted_cv_std else WARN,
+                "Weighted CV std should remain below threshold.",
+                actual=weighted_cv_std,
+                threshold=float(args.max_weighted_cv_std),
+            )
+        )
+
+        checks.append(
+            _check(
+                "weighted_optimism",
+                PASS if weighted_optimism <= args.max_weighted_optimism else WARN,
+                "Weighted optimism should remain controlled.",
+                actual=weighted_optimism,
+                threshold=float(args.max_weighted_optimism),
+            )
+        )
+
+    counts = _status_counts(checks)
+    decision = "GO" if counts["fail"] == 0 and counts["warn"] <= args.max_warnings else "NO_GO"
+
+    report = {
+        "generated_at_utc": _now_utc_iso(),
+        "candidate_name": args.candidate_name,
+        "decision": decision,
+        "inputs": {
+            "parity_json": args.parity_json,
+            "drift_json": args.drift_json,
+            "robustness_json": args.robustness_json,
+        },
+        "thresholds": {
+            "require_parity_pass": bool(args.require_parity_pass),
+            "max_adv_auc": float(args.max_adv_auc),
+            "max_high_psi_count": int(args.max_high_psi_count),
+            "max_high_tvd_count": int(args.max_high_tvd_count),
+            "min_weighted_delta_vs_baseline": float(args.min_weighted_delta_vs_baseline),
+            "min_weighted_delta_vs_equal": float(args.min_weighted_delta_vs_equal),
+            "max_weighted_cv_std": float(args.max_weighted_cv_std),
+            "max_weighted_optimism": float(args.max_weighted_optimism),
+            "max_warnings": int(args.max_warnings),
+        },
+        "summary": counts,
+        "checks": checks,
+    }
+    write_json(args.out_json, report)
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/make_submission.py
+++ b/scripts/make_submission.py
@@ -28,7 +28,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="none",
-        help="Optional feature blocks (A,B,C,F,G,H,R,S,V,O,P) or none.",
+        help="Optional feature blocks (A,B,C,F,G,T,H,R,S,V,O,P) or none.",
     )
     parser.add_argument(
         "--output-csv",

--- a/scripts/make_submission.py
+++ b/scripts/make_submission.py
@@ -28,7 +28,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="none",
-        help="Optional feature blocks (A,B,C,G,H,R,S,V,O,P) or none.",
+        help="Optional feature blocks (A,B,C,F,G,H,R,S,V,O,P) or none.",
     )
     parser.add_argument(
         "--output-csv",

--- a/scripts/make_submission.py
+++ b/scripts/make_submission.py
@@ -8,13 +8,28 @@ from _bootstrap import add_src_to_path
 
 add_src_to_path()
 
+from churn_baseline.feature_engineering import normalize_feature_blocks
 from churn_baseline.pipeline import make_submission
+
+
+def _parse_feature_blocks(raw: str) -> list[str]:
+    normalized_raw = raw.strip().lower()
+    if normalized_raw in {"none", "off", "baseline", ""}:
+        return []
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    return list(normalize_feature_blocks(tokens))
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate submission CSV for churn competition")
     parser.add_argument("--model-path", default="artifacts/models/catboost_baseline.cbm")
+    parser.add_argument("--train-csv", default="data/raw/train.csv")
     parser.add_argument("--test-csv", default="data/raw/test.csv")
+    parser.add_argument(
+        "--feature-blocks",
+        default="none",
+        help="Optional feature blocks (A,B,C,G,H,R,S,V,O,P) or none.",
+    )
     parser.add_argument(
         "--output-csv",
         default="artifacts/submissions/playground-series-s6e3.csv",
@@ -25,10 +40,13 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+    feature_blocks = _parse_feature_blocks(args.feature_blocks)
     result = make_submission(
         model_path=args.model_path,
         test_csv_path=args.test_csv,
         output_csv_path=args.output_csv,
+        feature_blocks=feature_blocks,
+        train_csv_path=args.train_csv,
     )
     print(json.dumps(result, indent=2))
     return 0

--- a/scripts/make_submission_ensemble.py
+++ b/scripts/make_submission_ensemble.py
@@ -58,7 +58,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="none",
-        help="Optional feature blocks (A,B,C,G,H,R,S,V,O,P) or none.",
+        help="Optional feature blocks (A,B,C,F,G,H,R,S,V,O,P) or none.",
     )
     return parser.parse_args()
 

--- a/scripts/make_submission_ensemble.py
+++ b/scripts/make_submission_ensemble.py
@@ -58,7 +58,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="none",
-        help="Optional feature blocks (A,B,C,F,G,H,R,S,V,O,P) or none.",
+        help="Optional feature blocks (A,B,C,F,G,T,H,R,S,V,O,P) or none.",
     )
     return parser.parse_args()
 

--- a/scripts/make_submission_ensemble.py
+++ b/scripts/make_submission_ensemble.py
@@ -9,6 +9,7 @@ from _bootstrap import add_src_to_path
 
 add_src_to_path()
 
+from churn_baseline.feature_engineering import normalize_feature_blocks
 from churn_baseline.pipeline import make_submission_ensemble
 
 
@@ -27,8 +28,17 @@ def _model_paths_from_metrics(metrics_path: str | Path) -> list[str]:
     return [str(path) for path in model_paths]
 
 
+def _parse_feature_blocks(raw: str) -> list[str]:
+    normalized_raw = raw.strip().lower()
+    if normalized_raw in {"none", "off", "baseline", ""}:
+        return []
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    return list(normalize_feature_blocks(tokens))
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate ensemble submission from multiple models")
+    parser.add_argument("--train-csv", default="data/raw/train.csv", help="Path to train.csv")
     parser.add_argument("--test-csv", default="data/raw/test.csv", help="Path to test.csv")
     parser.add_argument(
         "--output-csv",
@@ -45,11 +55,17 @@ def parse_args() -> argparse.Namespace:
         default="artifacts/reports/train_cv_multiseed_metrics.json",
         help="Metrics JSON with model_paths key",
     )
+    parser.add_argument(
+        "--feature-blocks",
+        default="none",
+        help="Optional feature blocks (A,B,C,G,H,R,S,V,O,P) or none.",
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
+    feature_blocks = _parse_feature_blocks(args.feature_blocks)
     if args.model_paths.strip():
         model_paths = _parse_model_paths(args.model_paths)
     else:
@@ -59,6 +75,8 @@ def main() -> int:
         model_paths=model_paths,
         test_csv_path=args.test_csv,
         output_csv_path=args.output_csv,
+        feature_blocks=feature_blocks,
+        train_csv_path=args.train_csv,
     )
     print(json.dumps(result, indent=2))
     return 0

--- a/scripts/make_submission_hierarchical_priors.py
+++ b/scripts/make_submission_hierarchical_priors.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Generate submission CSV for hierarchical target prior experiments."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.config import ID_COLUMN, TARGET_COLUMN
+from churn_baseline.data import load_csv, prepare_test_features
+from churn_baseline.feature_engineering import normalize_feature_blocks
+from churn_baseline.modeling import load_model, predict_proba
+from churn_baseline.target_priors import load_target_prior_encoder
+
+
+def _combine_features(
+    base_features: pd.DataFrame,
+    prior_features: pd.DataFrame,
+    *,
+    feature_mode: str,
+) -> pd.DataFrame:
+    if feature_mode == "priors_only":
+        return prior_features.copy()
+    if feature_mode == "raw_plus_priors":
+        return pd.concat(
+            [base_features.reset_index(drop=True), prior_features.reset_index(drop=True)],
+            axis=1,
+        )
+    raise ValueError(f"Unsupported feature mode: {feature_mode}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate submission CSV for hierarchical target prior experiment"
+    )
+    parser.add_argument("--test-csv", default="data/raw/test.csv", help="Path to test.csv")
+    parser.add_argument(
+        "--metrics-path",
+        default="artifacts/reports/hierarchical_priors_cv_metrics.json",
+        help="Metrics JSON produced by experiment_hierarchical_priors.py",
+    )
+    parser.add_argument(
+        "--output-csv",
+        default="artifacts/submissions/playground-series-s6e3-hier-priors.csv",
+        help="Output submission CSV path",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    metrics = json.loads(Path(args.metrics_path).read_text(encoding="utf-8"))
+    feature_blocks = list(normalize_feature_blocks(metrics.get("base_feature_blocks", [])))
+    feature_mode = str(metrics.get("feature_mode", "raw_plus_priors"))
+    model_path = metrics["model_path"]
+    prior_encoder_path = metrics["prior_encoder_path"]
+
+    test_df = load_csv(args.test_csv)
+    ids = test_df[ID_COLUMN].copy()
+    x_base = prepare_test_features(test_df, drop_id=True, feature_blocks=feature_blocks)
+    encoder = load_target_prior_encoder(prior_encoder_path)
+    x_prior = encoder.transform(x_base.reset_index(drop=True))
+    x_model = _combine_features(x_base.reset_index(drop=True), x_prior, feature_mode=feature_mode)
+
+    model = load_model(model_path)
+    predictions = predict_proba(model, x_model)
+
+    out_path = Path(args.output_csv)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    submission = pd.DataFrame({ID_COLUMN: ids, TARGET_COLUMN: predictions.values})
+    submission.to_csv(out_path, index=False)
+
+    result = {
+        "output_csv": str(out_path),
+        "rows": int(len(submission)),
+        "feature_mode": feature_mode,
+        "base_feature_blocks": feature_blocks,
+        "prediction_min": float(submission[TARGET_COLUMN].min()),
+        "prediction_max": float(submission[TARGET_COLUMN].max()),
+    }
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/make_submission_residual_hierarchical.py
+++ b/scripts/make_submission_residual_hierarchical.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Generate a submission by chaining trained residual rerankers over a base submission."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pandas as pd
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.diagnostics import parse_feature_blocks_arg
+from churn_baseline.specialist import make_residual_reranker_chain_submission
+
+
+def _parse_step(raw: str) -> dict[str, object]:
+    parts = [part.strip() for part in raw.split("|")]
+    if len(parts) != 4:
+        raise ValueError(
+            "Each --step must use format "
+            "'<preset>|<model_path>|<alpha>|<feature_blocks>'"
+        )
+    preset, model_path, alpha_raw, feature_blocks_raw = parts
+    return {
+        "preset": preset,
+        "model_path": model_path,
+        "alpha": float(alpha_raw),
+        "feature_blocks": parse_feature_blocks_arg(feature_blocks_raw),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a submission by chaining residual rerankers over a reference submission"
+    )
+    parser.add_argument(
+        "--train-csv",
+        default="data/raw/train.csv",
+        help="Path to train.csv for fit-aware feature blocks such as G.",
+    )
+    parser.add_argument("--test-csv", default="data/raw/test.csv")
+    parser.add_argument(
+        "--reference-submission",
+        default="artifacts/submissions/playground-series-s6e3-rvblend.csv",
+        help="Base submission CSV used as teacher/reference score.",
+    )
+    parser.add_argument(
+        "--output-csv",
+        default="artifacts/submissions/playground-series-s6e3-residual-hier.csv",
+        help="Final submission CSV path.",
+    )
+    parser.add_argument(
+        "--report-json",
+        default="artifacts/reports/submission_candidate_residual_hierarchical.json",
+        help="Report JSON path.",
+    )
+    parser.add_argument(
+        "--reference-component-csv",
+        default="",
+        help="Optional CSV with id + pred_* columns for teacher-aware rerankers.",
+    )
+    parser.add_argument(
+        "--reference-mode",
+        default="previous",
+        choices=["previous", "base"],
+        help="Use the previous step output or the base reference submission as the step teacher.",
+    )
+    parser.add_argument(
+        "--step",
+        action="append",
+        required=True,
+        help="Residual step spec: <preset>|<model_path>|<alpha>|<feature_blocks>.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    steps = [_parse_step(raw) for raw in args.step]
+    reference_component_frame = pd.read_csv(args.reference_component_csv) if args.reference_component_csv.strip() else None
+    if reference_component_frame is not None and args.reference_mode != "base":
+        raise ValueError("--reference-component-csv requires --reference-mode base for teacher-aware parity")
+    report = make_residual_reranker_chain_submission(
+        test_csv_path=args.test_csv,
+        train_csv_path=args.train_csv,
+        reference_submission_path=args.reference_submission,
+        reference_component_frame=reference_component_frame,
+        reference_mode=args.reference_mode,
+        steps=steps,
+        output_csv_path=args.output_csv,
+        report_path=args.report_json,
+    )
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/materialize_residual_submission.py
+++ b/scripts/materialize_residual_submission.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Build teacher components if needed, then materialize a residual submission in one command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.diagnostics import parse_feature_blocks_arg
+from churn_baseline.specialist import (
+    build_teacher_reference_component_frame,
+    make_residual_reranker_chain_submission,
+)
+
+
+def _parse_step(raw: str) -> dict[str, object]:
+    parts = [part.strip() for part in raw.split("|")]
+    if len(parts) != 4:
+        raise ValueError(
+            "Each --step must use format "
+            "'<preset>|<model_path>|<alpha>|<feature_blocks>'"
+        )
+    preset, model_path, alpha_raw, feature_blocks_raw = parts
+    return {
+        "preset": preset,
+        "model_path": model_path,
+        "alpha": float(alpha_raw),
+        "feature_blocks": parse_feature_blocks_arg(feature_blocks_raw),
+    }
+
+
+def _load_required_json_key(path: str | Path, key: str) -> object:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    value = payload.get(key)
+    if value is None:
+        raise ValueError(f"Could not find key '{key}' in {path}")
+    return value
+
+
+def _resolve_component_output_path(raw: str, output_csv: str, suffix: str) -> Path:
+    if raw.strip():
+        return Path(raw)
+    output_path = Path(output_csv)
+    return output_path.with_name(f"{output_path.stem}{suffix}{output_path.suffix}")
+
+
+def _resolve_component_report_path(raw: str, report_json: str, suffix: str) -> Path:
+    if raw.strip():
+        return Path(raw)
+    report_path = Path(report_json)
+    return report_path.with_name(f"{report_path.stem}{suffix}{report_path.suffix}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build teacher components if needed and materialize a residual submission"
+    )
+    parser.add_argument(
+        "--train-csv",
+        default="data/raw/train.csv",
+        help="Path to train.csv for fit-aware feature blocks such as G.",
+    )
+    parser.add_argument("--test-csv", default="data/raw/test.csv")
+    parser.add_argument(
+        "--reference-submission",
+        default="artifacts/submissions/playground-series-s6e3-rvblend.csv",
+        help="Base submission CSV used as teacher/reference score.",
+    )
+    parser.add_argument(
+        "--output-csv",
+        default="artifacts/submissions/playground-series-s6e3-residual-hier.csv",
+        help="Final submission CSV path.",
+    )
+    parser.add_argument(
+        "--report-json",
+        default="artifacts/reports/submission_candidate_residual_hierarchical.json",
+        help="Final residual report JSON path.",
+    )
+    parser.add_argument(
+        "--reference-mode",
+        default="previous",
+        choices=["previous", "base"],
+        help="Use the previous step output or the base reference submission as the step teacher.",
+    )
+    parser.add_argument(
+        "--teacher-aware",
+        action="store_true",
+        help="Build the teacher component frame and pass it to teacher-aware rerankers.",
+    )
+    parser.add_argument(
+        "--reference-component-csv",
+        default="",
+        help="Optional output/input CSV with id + pred_* columns for teacher-aware rerankers.",
+    )
+    parser.add_argument(
+        "--reference-component-report-json",
+        default="",
+        help="Optional JSON path for the teacher component build report.",
+    )
+    parser.add_argument(
+        "--cb-metrics-json",
+        default="artifacts/reports/train_cv_multiseed_gate_s5_hiiter_metrics.json",
+        help="Metrics JSON with cb model_paths.",
+    )
+    parser.add_argument(
+        "--cb-feature-blocks",
+        default="none",
+        help="Feature blocks used by the cb ensemble models.",
+    )
+    parser.add_argument(
+        "--r-model-path",
+        default="artifacts/models/fe_blockR_hiiter.cbm",
+        help="CatBoost model path for the R component.",
+    )
+    parser.add_argument(
+        "--r-feature-blocks",
+        default="R",
+        help="Feature blocks used by the R component model.",
+    )
+    parser.add_argument(
+        "--cbxgblgb-submission",
+        default="artifacts/submissions/playground-series-s6e3.csv",
+        help="Validated submission for the cb+xgb+lgb blend.",
+    )
+    parser.add_argument(
+        "--cbxgblgb-weights-json",
+        default="artifacts/reports/submission_candidate_cb5_xgb3_lgb_weights.json",
+        help="Weights JSON for the cb+xgb+lgb blend.",
+    )
+    parser.add_argument(
+        "--cbr-submission",
+        default="artifacts/submissions/playground-series-s6e3-rblend.csv",
+        help="Validated submission for the cb+xgb+lgb+r blend.",
+    )
+    parser.add_argument(
+        "--cbr-weights-json",
+        default="artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_weights.json",
+        help="Weights JSON for the cb+xgb+lgb+r blend.",
+    )
+    parser.add_argument(
+        "--cbrv-submission",
+        default="artifacts/submissions/playground-series-s6e3-rvblend.csv",
+        help="Validated submission for the cb+xgb+lgb+r+rv blend.",
+    )
+    parser.add_argument(
+        "--cbrv-weights-json",
+        default="artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json",
+        help="Weights JSON for the cb+xgb+lgb+r+rv blend.",
+    )
+    parser.add_argument(
+        "--step",
+        action="append",
+        required=True,
+        help="Residual step spec: <preset>|<model_path>|<alpha>|<feature_blocks>.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    steps = [_parse_step(raw) for raw in args.step]
+
+    reference_component_frame = None
+    teacher_component_csv_path = None
+    teacher_component_report_path = None
+
+    if args.teacher_aware:
+        if args.reference_mode != "base":
+            raise ValueError("--teacher-aware requires --reference-mode base for train/inference parity")
+
+        teacher_component_csv_path = _resolve_component_output_path(
+            args.reference_component_csv,
+            args.output_csv,
+            "_teacher_components",
+        )
+        teacher_component_report_path = _resolve_component_report_path(
+            args.reference_component_report_json,
+            args.report_json,
+            "_teacher_components",
+        )
+
+        component_frame, component_report = build_teacher_reference_component_frame(
+            test_csv_path=args.test_csv,
+            train_csv_path=args.train_csv,
+            cb_model_paths=_load_required_json_key(args.cb_metrics_json, "model_paths"),
+            cb_feature_blocks=parse_feature_blocks_arg(args.cb_feature_blocks),
+            r_model_path=args.r_model_path,
+            r_feature_blocks=parse_feature_blocks_arg(args.r_feature_blocks),
+            cbxgblgb_submission_path=args.cbxgblgb_submission,
+            cbxgblgb_weights=_load_required_json_key(args.cbxgblgb_weights_json, "weights"),
+            cbr_submission_path=args.cbr_submission,
+            cbr_weights=_load_required_json_key(args.cbr_weights_json, "weights"),
+            cbrv_submission_path=args.cbrv_submission,
+            cbrv_weights=_load_required_json_key(args.cbrv_weights_json, "weights"),
+        )
+        teacher_component_csv_path.parent.mkdir(parents=True, exist_ok=True)
+        component_frame.to_csv(teacher_component_csv_path, index=False)
+        teacher_component_report_path.parent.mkdir(parents=True, exist_ok=True)
+        teacher_component_report = {
+            **component_report,
+            "output_csv_path": str(teacher_component_csv_path),
+            "report_json_path": str(teacher_component_report_path),
+        }
+        teacher_component_report_path.write_text(json.dumps(teacher_component_report, indent=2), encoding="utf-8")
+        reference_component_frame = component_frame
+    elif args.reference_component_csv.strip():
+        reference_component_frame = pd.read_csv(args.reference_component_csv)
+
+    run_config = {
+        "train_csv": args.train_csv,
+        "test_csv": args.test_csv,
+        "reference_submission": args.reference_submission,
+        "reference_mode": args.reference_mode,
+        "teacher_aware": bool(args.teacher_aware),
+        "reference_component_csv": str(teacher_component_csv_path or args.reference_component_csv or ""),
+        "output_csv": args.output_csv,
+        "report_json": args.report_json,
+        "steps": steps,
+    }
+    print(json.dumps({"run_config": run_config}, indent=2))
+
+    report = make_residual_reranker_chain_submission(
+        test_csv_path=args.test_csv,
+        train_csv_path=args.train_csv,
+        reference_submission_path=args.reference_submission,
+        reference_component_frame=reference_component_frame,
+        reference_mode=args.reference_mode,
+        steps=steps,
+        output_csv_path=args.output_csv,
+        report_path=args.report_json,
+    )
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_baseline.py
+++ b/scripts/run_baseline.py
@@ -10,6 +10,7 @@ from _bootstrap import add_src_to_path
 add_src_to_path()
 
 from churn_baseline.config import CatBoostHyperParams
+from churn_baseline.feature_engineering import normalize_feature_blocks
 from churn_baseline.kaggle_api import submit_file
 from churn_baseline.pipeline import make_submission, train_baseline
 
@@ -23,6 +24,17 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output-csv", default="artifacts/submissions/playground-series-s6e3.csv")
     parser.add_argument("--valid-size", type=float, default=0.2)
     parser.add_argument("--random-state", type=int, default=42)
+    parser.add_argument(
+        "--feature-blocks",
+        default="none",
+        help="Optional feature blocks (A,B,C,G,H,R,S,V,O,P) or none.",
+    )
+    parser.add_argument(
+        "--stratify-mode",
+        choices=("target", "composite"),
+        default="target",
+        help="Holdout stratification: target only, or target plus family fallback.",
+    )
     parser.add_argument("--iterations", type=int, default=2200)
     parser.add_argument("--learning-rate", type=float, default=0.05)
     parser.add_argument("--depth", type=int, default=6)
@@ -35,8 +47,17 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _parse_feature_blocks(raw: str) -> list[str]:
+    normalized_raw = raw.strip().lower()
+    if normalized_raw in {"none", "off", "baseline", ""}:
+        return []
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    return list(normalize_feature_blocks(tokens))
+
+
 def main() -> int:
     args = parse_args()
+    feature_blocks = _parse_feature_blocks(args.feature_blocks)
     params = CatBoostHyperParams(
         iterations=args.iterations,
         learning_rate=args.learning_rate,
@@ -54,11 +75,15 @@ def main() -> int:
         random_state=args.random_state,
         early_stopping_rounds=args.early_stopping_rounds,
         verbose=args.verbose,
+        feature_blocks=feature_blocks,
+        stratify_mode=args.stratify_mode,
     )
     submission_result = make_submission(
         model_path=args.model_path,
         test_csv_path=args.test_csv,
         output_csv_path=args.output_csv,
+        feature_blocks=feature_blocks,
+        train_csv_path=args.train_csv,
     )
 
     result = {

--- a/scripts/run_baseline.py
+++ b/scripts/run_baseline.py
@@ -27,7 +27,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="none",
-        help="Optional feature blocks (A,B,C,G,H,R,S,V,O,P) or none.",
+        help="Optional feature blocks (A,B,C,F,G,H,R,S,V,O,P) or none.",
     )
     parser.add_argument(
         "--stratify-mode",

--- a/scripts/run_baseline.py
+++ b/scripts/run_baseline.py
@@ -27,7 +27,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="none",
-        help="Optional feature blocks (A,B,C,F,G,H,R,S,V,O,P) or none.",
+        help="Optional feature blocks (A,B,C,F,G,T,H,R,S,V,O,P) or none.",
     )
     parser.add_argument(
         "--stratify-mode",

--- a/scripts/run_ngram_xgb.py
+++ b/scripts/run_ngram_xgb.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Run the minimal bi-gram target-encoding XGBoost experiment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.artifacts import ensure_parent_dir
+from churn_baseline.ngram_xgb import DEFAULT_NGRAM_BASE_COLUMNS, NgramXgbParams, train_ngram_xgb_cv
+
+
+def _parse_columns(raw: str) -> list[str] | None:
+    value = str(raw or "").strip()
+    if not value:
+        return None
+    return [token.strip() for token in value.split(",") if token.strip()]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run minimal ngram+TE+XGBoost CV")
+    parser.add_argument("--train-csv", default="data/raw/train.csv")
+    parser.add_argument("--test-csv", default="data/raw/test.csv")
+    parser.add_argument("--original-csv", default="", help="Optional original Telco CSV used only for TE support.")
+    parser.add_argument("--folds", type=int, default=2)
+    parser.add_argument("--inner-folds", type=int, default=3)
+    parser.add_argument("--random-state", type=int, default=42)
+    parser.add_argument("--smoothing-alpha", type=float, default=20.0)
+    parser.add_argument("--ngram-base-columns", default=",".join(DEFAULT_NGRAM_BASE_COLUMNS))
+    parser.add_argument("--include-trigrams", action="store_true")
+    parser.add_argument("--n-estimators", type=int, default=1500)
+    parser.add_argument("--learning-rate", type=float, default=0.03)
+    parser.add_argument("--max-depth", type=int, default=4)
+    parser.add_argument("--min-child-weight", type=float, default=4.0)
+    parser.add_argument("--subsample", type=float, default=0.8)
+    parser.add_argument("--colsample-bytree", type=float, default=0.6)
+    parser.add_argument("--reg-alpha", type=float, default=1.0)
+    parser.add_argument("--reg-lambda", type=float, default=4.0)
+    parser.add_argument("--gamma", type=float, default=0.0)
+    parser.add_argument("--early-stopping-rounds", type=int, default=100)
+    parser.add_argument("--verbose-eval", type=int, default=0)
+    parser.add_argument("--metrics-path", default="artifacts/reports/ngram_te_xgb_smoke_metrics.json")
+    parser.add_argument("--oof-path", default="artifacts/reports/ngram_te_xgb_smoke_oof.csv")
+    parser.add_argument("--test-pred-path", default="", help="Optional test prediction CSV path.")
+    parser.add_argument(
+        "--reference-v3-oof",
+        default="",
+        help="Optional v3 OOF CSV with columns id,target,candidate_pred to build analysis-oof directly.",
+    )
+    parser.add_argument(
+        "--analysis-oof-path",
+        default="",
+        help="Optional merged analysis OOF path with id,target,reference_pred,candidate_pred.",
+    )
+    return parser.parse_args()
+
+
+def _build_analysis_oof(
+    *,
+    reference_v3_oof_path: str | Path,
+    candidate_oof_path: str | Path,
+    analysis_oof_path: str | Path,
+) -> str:
+    reference = pd.read_csv(reference_v3_oof_path)[["id", "target", "candidate_pred"]].rename(
+        columns={"candidate_pred": "reference_pred"}
+    )
+    candidate = pd.read_csv(candidate_oof_path)[["id", "target", "oof_pred"]].rename(columns={"oof_pred": "candidate_pred"})
+    merged = reference.merge(candidate, on=["id", "target"], how="inner", validate="one_to_one")
+    out_path = ensure_parent_dir(analysis_oof_path)
+    merged.to_csv(out_path, index=False)
+    return str(out_path)
+
+
+def main() -> int:
+    args = parse_args()
+    params = NgramXgbParams(
+        n_estimators=args.n_estimators,
+        learning_rate=args.learning_rate,
+        max_depth=args.max_depth,
+        min_child_weight=args.min_child_weight,
+        subsample=args.subsample,
+        colsample_bytree=args.colsample_bytree,
+        reg_alpha=args.reg_alpha,
+        reg_lambda=args.reg_lambda,
+        gamma=args.gamma,
+        random_state=args.random_state,
+        early_stopping_rounds=args.early_stopping_rounds,
+    )
+    metrics = train_ngram_xgb_cv(
+        train_csv_path=args.train_csv,
+        test_csv_path=args.test_csv,
+        original_csv_path=args.original_csv.strip() or None,
+        params=params,
+        folds=args.folds,
+        inner_folds=args.inner_folds,
+        random_state=args.random_state,
+        smoothing_alpha=args.smoothing_alpha,
+        include_trigrams=bool(args.include_trigrams),
+        ngram_base_columns=_parse_columns(args.ngram_base_columns),
+        verbose_eval=max(int(args.verbose_eval), 0),
+        metrics_path=args.metrics_path,
+        oof_path=args.oof_path,
+        test_pred_path=args.test_pred_path.strip() or None,
+    )
+    if args.reference_v3_oof.strip() and args.analysis_oof_path.strip():
+        metrics["analysis_oof_path"] = _build_analysis_oof(
+            reference_v3_oof_path=args.reference_v3_oof,
+            candidate_oof_path=args.oof_path,
+            analysis_oof_path=args.analysis_oof_path,
+        )
+        Path(args.metrics_path).write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+    print(json.dumps(metrics, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/snapshot_submission_artifacts.py
+++ b/scripts/snapshot_submission_artifacts.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Capture reproducibility snapshot for a submission candidate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _bootstrap import add_src_to_path
+
+add_src_to_path()
+
+from churn_baseline.artifacts import write_json
+from churn_baseline.diagnostics import (
+    collect_git_context,
+    describe_file,
+    load_json_if_exists,
+    utc_now_iso,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Snapshot submission artifacts with hashes")
+    parser.add_argument(
+        "--metrics-path",
+        default="artifacts/reports/train_cv_multiseed_metrics.json",
+        help="Training metrics JSON used by submission.",
+    )
+    parser.add_argument(
+        "--submission-csv",
+        default="",
+        help="Submission CSV to snapshot.",
+    )
+    parser.add_argument(
+        "--weights-json-path",
+        default="",
+        help="Optional weights/config JSON used for blend/stack submissions.",
+    )
+    parser.add_argument(
+        "--extra-path",
+        action="append",
+        default=[],
+        help="Additional artifact path to include (repeatable).",
+    )
+    parser.add_argument("--label", default="", help="Optional human-readable snapshot label.")
+    parser.add_argument(
+        "--out-json",
+        default="artifacts/reports/submission_artifact_snapshot.json",
+        help="Output snapshot JSON path.",
+    )
+    return parser.parse_args()
+
+
+def _extract_model_paths(metrics: dict[str, object]) -> list[str]:
+    paths: list[str] = []
+    maybe_single = metrics.get("model_path")
+    if isinstance(maybe_single, str):
+        paths.append(maybe_single)
+    maybe_multi = metrics.get("model_paths")
+    if isinstance(maybe_multi, list):
+        for item in maybe_multi:
+            if isinstance(item, str):
+                paths.append(item)
+    deduped: list[str] = []
+    seen = set()
+    for path in paths:
+        if path not in seen:
+            seen.add(path)
+            deduped.append(path)
+    return deduped
+
+
+def main() -> int:
+    args = parse_args()
+
+    metrics_payload = load_json_if_exists(args.metrics_path)
+    model_paths = _extract_model_paths(metrics_payload or {})
+
+    artifacts: dict[str, dict[str, object]] = {}
+    artifacts["metrics"] = describe_file(args.metrics_path)
+    if args.submission_csv.strip():
+        artifacts["submission"] = describe_file(args.submission_csv)
+    if args.weights_json_path.strip():
+        artifacts["weights"] = describe_file(args.weights_json_path)
+
+    for idx, model_path in enumerate(model_paths, start=1):
+        artifacts[f"model_{idx}"] = describe_file(model_path)
+
+    for idx, path in enumerate(args.extra_path, start=1):
+        artifacts[f"extra_{idx}"] = describe_file(path)
+
+    summary = {
+        "generated_at_utc": utc_now_iso(),
+        "label": args.label or None,
+        "git": collect_git_context(),
+        "inputs": {
+            "metrics_path": args.metrics_path,
+            "submission_csv": args.submission_csv or None,
+            "weights_json_path": args.weights_json_path or None,
+            "extra_paths": args.extra_path,
+        },
+        "metrics_summary": None,
+        "artifacts": artifacts,
+    }
+    if metrics_payload is not None:
+        summary["metrics_summary"] = {
+            "feature_blocks": metrics_payload.get("feature_blocks"),
+            "feature_count": metrics_payload.get("feature_count"),
+            "oof_auc": metrics_payload.get("oof_auc"),
+            "ensemble_oof_auc": metrics_payload.get("ensemble_oof_auc"),
+            "cv_mean_auc": metrics_payload.get("cv_mean_auc"),
+            "cv_std_auc": metrics_payload.get("cv_std_auc"),
+            "model_paths_count": len(model_paths),
+        }
+
+    write_json(args.out_json, summary)
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/train_cv_multiseed.py
+++ b/scripts/train_cv_multiseed.py
@@ -55,7 +55,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="none",
-        help="Optional feature blocks (A,B,C,G,H,R,S,V,O,P) or none.",
+        help="Optional feature blocks (A,B,C,F,G,H,R,S,V,O,P) or none.",
     )
     parser.add_argument(
         "--stratify-mode",

--- a/scripts/train_cv_multiseed.py
+++ b/scripts/train_cv_multiseed.py
@@ -55,7 +55,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="none",
-        help="Optional feature blocks (A,B,C,F,G,H,R,S,V,O,P) or none.",
+        help="Optional feature blocks (A,B,C,F,G,T,H,R,S,V,O,P) or none.",
     )
     parser.add_argument(
         "--stratify-mode",

--- a/scripts/train_cv_multiseed.py
+++ b/scripts/train_cv_multiseed.py
@@ -9,6 +9,7 @@ from _bootstrap import add_src_to_path
 add_src_to_path()
 
 from churn_baseline.config import CatBoostHyperParams
+from churn_baseline.feature_engineering import normalize_feature_blocks
 from churn_baseline.pipeline import train_baseline_cv_multiseed
 
 
@@ -17,6 +18,14 @@ def _parse_seeds(raw: str) -> list[int]:
     if not tokens:
         raise ValueError("At least one seed is required")
     return [int(token) for token in tokens]
+
+
+def _parse_feature_blocks(raw: str) -> list[str]:
+    normalized_raw = raw.strip().lower()
+    if normalized_raw in {"none", "off", "baseline", ""}:
+        return []
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    return list(normalize_feature_blocks(tokens))
 
 
 def parse_args() -> argparse.Namespace:
@@ -43,6 +52,11 @@ def parse_args() -> argparse.Namespace:
         default="42,2024,3407",
         help="Comma-separated list of integer seeds",
     )
+    parser.add_argument(
+        "--feature-blocks",
+        default="none",
+        help="Optional feature blocks (A,B,C,O,P) or none.",
+    )
     parser.add_argument("--iterations", type=int, default=2200, help="Max boosting rounds")
     parser.add_argument("--learning-rate", type=float, default=0.05, help="Learning rate")
     parser.add_argument("--depth", type=int, default=6, help="Tree depth")
@@ -60,6 +74,7 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     seeds = _parse_seeds(args.seeds)
+    feature_blocks = _parse_feature_blocks(args.feature_blocks)
     params = CatBoostHyperParams(
         iterations=args.iterations,
         learning_rate=args.learning_rate,
@@ -78,6 +93,7 @@ def main() -> int:
         seeds=seeds,
         early_stopping_rounds=args.early_stopping_rounds,
         verbose=args.verbose,
+        feature_blocks=feature_blocks,
     )
     print(json.dumps(metrics, indent=2))
     return 0

--- a/scripts/train_cv_multiseed.py
+++ b/scripts/train_cv_multiseed.py
@@ -55,7 +55,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--feature-blocks",
         default="none",
-        help="Optional feature blocks (A,B,C,O,P) or none.",
+        help="Optional feature blocks (A,B,C,G,H,R,S,V,O,P) or none.",
+    )
+    parser.add_argument(
+        "--stratify-mode",
+        choices=("target", "composite"),
+        default="target",
+        help="CV stratification: target only, or target plus family fallback.",
     )
     parser.add_argument("--iterations", type=int, default=2200, help="Max boosting rounds")
     parser.add_argument("--learning-rate", type=float, default=0.05, help="Learning rate")
@@ -94,6 +100,7 @@ def main() -> int:
         early_stopping_rounds=args.early_stopping_rounds,
         verbose=args.verbose,
         feature_blocks=feature_blocks,
+        stratify_mode=args.stratify_mode,
     )
     print(json.dumps(metrics, indent=2))
     return 0

--- a/src/churn_baseline/cleanroom_baseline.py
+++ b/src/churn_baseline/cleanroom_baseline.py
@@ -1,0 +1,172 @@
+"""Clean-room baseline smoke suite compared directly against incumbent v3."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+
+from .artifacts import ensure_parent_dir, write_json
+from .config import CatBoostHyperParams, ID_COLUMN
+from .diagnostics import OOF_TARGET_COLUMN, load_reference_prediction_frame, utc_now_iso
+from .evaluation import binary_auc
+from .feature_engineering import normalize_feature_blocks
+from .incumbent_v3 import compute_repeated_cv_auc_stats
+from .noise_audit import DEFAULT_V3_OOF_SPEC, DOMINANT_MACROFAMILY
+from .pipeline import train_baseline_cv
+from .validation_protocol import evaluate_validation_protocol
+
+
+@dataclass(frozen=True)
+class CleanroomConfig:
+    label: str
+    feature_blocks: tuple[str, ...]
+    stratify_mode: str = "target"
+
+
+DEFAULT_CLEANROOM_CONFIGS: tuple[CleanroomConfig, ...] = (
+    CleanroomConfig(label="cb_raw", feature_blocks=()),
+    CleanroomConfig(label="cb_r", feature_blocks=("R",)),
+    CleanroomConfig(label="cb_rv", feature_blocks=("R", "V")),
+)
+
+
+def _scan_simple_blend(reference_pred: pd.Series, candidate_pred: pd.Series, target: pd.Series) -> dict[str, Any]:
+    best = {
+        "best_alpha": 0.0,
+        "best_auc": float(binary_auc(target, reference_pred)),
+        "delta_vs_reference": 0.0,
+    }
+    for alpha in (0.05, 0.10, 0.15, 0.20, 0.25):
+        blended = ((1.0 - alpha) * reference_pred.astype(float)) + (alpha * candidate_pred.astype(float))
+        auc = float(binary_auc(target, blended))
+        delta = float(auc - best["best_auc"] + best["delta_vs_reference"])
+        if auc > best["best_auc"] + 1e-12:
+            best = {
+                "best_alpha": float(alpha),
+                "best_auc": auc,
+                "delta_vs_reference": float(auc - float(binary_auc(target, reference_pred))),
+            }
+    return best
+
+
+def run_cleanroom_baseline_suite(
+    *,
+    train_csv_path: str | Path,
+    v3_oof_spec: str = DEFAULT_V3_OOF_SPEC,
+    out_dir: str | Path = "artifacts/reports",
+    model_dir: str | Path = "artifacts/models",
+    configs: Sequence[CleanroomConfig] = DEFAULT_CLEANROOM_CONFIGS,
+    params: CatBoostHyperParams | None = None,
+    folds: int = 2,
+    random_state: int = 42,
+    early_stopping_rounds: int = 60,
+    verbose: int = 0,
+) -> dict[str, Any]:
+    if params is None:
+        params = CatBoostHyperParams(
+            iterations=150,
+            learning_rate=0.05,
+            depth=6,
+            l2_leaf_reg=5.0,
+            random_seed=random_state,
+        )
+
+    out_root = Path(out_dir)
+    model_root = Path(model_dir)
+    reference_frame, _ = load_reference_prediction_frame(
+        reference_oof_spec=v3_oof_spec,
+        id_column=ID_COLUMN,
+        target_column=OOF_TARGET_COLUMN,
+    )
+    reference_target = reference_frame[OOF_TARGET_COLUMN].astype(int)
+    reference_pred = reference_frame["reference_pred"].astype(float)
+    reference_metrics = compute_repeated_cv_auc_stats(reference_target, reference_pred)
+    reference_metrics_path = ensure_parent_dir(out_root / "cleanroom_reference_v3_metrics.json")
+    write_json(reference_metrics_path, reference_metrics)
+
+    rows: list[dict[str, Any]] = []
+    for config in configs:
+        label = f"cleanroom_{config.label}_smoke"
+        model_path = model_root / f"{label}.cbm"
+        metrics_path = out_root / f"{label}_metrics.json"
+        oof_path = out_root / f"{label}_oof.csv"
+        analysis_path = out_root / f"{label}_analysis_oof.csv"
+        candidate_metrics_path = out_root / f"{label}_candidate_metrics.json"
+        verdict_path = out_root / f"validation_protocol_{label}_vs_v3_smoke.json"
+
+        metrics = train_baseline_cv(
+            train_csv_path=train_csv_path,
+            model_path=model_path,
+            metrics_path=metrics_path,
+            oof_path=oof_path,
+            params=params,
+            folds=folds,
+            random_state=random_state,
+            early_stopping_rounds=early_stopping_rounds,
+            verbose=verbose,
+            feature_blocks=config.feature_blocks,
+            stratify_mode=config.stratify_mode,
+        )
+
+        candidate_frame = pd.read_csv(oof_path)
+        analysis_frame = reference_frame[[ID_COLUMN, OOF_TARGET_COLUMN, "reference_pred"]].merge(
+            candidate_frame[[ID_COLUMN, OOF_TARGET_COLUMN, "oof_pred"]].rename(columns={"oof_pred": "candidate_pred"}),
+            how="inner",
+            on=[ID_COLUMN, OOF_TARGET_COLUMN],
+            validate="one_to_one",
+        )
+        analysis_frame.to_csv(analysis_path, index=False)
+
+        candidate_metrics = compute_repeated_cv_auc_stats(
+            analysis_frame[OOF_TARGET_COLUMN],
+            analysis_frame["candidate_pred"],
+        )
+        write_json(candidate_metrics_path, candidate_metrics)
+        verdict = evaluate_validation_protocol(
+            train_csv_path=train_csv_path,
+            test_csv_path="data/raw/test.csv",
+            stage="smoke",
+            analysis_oof_path=analysis_path,
+            target_family_level="segment3",
+            target_family_value=DOMINANT_MACROFAMILY,
+            dominant_family_value=DOMINANT_MACROFAMILY,
+            candidate_metrics_json=candidate_metrics_path,
+            reference_metrics_json=reference_metrics_path,
+            out_json_path=verdict_path,
+        )
+        blend_scan = _scan_simple_blend(
+            reference_pred=analysis_frame["reference_pred"],
+            candidate_pred=analysis_frame["candidate_pred"],
+            target=analysis_frame[OOF_TARGET_COLUMN].astype(int),
+        )
+        rows.append(
+            {
+                "label": label,
+                "feature_blocks": list(normalize_feature_blocks(config.feature_blocks)),
+                "stratify_mode": config.stratify_mode,
+                "oof_auc": float(metrics["oof_auc"]),
+                "delta_vs_v3_oof_auc": float(candidate_metrics["full_auc"] - reference_metrics["full_auc"]),
+                "validation_verdict": verdict["verdict"],
+                "best_blend_alpha_vs_v3": float(blend_scan["best_alpha"]),
+                "best_blend_delta_vs_v3": float(blend_scan["delta_vs_reference"]),
+                "metrics_path": str(metrics_path),
+                "oof_path": str(oof_path),
+                "analysis_oof_path": str(analysis_path),
+                "validation_verdict_path": str(verdict_path),
+            }
+        )
+
+    summary = {
+        "generated_at_utc": utc_now_iso(),
+        "train_csv_path": str(train_csv_path),
+        "reference_v3_oof_spec": str(v3_oof_spec),
+        "reference_oof_auc": float(reference_metrics["full_auc"]),
+        "configs": rows,
+        "best_candidate": max(rows, key=lambda item: item["delta_vs_v3_oof_auc"]) if rows else None,
+        "best_blend_candidate": max(rows, key=lambda item: item["best_blend_delta_vs_v3"]) if rows else None,
+    }
+    return summary

--- a/src/churn_baseline/config.py
+++ b/src/churn_baseline/config.py
@@ -20,6 +20,7 @@ class CatBoostHyperParams:
     random_seed: int = 42
     loss_function: str = "Logloss"
     eval_metric: str = "AUC"
+    monotone_constraints: Dict[str, int] | None = None
 
     def to_catboost_kwargs(self) -> Dict[str, Any]:
         """Return kwargs accepted by CatBoostClassifier."""

--- a/src/churn_baseline/counterfactual_sensitivity.py
+++ b/src/churn_baseline/counterfactual_sensitivity.py
@@ -1,0 +1,499 @@
+"""Counterfactual teacher-sensitivity smoke against incumbent v3."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+import pandas as pd
+
+from .artifacts import ensure_parent_dir, write_json
+from .config import ID_COLUMN, TARGET_COLUMN
+from .data import load_csv
+from .diagnostics import build_family_frame, load_reference_prediction_frame
+from .evaluation import binary_auc
+from .feature_engineering import apply_feature_engineering, normalize_feature_blocks, partition_feature_blocks
+from .modeling import load_model, predict_proba
+from .uncertainty_band import DEFAULT_V3_OOF_SPEC
+
+DEFAULT_COMPONENT_WEIGHTS_JSON = "artifacts/reports/submission_candidate_cb5_xgb3_lgb_r_rvhi_weights.json"
+SUPPORTED_COMPONENTS: tuple[str, ...] = ("cb", "r", "rv")
+SUPPORTED_COUNTERFACTUALS: tuple[str, ...] = (
+    "auto_payment",
+    "paperless_off",
+    "contract_upgrade",
+    "stability_bundle",
+)
+SUPPORTED_SIGNALS: tuple[str, ...] = (
+    "stable_bundle_drop",
+    "mean_positive_drop",
+    "max_positive_drop",
+)
+MIN_MASK_ROWS = 2000
+
+
+def _clip_probability(values: np.ndarray | pd.Series, epsilon: float = 1e-6) -> np.ndarray:
+    return np.clip(np.asarray(values, dtype="float64"), epsilon, 1.0 - epsilon)
+
+
+def _load_v3_reference_frame(
+    *,
+    reference_v3_oof: str,
+) -> tuple[pd.DataFrame, dict[str, Any]]:
+    return load_reference_prediction_frame(
+        reference_oof_spec=reference_v3_oof,
+        id_column=ID_COLUMN,
+        target_column="target",
+    )
+
+
+def _align_reference_prediction(
+    train_df: pd.DataFrame,
+    reference_frame: pd.DataFrame,
+) -> tuple[pd.Series, pd.Series]:
+    required = {ID_COLUMN, "target", "reference_pred"}
+    missing = sorted(required.difference(reference_frame.columns))
+    if missing:
+        raise ValueError(f"reference_frame missing required columns: {missing}")
+
+    merged = train_df[[ID_COLUMN, TARGET_COLUMN]].merge(
+        reference_frame[[ID_COLUMN, "target", "reference_pred"]],
+        how="left",
+        on=ID_COLUMN,
+        validate="one_to_one",
+    )
+    if merged["reference_pred"].isna().any():
+        sample_ids = merged.loc[merged["reference_pred"].isna(), ID_COLUMN].head(5).tolist()
+        raise ValueError(f"reference_frame missing ids from train.csv: {sample_ids}")
+
+    train_target = (train_df[TARGET_COLUMN].astype(str).str.lower() == "yes").astype("int8")
+    reference_target = pd.to_numeric(merged["target"], errors="raise").astype("int8")
+    if not np.array_equal(train_target.to_numpy(dtype="int8"), reference_target.to_numpy(dtype="int8")):
+        raise ValueError("reference_frame target does not align with train.csv")
+
+    reference_pred = pd.Series(
+        pd.to_numeric(merged["reference_pred"], errors="raise").astype("float64").values,
+        index=train_df.index,
+        dtype="float64",
+        name="reference_pred",
+    )
+    return train_target, reference_pred
+
+
+def _load_component_weights(
+    weights_json_path: str | Path,
+    *,
+    allowed_components: Sequence[str],
+) -> tuple[dict[str, float], dict[str, Any]]:
+    payload = json.loads(Path(weights_json_path).read_text(encoding="utf-8"))
+    weights_raw = payload.get("weights")
+    if not isinstance(weights_raw, dict) or not weights_raw:
+        raise ValueError(f"weights json {weights_json_path} does not contain a valid 'weights' object")
+
+    selected = {
+        str(name): float(value)
+        for name, value in weights_raw.items()
+        if str(name) in set(allowed_components)
+    }
+    if not selected:
+        raise ValueError(
+            f"weights json {weights_json_path} does not contain any of the required components {list(allowed_components)}"
+        )
+
+    weight_sum = float(sum(selected.values()))
+    if weight_sum <= 0.0:
+        raise ValueError(f"selected component weights must sum to > 0, got {weight_sum}")
+
+    normalized = {name: float(value / weight_sum) for name, value in selected.items()}
+    component_paths = payload.get("components", {})
+    if not isinstance(component_paths, dict):
+        raise ValueError(f"weights json {weights_json_path} must contain a 'components' mapping")
+    return normalized, component_paths
+
+
+def _prepare_feature_matrix(raw_frame: pd.DataFrame, feature_blocks: Sequence[str] | None) -> pd.DataFrame:
+    normalized_blocks = normalize_feature_blocks(feature_blocks)
+    stateless_blocks, stateful_blocks = partition_feature_blocks(normalized_blocks)
+    if stateful_blocks:
+        raise ValueError(
+            "counterfactual sensitivity smoke only supports stateless blocks. "
+            f"Got stateful blocks: {list(stateful_blocks)}"
+        )
+
+    features = raw_frame.copy()
+    drop_columns = [column for column in (ID_COLUMN, TARGET_COLUMN) if column in features.columns]
+    if drop_columns:
+        features = features.drop(columns=drop_columns)
+    return apply_feature_engineering(features, feature_blocks=stateless_blocks)
+
+
+def _apply_counterfactual(raw_frame: pd.DataFrame, name: str) -> pd.DataFrame:
+    out = raw_frame.copy()
+    payment = out["PaymentMethod"].astype(str)
+    paperless = out["PaperlessBilling"].astype(str)
+    contract = out["Contract"].astype(str)
+
+    if name == "auto_payment":
+        mapped = payment.replace(
+            {
+                "Electronic check": "Bank transfer (automatic)",
+                "Mailed check": "Credit card (automatic)",
+            }
+        )
+        out["PaymentMethod"] = mapped
+        return out
+
+    if name == "paperless_off":
+        out["PaperlessBilling"] = np.where(paperless.eq("Yes"), "No", paperless)
+        return out
+
+    if name == "contract_upgrade":
+        mapped = contract.replace(
+            {
+                "Month-to-month": "One year",
+                "One year": "Two year",
+            }
+        )
+        out["Contract"] = mapped
+        return out
+
+    if name == "stability_bundle":
+        out = _apply_counterfactual(out, "auto_payment")
+        out = _apply_counterfactual(out, "paperless_off")
+        out = _apply_counterfactual(out, "contract_upgrade")
+        return out
+
+    raise ValueError(f"Unsupported counterfactual '{name}'. Available: {list(SUPPORTED_COUNTERFACTUALS)}")
+
+
+def _predict_catboost_average(
+    feature_frame: pd.DataFrame,
+    model_paths: Sequence[str | Path],
+) -> np.ndarray:
+    if not model_paths:
+        raise ValueError("model_paths must not be empty")
+
+    prediction_rows: list[np.ndarray] = []
+    for model_path in model_paths:
+        model = load_model(model_path)
+        prediction_rows.append(predict_proba(model, feature_frame).to_numpy(dtype="float64"))
+    return np.mean(np.column_stack(prediction_rows), axis=1)
+
+
+def _resolve_component_model_paths(
+    component_paths: Mapping[str, Any],
+    *,
+    component: str,
+) -> list[str]:
+    if component == "cb":
+        raw_paths = component_paths.get("cb_models")
+        if not isinstance(raw_paths, list) or not raw_paths:
+            raise ValueError("weights json does not contain a valid 'cb_models' list")
+        return [str(path) for path in raw_paths]
+    if component == "r":
+        model_path = component_paths.get("r_model")
+        if not model_path:
+            raise ValueError("weights json does not contain 'r_model'")
+        return [str(model_path)]
+    if component == "rv":
+        model_path = component_paths.get("rv_model")
+        if not model_path:
+            raise ValueError("weights json does not contain 'rv_model'")
+        return [str(model_path)]
+    raise ValueError(f"Unsupported component '{component}'. Available: {list(SUPPORTED_COMPONENTS)}")
+
+
+def _component_feature_blocks(component: str) -> tuple[str, ...]:
+    if component == "cb":
+        return ()
+    if component == "r":
+        return ("R",)
+    if component == "rv":
+        return ("R", "V")
+    raise ValueError(f"Unsupported component '{component}'. Available: {list(SUPPORTED_COMPONENTS)}")
+
+
+def _predict_component_scenarios(
+    raw_focus_frame: pd.DataFrame,
+    *,
+    component: str,
+    model_paths: Sequence[str | Path],
+    counterfactuals: Sequence[str],
+) -> dict[str, np.ndarray]:
+    scenario_frames: dict[str, pd.DataFrame] = {"base": raw_focus_frame}
+    for name in counterfactuals:
+        scenario_frames[name] = _apply_counterfactual(raw_focus_frame, name)
+
+    predictions: dict[str, np.ndarray] = {}
+    feature_blocks = _component_feature_blocks(component)
+    for scenario_name, scenario_frame in scenario_frames.items():
+        feature_frame = _prepare_feature_matrix(scenario_frame, feature_blocks)
+        predictions[scenario_name] = _predict_catboost_average(feature_frame, model_paths)
+    return predictions
+
+
+def _build_counterfactual_signals(
+    raw_focus_frame: pd.DataFrame,
+    *,
+    component_weights: Mapping[str, float],
+    component_paths: Mapping[str, Any],
+    counterfactuals: Sequence[str],
+) -> tuple[pd.DataFrame, dict[str, Any]]:
+    weighted_base = np.zeros(len(raw_focus_frame), dtype="float64")
+    weighted_counterfactuals = {
+        name: np.zeros(len(raw_focus_frame), dtype="float64")
+        for name in counterfactuals
+    }
+    component_rows: list[dict[str, Any]] = []
+
+    for component, weight in component_weights.items():
+        model_paths = _resolve_component_model_paths(component_paths, component=component)
+        scenario_predictions = _predict_component_scenarios(
+            raw_focus_frame,
+            component=component,
+            model_paths=model_paths,
+            counterfactuals=counterfactuals,
+        )
+        weighted_base += float(weight) * scenario_predictions["base"]
+        component_rows.append(
+            {
+                "component": str(component),
+                "weight": float(weight),
+                "model_count": int(len(model_paths)),
+                "base_pred_mean": float(np.mean(scenario_predictions["base"])),
+                "base_pred_std": float(np.std(scenario_predictions["base"], ddof=0)),
+            }
+        )
+        for name in counterfactuals:
+            weighted_counterfactuals[name] += float(weight) * scenario_predictions[name]
+            component_rows[-1][f"{name}_delta_mean"] = float(
+                np.mean(scenario_predictions[name] - scenario_predictions["base"])
+            )
+
+    signal_frame = pd.DataFrame(index=raw_focus_frame.index)
+    signal_frame["cf_base_teacher_pred"] = _clip_probability(weighted_base)
+
+    positive_drop_columns: list[str] = []
+    for name in counterfactuals:
+        scenario_pred = _clip_probability(weighted_counterfactuals[name])
+        signal_frame[f"cf_{name}_pred"] = scenario_pred
+        signal_frame[f"cf_{name}_delta"] = scenario_pred - signal_frame["cf_base_teacher_pred"].to_numpy(dtype="float64")
+        signal_frame[f"cf_{name}_positive_drop"] = np.clip(
+            signal_frame["cf_base_teacher_pred"].to_numpy(dtype="float64") - scenario_pred,
+            a_min=0.0,
+            a_max=None,
+        )
+        positive_drop_columns.append(f"cf_{name}_positive_drop")
+
+    positive_drop_matrix = signal_frame[positive_drop_columns].to_numpy(dtype="float64")
+    signal_frame["cf_mean_positive_drop"] = positive_drop_matrix.mean(axis=1)
+    signal_frame["cf_max_positive_drop"] = positive_drop_matrix.max(axis=1)
+    signal_frame["cf_stable_bundle_drop"] = signal_frame["cf_stability_bundle_positive_drop"].astype("float64")
+
+    summary = {
+        "component_rows": component_rows,
+        "counterfactuals": list(counterfactuals),
+        "signal_summary": {
+            "mean_positive_drop_mean": float(signal_frame["cf_mean_positive_drop"].mean()),
+            "mean_positive_drop_std": float(signal_frame["cf_mean_positive_drop"].std(ddof=0)),
+            "max_positive_drop_mean": float(signal_frame["cf_max_positive_drop"].mean()),
+            "stable_bundle_drop_mean": float(signal_frame["cf_stable_bundle_drop"].mean()),
+        },
+    }
+    return signal_frame, summary
+
+
+def _build_focus_mask(
+    train_df: pd.DataFrame,
+    *,
+    reference_pred: pd.Series,
+    target_family_level: str,
+    target_family_value: str,
+    reference_band_half_width: float | None,
+) -> tuple[pd.Series, dict[str, Any]]:
+    if target_family_level not in {"segment3", "segment5"}:
+        raise ValueError("target_family_level must be 'segment3' or 'segment5'")
+    if reference_band_half_width is not None and (reference_band_half_width <= 0.0 or reference_band_half_width >= 0.5):
+        raise ValueError(f"reference_band_half_width must be in (0, 0.5), got {reference_band_half_width}")
+
+    family_frame = build_family_frame(train_df)
+    family_mask = family_frame[target_family_level].astype(str).eq(str(target_family_value))
+    if reference_band_half_width is None:
+        final_mask = family_mask
+    else:
+        band_mask = reference_pred.sub(0.5).abs().le(float(reference_band_half_width))
+        final_mask = family_mask & band_mask
+
+    final_rows = int(final_mask.sum())
+    if final_rows < MIN_MASK_ROWS:
+        raise ValueError(
+            f"counterfactual focus mask selects only {final_rows} rows. Minimum required: {MIN_MASK_ROWS}"
+        )
+
+    summary = {
+        "target_family_level": str(target_family_level),
+        "target_family_value": str(target_family_value),
+        "reference_band_half_width": None if reference_band_half_width is None else float(reference_band_half_width),
+        "family_rows": int(family_mask.sum()),
+        "mask_rows": final_rows,
+        "mask_rate": float(final_rows / max(len(train_df), 1)),
+        "reference_mean_on_mask": float(reference_pred.loc[final_mask].mean()),
+        "reference_std_on_mask": float(reference_pred.loc[final_mask].std(ddof=0)),
+    }
+    return final_mask.astype(bool), summary
+
+
+def _parse_signal_value(signal_frame: pd.DataFrame, signal_name: str) -> pd.Series:
+    column_map = {
+        "stable_bundle_drop": "cf_stable_bundle_drop",
+        "mean_positive_drop": "cf_mean_positive_drop",
+        "max_positive_drop": "cf_max_positive_drop",
+    }
+    if signal_name not in column_map:
+        raise ValueError(f"Unsupported signal_name '{signal_name}'. Available: {list(SUPPORTED_SIGNALS)}")
+    return signal_frame[column_map[signal_name]].astype("float64")
+
+
+def _scan_counterfactual_candidate(
+    y: pd.Series,
+    reference_pred: pd.Series,
+    mask: pd.Series,
+    signal_frame: pd.DataFrame,
+    *,
+    signal_names: Sequence[str],
+    alpha_grid: Sequence[float],
+) -> tuple[pd.Series, dict[str, Any], list[dict[str, Any]]]:
+    if not signal_names:
+        raise ValueError("signal_names must not be empty")
+    if not alpha_grid:
+        raise ValueError("alpha_grid must not be empty")
+
+    best_auc = float(binary_auc(y, reference_pred))
+    best_pred = reference_pred.copy()
+    best_row = {
+        "signal_name": "reference",
+        "alpha": 0.0,
+        "candidate_oof_auc": best_auc,
+        "delta_vs_reference_oof_auc": 0.0,
+        "mask_rows": int(mask.sum()),
+    }
+    scan_rows: list[dict[str, Any]] = [dict(best_row)]
+
+    for signal_name in signal_names:
+        signal = _parse_signal_value(signal_frame, signal_name)
+        for alpha in alpha_grid:
+            candidate = reference_pred.copy()
+            candidate.loc[mask] = _clip_probability(
+                reference_pred.loc[mask].to_numpy(dtype="float64") + float(alpha) * signal.loc[mask].to_numpy(dtype="float64")
+            )
+            auc = float(binary_auc(y, candidate))
+            row = {
+                "signal_name": str(signal_name),
+                "alpha": float(alpha),
+                "candidate_oof_auc": auc,
+                "delta_vs_reference_oof_auc": float(auc - best_auc),
+                "mask_rows": int(mask.sum()),
+                "signal_mean_on_mask": float(signal.loc[mask].mean()),
+                "signal_std_on_mask": float(signal.loc[mask].std(ddof=0)),
+            }
+            scan_rows.append(row)
+            if auc > best_row["candidate_oof_auc"] + 1e-15:
+                best_row = dict(row)
+                best_pred = candidate
+    best_row["reference_oof_auc"] = best_auc
+    best_row["delta_vs_reference_oof_auc"] = float(best_row["candidate_oof_auc"] - best_auc)
+    return best_pred, best_row, scan_rows
+
+
+def run_counterfactual_sensitivity_smoke(
+    *,
+    train_csv_path: str | Path,
+    reference_v3_oof: str,
+    component_weights_json: str | Path,
+    target_family_level: str,
+    target_family_value: str,
+    reference_band_half_width: float | None,
+    alpha_grid: Sequence[float],
+    counterfactuals: Sequence[str],
+    signal_names: Sequence[str],
+    metrics_path: str | Path,
+    oof_path: str | Path,
+) -> dict[str, Any]:
+    train_df = load_csv(train_csv_path)
+    target, reference_pred = _align_reference_prediction(
+        train_df,
+        _load_v3_reference_frame(reference_v3_oof=reference_v3_oof)[0],
+    )
+    focus_mask, mask_summary = _build_focus_mask(
+        train_df,
+        reference_pred=reference_pred,
+        target_family_level=target_family_level,
+        target_family_value=target_family_value,
+        reference_band_half_width=reference_band_half_width,
+    )
+
+    raw_focus_frame = train_df.loc[focus_mask].copy()
+    component_weights, component_paths = _load_component_weights(
+        component_weights_json,
+        allowed_components=SUPPORTED_COMPONENTS,
+    )
+    signal_frame, signal_summary = _build_counterfactual_signals(
+        raw_focus_frame,
+        component_weights=component_weights,
+        component_paths=component_paths,
+        counterfactuals=counterfactuals,
+    )
+
+    full_signal_frame = pd.DataFrame(index=train_df.index)
+    full_signal_frame["cf_mean_positive_drop"] = 0.0
+    full_signal_frame["cf_max_positive_drop"] = 0.0
+    full_signal_frame["cf_stable_bundle_drop"] = 0.0
+    for column in signal_frame.columns:
+        full_signal_frame[column] = 0.0
+        full_signal_frame.loc[focus_mask, column] = signal_frame[column].to_numpy(dtype="float64")
+
+    candidate_pred, best_row, scan_rows = _scan_counterfactual_candidate(
+        target,
+        reference_pred,
+        focus_mask,
+        full_signal_frame,
+        signal_names=signal_names,
+        alpha_grid=alpha_grid,
+    )
+
+    analysis_oof = pd.DataFrame(
+        {
+            ID_COLUMN: train_df[ID_COLUMN].to_numpy(),
+            "target": target.to_numpy(dtype="int8"),
+            "reference_pred": reference_pred.to_numpy(dtype="float64"),
+            "candidate_pred": candidate_pred.to_numpy(dtype="float64"),
+        }
+    )
+    ensure_parent_dir(oof_path)
+    analysis_oof.to_csv(oof_path, index=False)
+
+    metrics = {
+        "experiment_name": "counterfactual_teacher_sensitivity",
+        "reference_v3_oof": str(reference_v3_oof),
+        "component_weights_json": str(component_weights_json),
+        "component_weights_subset": {name: float(value) for name, value in component_weights.items()},
+        "target_family_level": str(target_family_level),
+        "target_family_value": str(target_family_value),
+        "reference_band_half_width": None if reference_band_half_width is None else float(reference_band_half_width),
+        "counterfactuals": [str(name) for name in counterfactuals],
+        "signal_names": [str(name) for name in signal_names],
+        "mask_summary": mask_summary,
+        "signal_summary": signal_summary,
+        "best_signal_name": str(best_row["signal_name"]),
+        "best_alpha": float(best_row["alpha"]),
+        "reference_oof_auc": float(best_row["reference_oof_auc"]),
+        "candidate_oof_auc": float(best_row["candidate_oof_auc"]),
+        "delta_vs_reference_oof_auc": float(best_row["delta_vs_reference_oof_auc"]),
+        "scan_rows": scan_rows,
+        "oof_path": str(oof_path),
+        "metrics_path": str(metrics_path),
+    }
+    write_json(metrics_path, metrics)
+    return metrics

--- a/src/churn_baseline/diagnostics.py
+++ b/src/churn_baseline/diagnostics.py
@@ -20,13 +20,11 @@ from .config import ID_COLUMN, TARGET_COLUMN
 from .data import encode_target, infer_categorical_columns, load_csv, prepare_test_features, prepare_train_features
 from .evaluation import binary_auc
 from .feature_engineering import (
-    BLOCK_G,
-    apply_coverage_backoff_features,
     apply_feature_engineering,
-    fit_coverage_backoff_state,
     normalize_feature_blocks,
     partition_feature_blocks,
 )
+from .pipeline import _transform_pair_with_stateful_blocks
 
 
 PASS_STATUS = "PASS"
@@ -696,11 +694,7 @@ def _transform_train_valid_for_generalization(
     stateless_blocks, stateful_blocks = partition_feature_blocks(normalized_blocks)
     x_train, y_train = prepare_train_features(train_df, drop_id=True, feature_blocks=stateless_blocks)
     x_valid, y_valid = prepare_train_features(valid_df, drop_id=True, feature_blocks=stateless_blocks)
-
-    if BLOCK_G in stateful_blocks:
-        coverage_state = fit_coverage_backoff_state(x_train)
-        x_train = apply_coverage_backoff_features(x_train, coverage_state)
-        x_valid = apply_coverage_backoff_features(x_valid, coverage_state)
+    x_train, x_valid = _transform_pair_with_stateful_blocks(x_train, x_valid, stateful_blocks)
 
     cat_columns = infer_categorical_columns(x_train)
     return x_train, y_train, x_valid, y_valid, cat_columns

--- a/src/churn_baseline/diagnostics.py
+++ b/src/churn_baseline/diagnostics.py
@@ -15,9 +15,18 @@ import pandas as pd
 from catboost import CatBoostClassifier
 from sklearn.model_selection import StratifiedKFold
 
-from .data import infer_categorical_columns
+from .artifacts import write_json
+from .config import ID_COLUMN, TARGET_COLUMN
+from .data import encode_target, infer_categorical_columns, load_csv, prepare_test_features, prepare_train_features
 from .evaluation import binary_auc
-from .feature_engineering import normalize_feature_blocks
+from .feature_engineering import (
+    BLOCK_G,
+    apply_coverage_backoff_features,
+    apply_feature_engineering,
+    fit_coverage_backoff_state,
+    normalize_feature_blocks,
+    partition_feature_blocks,
+)
 
 
 PASS_STATUS = "PASS"
@@ -33,6 +42,17 @@ class OOFInputSpec:
     name: str
     path: str
     prediction_column: str | None = None
+
+
+DEFAULT_REFERENCE_OOF_SPECS: tuple[str, ...] = (
+    "cb=artifacts/reports/train_cv_multiseed_gate_s5_hiiter_oof.csv#oof_ensemble",
+    "xgb=artifacts/reports/train_xgboost_cv_multiseed_hiiter_oof.csv#oof_ensemble",
+    "lgb=artifacts/reports/train_lightgbm_cv_full_hiiter_oof.csv#oof_pred",
+    "r=artifacts/reports/fe_blockR_hiiter_oof.csv#oof_pred",
+    "rv=artifacts/reports/fe_blockRV_hiiter_oof.csv#oof_pred",
+)
+
+SUPPORTED_FAMILY_LEVELS = ("segment3", "segment5")
 
 
 def utc_now_iso() -> str:
@@ -494,6 +514,391 @@ def load_merged_oof_matrix(
     if merged is None or merged.empty:
         raise ValueError("Merged OOF matrix is empty.")
     return merged, model_columns
+
+
+def load_reference_prediction_frame(
+    *,
+    reference_oof_spec: str | None = None,
+    oof_specs: Sequence[str] | None = None,
+    reference_weights_json: str | Path | None = None,
+    id_column: str = ID_COLUMN,
+    target_column: str = OOF_TARGET_COLUMN,
+) -> tuple[pd.DataFrame, dict[str, Any]]:
+    """Load reference predictions from either a direct OOF file or a weighted blend."""
+    def _normalize_target_column(frame: pd.DataFrame) -> pd.DataFrame:
+        out = frame.copy()
+        target_series = out[target_column]
+        if pd.api.types.is_numeric_dtype(target_series):
+            out[target_column] = pd.to_numeric(target_series, errors="raise").astype("int8")
+        else:
+            out[target_column] = encode_target(target_series)
+        return out
+
+    if reference_oof_spec:
+        spec = parse_oof_input_spec(f"reference={reference_oof_spec}")
+        merged, _ = load_merged_oof_matrix((spec,), id_column=id_column, target_column=target_column)
+        merged = _normalize_target_column(merged)
+        reference_col = "pred_reference"
+        return (
+            merged[[id_column, target_column, reference_col]].rename(columns={reference_col: "reference_pred"}),
+            {
+                "mode": "direct_oof",
+                "reference_oof_spec": reference_oof_spec,
+            },
+        )
+
+    specs_raw = list(oof_specs or DEFAULT_REFERENCE_OOF_SPECS)
+    specs = [parse_oof_input_spec(raw) for raw in specs_raw]
+    merged, model_columns = load_merged_oof_matrix(specs, id_column=id_column, target_column=target_column)
+    merged = _normalize_target_column(merged)
+    if reference_weights_json is None:
+        raise ValueError("reference_weights_json is required when reference_oof_spec is not provided.")
+
+    payload = json.loads(Path(reference_weights_json).read_text(encoding="utf-8"))
+    weights_raw = payload.get("weights")
+    if not isinstance(weights_raw, dict) or not weights_raw:
+        raise ValueError(f"Could not find weights in {reference_weights_json}")
+
+    weights: dict[str, float] = {}
+    for name, value in weights_raw.items():
+        column = f"pred_{name}"
+        if column not in merged.columns:
+            raise ValueError(
+                f"Weight '{name}' from {reference_weights_json} does not match merged OOF columns {model_columns}."
+            )
+        weights[column] = float(value)
+
+    reference_pred = np.zeros(len(merged), dtype="float64")
+    for column, weight in weights.items():
+        reference_pred += merged[column].to_numpy(dtype="float64") * float(weight)
+
+    out = merged[[id_column, target_column]].copy()
+    out["reference_pred"] = reference_pred
+    return (
+        out,
+        {
+            "mode": "weighted_oof_blend",
+            "reference_weights_json": str(reference_weights_json),
+            "oof_specs": specs_raw,
+            "weights": {column.replace("pred_", ""): float(weight) for column, weight in weights.items()},
+        },
+    )
+
+
+def build_family_frame(
+    frame: pd.DataFrame,
+    *,
+    include_id: bool = True,
+) -> pd.DataFrame:
+    """Build reusable family keys from raw train/test rows."""
+    required = ("PaymentMethod", "Contract", "InternetService", "PaperlessBilling", "tenure")
+    missing = [column for column in required if column not in frame.columns]
+    if missing:
+        raise ValueError(f"Cannot build families; missing columns: {missing}")
+
+    work = frame.copy()
+    if TARGET_COLUMN in work.columns:
+        work = work.drop(columns=[TARGET_COLUMN])
+    if not include_id and ID_COLUMN in work.columns:
+        work = work.drop(columns=[ID_COLUMN])
+
+    engineered = apply_feature_engineering(work, feature_blocks=["A"])
+    out = pd.DataFrame(index=engineered.index)
+    if include_id and ID_COLUMN in frame.columns:
+        out[ID_COLUMN] = frame[ID_COLUMN].values
+    out["segment3"] = (
+        engineered["PaymentMethod"].astype(str)
+        + "__"
+        + engineered["Contract"].astype(str)
+        + "__"
+        + engineered["InternetService"].astype(str)
+    )
+    out["segment5"] = (
+        engineered["PaymentMethod"].astype(str)
+        + "__"
+        + engineered["Contract"].astype(str)
+        + "__"
+        + engineered["InternetService"].astype(str)
+        + "__"
+        + engineered["PaperlessBilling"].astype(str)
+        + "__"
+        + engineered["tenure_bin"].astype(str)
+    )
+    out["tenure_bin"] = engineered["tenure_bin"].astype(str)
+    return out
+
+
+def summarize_reference_family_metrics(
+    analysis_frame: pd.DataFrame,
+    *,
+    family_level: str,
+    test_family_counts: pd.Series | None = None,
+) -> pd.DataFrame:
+    """Aggregate reference metrics by family."""
+    if family_level not in SUPPORTED_FAMILY_LEVELS:
+        raise ValueError(f"Unsupported family_level '{family_level}'. Supported: {SUPPORTED_FAMILY_LEVELS}")
+
+    family_column = family_level
+    y_true = analysis_frame[OOF_TARGET_COLUMN].astype(int)
+    reference_pred = analysis_frame["reference_pred"].astype("float64")
+    reference_loss = -(y_true * np.log(reference_pred.clip(1e-6, 1.0 - 1e-6)) + (1.0 - y_true) * np.log((1.0 - reference_pred).clip(1e-6, 1.0 - 1e-6)))
+    work = analysis_frame[[family_column]].copy()
+    work["target"] = y_true.values
+    work["reference_pred"] = reference_pred.values
+    work["reference_loss"] = reference_loss.values
+
+    total_rows = float(len(work))
+    rows: list[dict[str, Any]] = []
+    for family_value, part in work.groupby(family_column, dropna=False):
+        positives = int(part["target"].sum())
+        family_auc = None
+        if part["target"].nunique(dropna=False) >= 2:
+            family_auc = float(binary_auc(part["target"], part["reference_pred"]))
+        test_rows = None
+        if test_family_counts is not None:
+            test_rows = int(test_family_counts.get(str(family_value), 0))
+        mean_loss = float(part["reference_loss"].mean())
+        rows.append(
+            {
+                "family_level": family_level,
+                "family_value": str(family_value),
+                "train_rows": int(len(part)),
+                "test_rows": test_rows,
+                "positive_rows": positives,
+                "positive_rate": float(part["target"].mean()),
+                "reference_auc": family_auc,
+                "reference_logloss": mean_loss,
+                "reference_logloss_contribution": float(mean_loss * float(len(part)) / total_rows),
+            }
+        )
+
+    summary = pd.DataFrame(rows)
+    if summary.empty:
+        return summary
+    if "test_rows" in summary.columns:
+        test_rows_series = summary["test_rows"].fillna(0).astype("float64")
+        summary["test_train_ratio"] = (test_rows_series / summary["train_rows"].clip(lower=1).astype("float64")).astype(
+            "float64"
+        )
+    return summary.sort_values(
+        by=["reference_logloss_contribution", "train_rows"],
+        ascending=[False, False],
+    ).reset_index(drop=True)
+
+
+def _transform_train_valid_for_generalization(
+    train_df: pd.DataFrame,
+    valid_df: pd.DataFrame,
+    *,
+    feature_blocks: Sequence[str] | None,
+) -> tuple[pd.DataFrame, pd.Series, pd.DataFrame, pd.Series, list[str]]:
+    normalized_blocks = normalize_feature_blocks(feature_blocks)
+    stateless_blocks, stateful_blocks = partition_feature_blocks(normalized_blocks)
+    x_train, y_train = prepare_train_features(train_df, drop_id=True, feature_blocks=stateless_blocks)
+    x_valid, y_valid = prepare_train_features(valid_df, drop_id=True, feature_blocks=stateless_blocks)
+
+    if BLOCK_G in stateful_blocks:
+        coverage_state = fit_coverage_backoff_state(x_train)
+        x_train = apply_coverage_backoff_features(x_train, coverage_state)
+        x_valid = apply_coverage_backoff_features(x_valid, coverage_state)
+
+    cat_columns = infer_categorical_columns(x_train)
+    return x_train, y_train, x_valid, y_valid, cat_columns
+
+
+def evaluate_family_leaveout_generalization(
+    train_df: pd.DataFrame,
+    *,
+    family_assignments: pd.Series,
+    family_values: Sequence[str],
+    feature_blocks: Sequence[str] | None,
+    iterations: int,
+    learning_rate: float,
+    depth: int,
+    l2_leaf_reg: float,
+    random_seed: int,
+) -> pd.DataFrame:
+    """Train without selected families and score them as unseen cohorts."""
+    if len(train_df) != len(family_assignments):
+        raise ValueError("train_df and family_assignments must have the same length.")
+
+    rows: list[dict[str, Any]] = []
+    for family_value in family_values:
+        valid_mask = family_assignments.astype(str).eq(str(family_value))
+        train_part = train_df.loc[~valid_mask].copy()
+        valid_part = train_df.loc[valid_mask].copy()
+        if valid_part.empty:
+            continue
+
+        x_train, y_train, x_valid, y_valid, cat_columns = _transform_train_valid_for_generalization(
+            train_part,
+            valid_part,
+            feature_blocks=feature_blocks,
+        )
+
+        model = CatBoostClassifier(
+            iterations=int(iterations),
+            learning_rate=float(learning_rate),
+            depth=int(depth),
+            l2_leaf_reg=float(l2_leaf_reg),
+            loss_function="Logloss",
+            eval_metric="AUC",
+            random_seed=int(random_seed),
+            allow_writing_files=False,
+        )
+        model.fit(x_train, y_train, cat_features=cat_columns, verbose=False)
+        pred_valid = model.predict_proba(x_valid)[:, 1]
+        pred_valid_series = pd.Series(pred_valid, index=valid_part.index, dtype="float64")
+
+        auc_value = None
+        if y_valid.nunique(dropna=False) >= 2:
+            auc_value = float(binary_auc(y_valid, pred_valid_series))
+        loss_value = float(
+            -(
+                y_valid.astype("float64") * np.log(pred_valid_series.clip(1e-6, 1.0 - 1e-6))
+                + (1.0 - y_valid.astype("float64")) * np.log((1.0 - pred_valid_series).clip(1e-6, 1.0 - 1e-6))
+            ).mean()
+        )
+        rows.append(
+            {
+                "family_value": str(family_value),
+                "lofo_auc": auc_value,
+                "lofo_logloss": loss_value,
+                "lofo_rows": int(len(valid_part)),
+                "lofo_positive_rate": float(y_valid.mean()),
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def run_family_generalization_compass(
+    *,
+    train_csv_path: str | Path,
+    test_csv_path: str | Path,
+    family_level: str,
+    feature_blocks: Sequence[str] | None,
+    top_k_families: int,
+    min_train_rows: int,
+    min_test_rows: int,
+    iterations: int,
+    learning_rate: float,
+    depth: int,
+    l2_leaf_reg: float,
+    random_seed: int,
+    reference_oof_spec: str | None = None,
+    oof_specs: Sequence[str] | None = None,
+    reference_weights_json: str | Path | None = None,
+    out_json_path: str | Path | None = None,
+    out_csv_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Build ranked family generalization compass using leave-one-family-out retraining."""
+    if family_level not in SUPPORTED_FAMILY_LEVELS:
+        raise ValueError(f"Unsupported family_level '{family_level}'. Supported: {SUPPORTED_FAMILY_LEVELS}")
+
+    train_df = load_csv(train_csv_path)
+    test_df = load_csv(test_csv_path)
+    family_train = build_family_frame(train_df)
+    family_test = build_family_frame(test_df)
+    reference_frame, reference_source = load_reference_prediction_frame(
+        reference_oof_spec=reference_oof_spec,
+        oof_specs=oof_specs,
+        reference_weights_json=reference_weights_json,
+        id_column=ID_COLUMN,
+        target_column=OOF_TARGET_COLUMN,
+    )
+
+    analysis = train_df[[ID_COLUMN, TARGET_COLUMN]].copy().merge(
+        family_train[[ID_COLUMN, "segment3", "segment5"]],
+        how="inner",
+        on=ID_COLUMN,
+        validate="one_to_one",
+    )
+    analysis = analysis.merge(
+        reference_frame[[ID_COLUMN, OOF_TARGET_COLUMN, "reference_pred"]],
+        how="inner",
+        on=ID_COLUMN,
+        validate="one_to_one",
+    )
+    if analysis.empty:
+        raise ValueError("Merged family generalization analysis frame is empty.")
+    train_target_encoded = encode_target(analysis[TARGET_COLUMN])
+    reference_target = analysis[OOF_TARGET_COLUMN].astype("int8")
+    if not np.array_equal(train_target_encoded.to_numpy(dtype="int8"), reference_target.to_numpy(dtype="int8")):
+        raise ValueError("Reference OOF target does not align with train.csv target labels.")
+    analysis = analysis.drop(columns=[OOF_TARGET_COLUMN]).rename(columns={TARGET_COLUMN: OOF_TARGET_COLUMN})
+    analysis[OOF_TARGET_COLUMN] = train_target_encoded.astype("int8").values
+
+    test_family_counts = family_test[family_level].astype(str).value_counts(dropna=False)
+    reference_summary = summarize_reference_family_metrics(
+        analysis,
+        family_level=family_level,
+        test_family_counts=test_family_counts,
+    )
+    gated = reference_summary[
+        reference_summary["train_rows"].ge(int(min_train_rows))
+        & reference_summary["test_rows"].fillna(0).astype(int).ge(int(min_test_rows))
+    ].copy()
+    selected = gated.head(int(top_k_families)).copy()
+
+    lofo = evaluate_family_leaveout_generalization(
+        train_df=train_df,
+        family_assignments=family_train[family_level],
+        family_values=selected["family_value"].tolist(),
+        feature_blocks=feature_blocks,
+        iterations=iterations,
+        learning_rate=learning_rate,
+        depth=depth,
+        l2_leaf_reg=l2_leaf_reg,
+        random_seed=random_seed,
+    )
+
+    combined = reference_summary.merge(lofo, how="left", on="family_value", validate="one_to_one")
+    if not combined.empty:
+        combined["generalization_gap_auc"] = combined["reference_auc"] - combined["lofo_auc"]
+        combined["generalization_gap_logloss"] = combined["lofo_logloss"] - combined["reference_logloss"]
+        combined["generalization_gap_logloss_contribution"] = (
+            combined["generalization_gap_logloss"] * combined["train_rows"].astype("float64") / float(len(train_df))
+        )
+
+    summary = {
+        "generated_at_utc": utc_now_iso(),
+        "train_csv_path": str(train_csv_path),
+        "test_csv_path": str(test_csv_path),
+        "family_level": family_level,
+        "feature_blocks": list(normalize_feature_blocks(feature_blocks)),
+        "reference_source": reference_source,
+        "selection": {
+            "top_k_families": int(top_k_families),
+            "min_train_rows": int(min_train_rows),
+            "min_test_rows": int(min_test_rows),
+            "eligible_family_count": int(len(gated)),
+            "evaluated_family_count": int(lofo["family_value"].nunique()) if not lofo.empty else 0,
+        },
+        "model_params": {
+            "iterations": int(iterations),
+            "learning_rate": float(learning_rate),
+            "depth": int(depth),
+            "l2_leaf_reg": float(l2_leaf_reg),
+            "random_seed": int(random_seed),
+        },
+        "top_reference_risk_families": reference_summary.head(min(int(top_k_families), len(reference_summary))).to_dict(
+            orient="records"
+        ),
+        "top_generalization_gap_families": combined.dropna(subset=["generalization_gap_logloss"]).sort_values(
+            by=["generalization_gap_logloss_contribution", "generalization_gap_auc"],
+            ascending=[False, False],
+            na_position="last",
+        ).head(min(int(top_k_families), len(combined))).to_dict(orient="records"),
+    }
+
+    if out_csv_path is not None:
+        out_csv = Path(out_csv_path)
+        out_csv.parent.mkdir(parents=True, exist_ok=True)
+        combined.to_csv(out_csv, index=False)
+    if out_json_path is not None:
+        write_json(out_json_path, summary)
+    return summary
 
 
 def normalize_weights(weights: np.ndarray) -> np.ndarray:

--- a/src/churn_baseline/diagnostics.py
+++ b/src/churn_baseline/diagnostics.py
@@ -1,0 +1,693 @@
+"""Diagnostics utilities for CV-vs-leaderboard gap analysis."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+from catboost import CatBoostClassifier
+from sklearn.model_selection import StratifiedKFold
+
+from .data import infer_categorical_columns
+from .evaluation import binary_auc
+from .feature_engineering import normalize_feature_blocks
+
+
+PASS_STATUS = "PASS"
+WARN_STATUS = "WARN"
+FAIL_STATUS = "FAIL"
+OOF_TARGET_COLUMN = "target"
+
+
+@dataclass(frozen=True)
+class OOFInputSpec:
+    """Input descriptor for OOF artifact."""
+
+    name: str
+    path: str
+    prediction_column: str | None = None
+
+
+def utc_now_iso() -> str:
+    """Return current UTC timestamp in ISO-8601."""
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def parse_feature_blocks_arg(raw: str) -> list[str]:
+    """Parse CLI feature block string into normalized feature blocks."""
+    normalized_raw = raw.strip().lower()
+    if normalized_raw in {"none", "off", "baseline", ""}:
+        return []
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    return list(normalize_feature_blocks(tokens))
+
+
+def make_check(name: str, status: str, details: dict[str, Any]) -> dict[str, Any]:
+    """Build a structured check row."""
+    if status not in {PASS_STATUS, WARN_STATUS, FAIL_STATUS}:
+        raise ValueError(f"Unsupported check status '{status}'")
+    return {"name": name, "status": status, "details": details}
+
+
+def summarize_checks(checks: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate check statuses and counters."""
+    counters = {PASS_STATUS: 0, WARN_STATUS: 0, FAIL_STATUS: 0}
+    for item in checks:
+        status = str(item.get("status", "")).upper()
+        if status in counters:
+            counters[status] += 1
+
+    if counters[FAIL_STATUS] > 0:
+        overall = FAIL_STATUS
+    elif counters[WARN_STATUS] > 0:
+        overall = WARN_STATUS
+    else:
+        overall = PASS_STATUS
+
+    return {
+        "overall_status": overall,
+        "check_counts": {
+            "pass": int(counters[PASS_STATUS]),
+            "warn": int(counters[WARN_STATUS]),
+            "fail": int(counters[FAIL_STATUS]),
+            "total": int(sum(counters.values())),
+        },
+    }
+
+
+def load_json_if_exists(path: str | Path) -> dict[str, Any] | None:
+    """Load JSON file if path exists; return None otherwise."""
+    input_path = Path(path)
+    if not input_path.exists():
+        return None
+    with input_path.open("r", encoding="utf-8") as fh:
+        payload = json.load(fh)
+    if isinstance(payload, dict):
+        return payload
+    raise ValueError(f"Expected JSON object in {input_path}, got {type(payload).__name__}")
+
+
+def sha256_file(path: str | Path, chunk_size: int = 1 << 20) -> str:
+    """Calculate SHA-256 digest for a file."""
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as fh:
+        while True:
+            chunk = fh.read(chunk_size)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def describe_file(path: str | Path) -> dict[str, Any]:
+    """Collect file metadata and hash if file exists."""
+    target = Path(path)
+    exists = target.exists()
+    data: dict[str, Any] = {
+        "path": str(target),
+        "exists": bool(exists),
+    }
+    if not exists:
+        return data
+
+    stat = target.stat()
+    data["size_bytes"] = int(stat.st_size)
+    data["modified_utc"] = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
+    data["sha256"] = sha256_file(target)
+    return data
+
+
+def collect_git_context() -> dict[str, Any]:
+    """Collect lightweight git context for reproducibility."""
+
+    def _run_git(*args: str) -> str | None:
+        command = ["git", *args]
+        try:
+            result = subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except Exception:
+            return None
+        value = result.stdout.strip()
+        return value or None
+
+    return {
+        "branch": _run_git("branch", "--show-current"),
+        "commit": _run_git("rev-parse", "HEAD"),
+        "commit_short": _run_git("rev-parse", "--short", "HEAD"),
+        "status_short": _run_git("status", "--short"),
+    }
+
+
+def _psi_from_series(
+    train_values: pd.Series,
+    test_values: pd.Series,
+    bins: int,
+    epsilon: float = 1e-9,
+) -> float | None:
+    """Compute population stability index (PSI) using train quantile bins."""
+    train_clean = pd.to_numeric(train_values, errors="coerce").dropna().to_numpy(dtype="float64")
+    test_clean = pd.to_numeric(test_values, errors="coerce").dropna().to_numpy(dtype="float64")
+    if len(train_clean) == 0 or len(test_clean) == 0:
+        return None
+
+    quantiles = np.linspace(0.0, 1.0, int(max(bins, 2)) + 1)
+    edges = np.unique(np.quantile(train_clean, quantiles))
+    if len(edges) < 2:
+        return 0.0
+    edges[0] = -np.inf
+    edges[-1] = np.inf
+
+    train_hist, _ = np.histogram(train_clean, bins=edges)
+    test_hist, _ = np.histogram(test_clean, bins=edges)
+
+    train_ratio = train_hist.astype("float64") / float(max(np.sum(train_hist), 1))
+    test_ratio = test_hist.astype("float64") / float(max(np.sum(test_hist), 1))
+    train_ratio = np.clip(train_ratio, epsilon, None)
+    test_ratio = np.clip(test_ratio, epsilon, None)
+    return float(np.sum((test_ratio - train_ratio) * np.log(test_ratio / train_ratio)))
+
+
+def build_numeric_drift_table(
+    train_features: pd.DataFrame,
+    test_features: pd.DataFrame,
+    *,
+    psi_bins: int = 10,
+) -> pd.DataFrame:
+    """Build per-column numeric drift summary."""
+    rows: list[dict[str, Any]] = []
+    common_columns = [col for col in train_features.columns if col in test_features.columns]
+
+    for column in common_columns:
+        train_series = train_features[column]
+        test_series = test_features[column]
+        if not pd.api.types.is_numeric_dtype(train_series):
+            continue
+        if not pd.api.types.is_numeric_dtype(test_series):
+            continue
+
+        train_num = pd.to_numeric(train_series, errors="coerce")
+        test_num = pd.to_numeric(test_series, errors="coerce")
+        train_non_na = train_num.dropna()
+        test_non_na = test_num.dropna()
+        if len(train_non_na) == 0 or len(test_non_na) == 0:
+            continue
+
+        train_mean = float(train_non_na.mean())
+        test_mean = float(test_non_na.mean())
+        train_std = float(train_non_na.std(ddof=0))
+        test_std = float(test_non_na.std(ddof=0))
+        std_ratio = float(test_std / train_std) if train_std > 1e-12 else None
+
+        row = {
+            "column": str(column),
+            "train_count": int(train_non_na.shape[0]),
+            "test_count": int(test_non_na.shape[0]),
+            "train_missing_rate": float(train_num.isna().mean()),
+            "test_missing_rate": float(test_num.isna().mean()),
+            "missing_rate_delta": float(test_num.isna().mean() - train_num.isna().mean()),
+            "train_mean": train_mean,
+            "test_mean": test_mean,
+            "mean_delta": float(test_mean - train_mean),
+            "train_std": train_std,
+            "test_std": test_std,
+            "std_ratio_test_over_train": std_ratio,
+            "train_p01": float(train_non_na.quantile(0.01)),
+            "train_p50": float(train_non_na.quantile(0.50)),
+            "train_p99": float(train_non_na.quantile(0.99)),
+            "test_p01": float(test_non_na.quantile(0.01)),
+            "test_p50": float(test_non_na.quantile(0.50)),
+            "test_p99": float(test_non_na.quantile(0.99)),
+            "psi": _psi_from_series(train_non_na, test_non_na, bins=psi_bins),
+        }
+        rows.append(row)
+
+    if not rows:
+        return pd.DataFrame(columns=["column", "psi"])
+    table = pd.DataFrame(rows)
+    return table.sort_values(by="psi", ascending=False, na_position="last").reset_index(drop=True)
+
+
+def build_categorical_drift_table(
+    train_features: pd.DataFrame,
+    test_features: pd.DataFrame,
+    *,
+    max_unseen_examples: int = 10,
+) -> pd.DataFrame:
+    """Build per-column categorical drift summary."""
+    rows: list[dict[str, Any]] = []
+    common_columns = [col for col in train_features.columns if col in test_features.columns]
+
+    for column in common_columns:
+        train_series = train_features[column]
+        test_series = test_features[column]
+        if not pd.api.types.is_object_dtype(train_series) and not pd.api.types.is_categorical_dtype(
+            train_series
+        ):
+            continue
+
+        train_norm = train_series.fillna("__MISSING__").astype(str)
+        test_norm = test_series.fillna("__MISSING__").astype(str)
+
+        train_freq = train_norm.value_counts(normalize=True)
+        test_freq = test_norm.value_counts(normalize=True)
+
+        all_values = sorted(set(train_freq.index) | set(test_freq.index))
+        train_probs = train_freq.reindex(all_values, fill_value=0.0).to_numpy(dtype="float64")
+        test_probs = test_freq.reindex(all_values, fill_value=0.0).to_numpy(dtype="float64")
+        tvd = 0.5 * np.sum(np.abs(train_probs - test_probs))
+
+        unseen_test_values = sorted(set(test_freq.index) - set(train_freq.index))
+        rows.append(
+            {
+                "column": str(column),
+                "train_unique": int(train_freq.shape[0]),
+                "test_unique": int(test_freq.shape[0]),
+                "unseen_in_test_count": int(len(unseen_test_values)),
+                "unseen_in_test_values": unseen_test_values[:max_unseen_examples],
+                "tvd": float(tvd),
+                "train_top_1": str(train_freq.index[0]) if not train_freq.empty else None,
+                "train_top_1_share": float(train_freq.iloc[0]) if not train_freq.empty else None,
+                "test_top_1": str(test_freq.index[0]) if not test_freq.empty else None,
+                "test_top_1_share": float(test_freq.iloc[0]) if not test_freq.empty else None,
+            }
+        )
+
+    if not rows:
+        return pd.DataFrame(columns=["column", "tvd"])
+    table = pd.DataFrame(rows)
+    return table.sort_values(by="tvd", ascending=False).reset_index(drop=True)
+
+
+def run_adversarial_validation(
+    train_features: pd.DataFrame,
+    test_features: pd.DataFrame,
+    *,
+    folds: int = 3,
+    random_state: int = 42,
+    iterations: int = 500,
+    learning_rate: float = 0.05,
+    depth: int = 6,
+    early_stopping_rounds: int = 80,
+    sample_frac: float = 0.35,
+) -> dict[str, Any]:
+    """Run adversarial validation using CatBoost (train-vs-test classifier)."""
+    if folds < 2:
+        raise ValueError("folds must be >= 2")
+    if not (0.0 < sample_frac <= 1.0):
+        raise ValueError("sample_frac must be in (0, 1]")
+
+    train_work = train_features.copy()
+    test_work = test_features.copy()
+    if sample_frac < 1.0:
+        train_work = train_work.sample(frac=sample_frac, random_state=random_state)
+        test_work = test_work.sample(frac=sample_frac, random_state=random_state)
+
+    train_work = train_work.reset_index(drop=True)
+    test_work = test_work.reset_index(drop=True)
+
+    combined_x = pd.concat([train_work, test_work], axis=0, ignore_index=True)
+    combined_y = np.concatenate(
+        [
+            np.zeros(len(train_work), dtype="int8"),
+            np.ones(len(test_work), dtype="int8"),
+        ]
+    )
+
+    cat_columns = infer_categorical_columns(combined_x)
+    splitter = StratifiedKFold(n_splits=folds, shuffle=True, random_state=random_state)
+
+    fold_rows = []
+    fold_iterations = []
+    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(combined_x, combined_y), start=1):
+        x_train = combined_x.iloc[train_idx]
+        y_train = combined_y[train_idx]
+        x_valid = combined_x.iloc[valid_idx]
+        y_valid = combined_y[valid_idx]
+
+        model = CatBoostClassifier(
+            iterations=int(iterations),
+            learning_rate=float(learning_rate),
+            depth=int(depth),
+            loss_function="Logloss",
+            eval_metric="AUC",
+            random_seed=int(random_state),
+            allow_writing_files=False,
+        )
+        model.fit(
+            x_train,
+            y_train,
+            cat_features=cat_columns,
+            eval_set=(x_valid, y_valid),
+            use_best_model=True,
+            early_stopping_rounds=int(early_stopping_rounds),
+            verbose=False,
+        )
+        pred_valid = model.predict_proba(x_valid)[:, 1]
+        fold_auc = binary_auc(y_valid, pred_valid)
+        best_iter = model.get_best_iteration()
+        final_iter = int(best_iter) + 1 if best_iter is not None and best_iter >= 0 else int(iterations)
+        fold_iterations.append(max(final_iter, 1))
+        fold_rows.append(
+            {
+                "fold": int(fold_number),
+                "valid_rows": int(len(valid_idx)),
+                "auc": float(fold_auc),
+                "best_iteration": int(best_iter) if best_iter is not None else None,
+                "final_iterations": int(max(final_iter, 1)),
+            }
+        )
+
+    aucs = [float(item["auc"]) for item in fold_rows]
+    final_iterations = max(int(round(float(np.mean(fold_iterations)))), 1)
+
+    full_model = CatBoostClassifier(
+        iterations=int(final_iterations),
+        learning_rate=float(learning_rate),
+        depth=int(depth),
+        loss_function="Logloss",
+        eval_metric="AUC",
+        random_seed=int(random_state),
+        allow_writing_files=False,
+    )
+    full_model.fit(combined_x, combined_y, cat_features=cat_columns, verbose=False)
+    importances = full_model.get_feature_importance()
+
+    importance_rows = []
+    for idx, column in enumerate(combined_x.columns):
+        importance_rows.append(
+            {
+                "feature": str(column),
+                "importance": float(importances[idx]),
+            }
+        )
+    importance_rows = sorted(importance_rows, key=lambda item: float(item["importance"]), reverse=True)
+
+    return {
+        "train_sample_rows": int(len(train_work)),
+        "test_sample_rows": int(len(test_work)),
+        "total_rows": int(len(combined_x)),
+        "feature_count": int(combined_x.shape[1]),
+        "categorical_column_count": int(len(cat_columns)),
+        "categorical_columns": cat_columns,
+        "cv_folds": int(folds),
+        "cv_fold_metrics": fold_rows,
+        "cv_mean_auc": float(np.mean(aucs)),
+        "cv_std_auc": float(np.std(aucs)),
+        "final_iterations": int(final_iterations),
+        "top_feature_importance": importance_rows[:30],
+        "params": {
+            "iterations": int(iterations),
+            "learning_rate": float(learning_rate),
+            "depth": int(depth),
+            "early_stopping_rounds": int(early_stopping_rounds),
+            "sample_frac": float(sample_frac),
+            "random_state": int(random_state),
+        },
+    }
+
+
+def parse_oof_input_spec(raw: str) -> OOFInputSpec:
+    """Parse '<name>=<path>[#<prediction_column>]'."""
+    text = raw.strip()
+    if "=" not in text:
+        raise ValueError(
+            f"Invalid --oof value '{raw}'. Expected format: <name>=<path>[#<prediction_column>]"
+        )
+    name, payload = text.split("=", 1)
+    name = name.strip()
+    payload = payload.strip()
+    if not name:
+        raise ValueError(f"Invalid --oof value '{raw}': empty model name")
+    if not payload:
+        raise ValueError(f"Invalid --oof value '{raw}': empty path")
+
+    path_value, has_column, prediction_column = payload.partition("#")
+    path_value = path_value.strip()
+    prediction_column = prediction_column.strip() if has_column else None
+    if not path_value:
+        raise ValueError(f"Invalid --oof value '{raw}': empty path")
+    if prediction_column == "":
+        prediction_column = None
+    return OOFInputSpec(name=name, path=path_value, prediction_column=prediction_column)
+
+
+def _detect_oof_prediction_column(df: pd.DataFrame, preferred: str | None = None) -> str:
+    if preferred:
+        if preferred not in df.columns:
+            raise ValueError(f"Prediction column '{preferred}' not found in OOF file")
+        return preferred
+    for candidate in ("oof_pred", "oof_ensemble", "prediction", "pred"):
+        if candidate in df.columns:
+            return candidate
+    oof_like = [column for column in df.columns if str(column).startswith("oof_")]
+    if len(oof_like) == 1:
+        return oof_like[0]
+    if len(oof_like) > 1:
+        raise ValueError(f"Multiple oof_* columns found, specify one explicitly: {oof_like}")
+    raise ValueError("Could not auto-detect OOF prediction column.")
+
+
+def load_merged_oof_matrix(
+    specs: Sequence[OOFInputSpec],
+    *,
+    id_column: str = "id",
+    target_column: str = OOF_TARGET_COLUMN,
+) -> tuple[pd.DataFrame, list[str]]:
+    """Load and merge OOF files into one matrix: id, target, pred_<name>..."""
+    if not specs:
+        raise ValueError("At least one OOF input is required.")
+
+    merged: pd.DataFrame | None = None
+    model_columns: list[str] = []
+    for spec in specs:
+        oof_df = pd.read_csv(spec.path)
+        if id_column not in oof_df.columns or target_column not in oof_df.columns:
+            raise ValueError(
+                f"OOF file '{spec.path}' must contain columns '{id_column}' and '{target_column}'."
+            )
+        pred_column = _detect_oof_prediction_column(oof_df, preferred=spec.prediction_column)
+        out_column = f"pred_{spec.name}"
+        part = oof_df[[id_column, target_column, pred_column]].copy()
+        part = part.rename(columns={pred_column: out_column})
+        if merged is None:
+            merged = part
+        else:
+            merged = merged.merge(
+                part,
+                how="inner",
+                on=[id_column, target_column],
+                validate="one_to_one",
+            )
+        model_columns.append(out_column)
+
+    if merged is None or merged.empty:
+        raise ValueError("Merged OOF matrix is empty.")
+    return merged, model_columns
+
+
+def normalize_weights(weights: np.ndarray) -> np.ndarray:
+    """Project weights to simplex."""
+    clipped = np.maximum(weights.astype("float64"), 0.0)
+    total = float(np.sum(clipped))
+    if total <= 0.0:
+        return np.full(shape=clipped.shape, fill_value=1.0 / float(len(clipped)), dtype="float64")
+    return clipped / total
+
+
+def coordinate_descent_weights(
+    y_true: np.ndarray,
+    pred_matrix: np.ndarray,
+    *,
+    step: float = 0.02,
+    max_rounds: int = 25,
+) -> dict[str, Any]:
+    """Fit simplex-constrained blend weights with coordinate descent."""
+    if pred_matrix.ndim != 2 or pred_matrix.shape[1] < 2:
+        raise ValueError("pred_matrix must have shape (n_rows, n_models>=2)")
+    if step <= 0.0 or step >= 1.0:
+        raise ValueError("step must be in (0, 1)")
+    if max_rounds < 1:
+        raise ValueError("max_rounds must be >= 1")
+
+    n_models = pred_matrix.shape[1]
+    weights = np.full(shape=n_models, fill_value=1.0 / float(n_models), dtype="float64")
+    best_auc = binary_auc(y_true, pred_matrix @ weights)
+    rounds_used = 0
+
+    for round_idx in range(max_rounds):
+        improved = False
+        for focus in range(n_models):
+            for direction in (-1.0, 1.0):
+                candidate = weights.copy()
+                old_focus = float(candidate[focus])
+                new_focus = old_focus + float(direction) * float(step)
+                if new_focus < 0.0 or new_focus > 1.0:
+                    continue
+
+                rest_old = 1.0 - old_focus
+                rest_new = 1.0 - new_focus
+                candidate[focus] = new_focus
+                if rest_old <= 1e-12:
+                    fill = rest_new / float(n_models - 1)
+                    for idx in range(n_models):
+                        if idx != focus:
+                            candidate[idx] = fill
+                else:
+                    scale = rest_new / rest_old
+                    for idx in range(n_models):
+                        if idx != focus:
+                            candidate[idx] = candidate[idx] * scale
+                candidate = normalize_weights(candidate)
+                auc = binary_auc(y_true, pred_matrix @ candidate)
+                if float(auc) > float(best_auc) + 1e-10:
+                    weights = candidate
+                    best_auc = float(auc)
+                    improved = True
+        rounds_used = round_idx + 1
+        if not improved:
+            break
+
+    return {
+        "weights": weights,
+        "auc": float(best_auc),
+        "rounds_used": int(rounds_used),
+    }
+
+
+def _rank_average_predictions(pred_matrix: np.ndarray) -> np.ndarray:
+    rank_matrix = np.zeros_like(pred_matrix, dtype="float64")
+    for idx in range(pred_matrix.shape[1]):
+        rank_matrix[:, idx] = pd.Series(pred_matrix[:, idx]).rank(method="average").to_numpy(
+            dtype="float64"
+        )
+    rank_mean = np.mean(rank_matrix, axis=1)
+    return rank_mean / float(len(rank_mean))
+
+
+def evaluate_ensemble_robustness(
+    merged_oof: pd.DataFrame,
+    model_columns: Sequence[str],
+    *,
+    target_column: str = OOF_TARGET_COLUMN,
+    repeats: int = 3,
+    folds: int = 5,
+    random_state: int = 42,
+    weighted_step: float = 0.02,
+    weighted_rounds: int = 25,
+) -> dict[str, Any]:
+    """Evaluate equal/rank/weighted ensembles under repeated split validation."""
+    if repeats < 1:
+        raise ValueError("repeats must be >= 1")
+    if folds < 2:
+        raise ValueError("folds must be >= 2")
+
+    y = merged_oof[target_column].astype(int).to_numpy()
+    matrix = merged_oof[list(model_columns)].to_numpy(dtype="float64")
+    n_models = matrix.shape[1]
+    if n_models < 2:
+        raise ValueError("At least 2 model columns are required.")
+
+    equal_weights = np.full(shape=n_models, fill_value=1.0 / float(n_models), dtype="float64")
+    equal_full_auc = binary_auc(y, matrix @ equal_weights)
+    rank_full_auc = binary_auc(y, _rank_average_predictions(matrix))
+    weighted_full = coordinate_descent_weights(
+        y,
+        matrix,
+        step=weighted_step,
+        max_rounds=weighted_rounds,
+    )
+
+    method_fold_aucs: dict[str, list[float]] = {"equal": [], "rank": [], "weighted": []}
+    fold_rows: list[dict[str, Any]] = []
+    for rep in range(repeats):
+        splitter = StratifiedKFold(
+            n_splits=folds,
+            shuffle=True,
+            random_state=int(random_state) + int(rep),
+        )
+        for fold_number, (fit_idx, valid_idx) in enumerate(splitter.split(matrix, y), start=1):
+            fit_x = matrix[fit_idx]
+            fit_y = y[fit_idx]
+            valid_x = matrix[valid_idx]
+            valid_y = y[valid_idx]
+
+            equal_auc = binary_auc(valid_y, valid_x @ equal_weights)
+            rank_auc = binary_auc(valid_y, _rank_average_predictions(valid_x))
+            weighted_fit = coordinate_descent_weights(
+                fit_y,
+                fit_x,
+                step=weighted_step,
+                max_rounds=weighted_rounds,
+            )
+            weighted_pred = valid_x @ weighted_fit["weights"]
+            weighted_auc = binary_auc(valid_y, weighted_pred)
+
+            method_fold_aucs["equal"].append(float(equal_auc))
+            method_fold_aucs["rank"].append(float(rank_auc))
+            method_fold_aucs["weighted"].append(float(weighted_auc))
+
+            fold_rows.append(
+                {
+                    "repeat": int(rep + 1),
+                    "fold": int(fold_number),
+                    "valid_rows": int(len(valid_idx)),
+                    "equal_auc": float(equal_auc),
+                    "rank_auc": float(rank_auc),
+                    "weighted_auc": float(weighted_auc),
+                    "weighted_fit_weights": {
+                        model_columns[idx]: float(weighted_fit["weights"][idx]) for idx in range(n_models)
+                    },
+                }
+            )
+
+    method_summary = {}
+    for method, aucs in method_fold_aucs.items():
+        method_summary[method] = {
+            "cv_mean_auc": float(np.mean(aucs)),
+            "cv_std_auc": float(np.std(aucs)),
+            "cv_min_auc": float(np.min(aucs)),
+            "cv_max_auc": float(np.max(aucs)),
+            "full_auc": (
+                float(equal_full_auc)
+                if method == "equal"
+                else float(rank_full_auc) if method == "rank" else float(weighted_full["auc"])
+            ),
+            "optimism_full_minus_cv_mean": (
+                float(equal_full_auc - np.mean(aucs))
+                if method == "equal"
+                else float(rank_full_auc - np.mean(aucs))
+                if method == "rank"
+                else float(weighted_full["auc"] - np.mean(aucs))
+            ),
+        }
+
+    return {
+        "rows": int(len(merged_oof)),
+        "model_columns": list(model_columns),
+        "model_count": int(n_models),
+        "repeats": int(repeats),
+        "folds": int(folds),
+        "random_state": int(random_state),
+        "weighted_fit": {
+            "full_data_auc": float(weighted_full["auc"]),
+            "full_data_weights": {
+                model_columns[idx]: float(weighted_full["weights"][idx]) for idx in range(n_models)
+            },
+            "rounds_used": int(weighted_full["rounds_used"]),
+            "step": float(weighted_step),
+            "max_rounds": int(weighted_rounds),
+        },
+        "methods": method_summary,
+        "cv_fold_metrics": fold_rows,
+    }

--- a/src/churn_baseline/feature_engineering.py
+++ b/src/churn_baseline/feature_engineering.py
@@ -180,6 +180,38 @@ def _yes_no_flag(series: pd.Series, positive_value: str = "yes") -> pd.Series:
     return series.astype(str).str.lower().eq(positive_value).astype("int8")
 
 
+def ensure_monotonic_features(frame: pd.DataFrame) -> pd.DataFrame:
+    """Add a minimal set of numeric features for monotonic-constraint experiments."""
+    _require_columns(frame, ("tenure", "Contract", "PaymentMethod"), block="MONO")
+    out = frame.copy()
+
+    if "contract_commitment_ordinal" not in out.columns:
+        out["contract_commitment_ordinal"] = out["Contract"].astype(str).map(
+            {
+                "Month-to-month": 1,
+                "One year": 12,
+                "Two year": 24,
+            }
+        ).fillna(1).astype("int16")
+
+    payment_method = out["PaymentMethod"].astype(str)
+    payment_method_norm = payment_method.str.lower()
+    if "is_manual_payment" not in out.columns:
+        out["is_manual_payment"] = (~payment_method_norm.str.contains("automatic", regex=False)).astype("int8")
+
+    if "payment_friction_index" not in out.columns:
+        out["payment_friction_index"] = payment_method.map(
+            {
+                "Credit card (automatic)": 0,
+                "Bank transfer (automatic)": 0,
+                "Electronic check": 2,
+                "Mailed check": 3,
+            }
+        ).fillna(1).astype("int8")
+
+    return out
+
+
 def _group_size(frame: pd.DataFrame, columns: Sequence[str]) -> pd.Series:
     return frame.groupby(list(columns), dropna=False)[columns[0]].transform("size").astype("int32")
 

--- a/src/churn_baseline/feature_engineering.py
+++ b/src/churn_baseline/feature_engineering.py
@@ -13,6 +13,7 @@ import pandas as pd
 BLOCK_A: Final[str] = "A"
 BLOCK_B: Final[str] = "B"
 BLOCK_C: Final[str] = "C"
+BLOCK_F: Final[str] = "F"
 BLOCK_G: Final[str] = "G"
 BLOCK_H: Final[str] = "H"
 BLOCK_R: Final[str] = "R"
@@ -24,6 +25,7 @@ SUPPORTED_BLOCKS: Final[tuple[str, ...]] = (
     BLOCK_A,
     BLOCK_B,
     BLOCK_C,
+    BLOCK_F,
     BLOCK_G,
     BLOCK_H,
     BLOCK_R,
@@ -57,6 +59,9 @@ BLOCK_ALIASES: Final[dict[str, str]] = {
     "BACKOFF": BLOCK_G,
     "SUPPORT": BLOCK_G,
     "FAMILY": BLOCK_G,
+    "SURFACE": BLOCK_F,
+    "FOCUS": BLOCK_F,
+    "EC_SURFACE": BLOCK_F,
     "HARD": BLOCK_H,
     "CONTRAST": BLOCK_H,
     "COHORT": BLOCK_H,
@@ -128,6 +133,9 @@ def apply_feature_engineering(
         if block == BLOCK_C:
             out = _apply_block_c(out)
             continue
+        if block == BLOCK_F:
+            out = _apply_block_f(out)
+            continue
         if block == BLOCK_G:
             raise ValueError(
                 "Feature block G requires train-fitted coverage state; "
@@ -165,6 +173,14 @@ def _build_tenure_bin(tenure_values: pd.Series) -> pd.Series:
         tenure_values,
         bins=[-np.inf, 6, 12, 24, 48, np.inf],
         labels=["0_6", "7_12", "13_24", "25_48", "49_plus"],
+    ).astype(str)
+
+
+def _build_surface_tenure_bin(tenure_values: pd.Series) -> pd.Series:
+    return pd.cut(
+        tenure_values,
+        bins=[-np.inf, 2, 6, 12, 18, 24, 36, 48, 60, np.inf],
+        labels=["0_2", "3_6", "7_12", "13_18", "19_24", "25_36", "37_48", "49_60", "61_plus"],
     ).astype(str)
 
 
@@ -214,6 +230,84 @@ def ensure_monotonic_features(frame: pd.DataFrame) -> pd.DataFrame:
 
 def _group_size(frame: pd.DataFrame, columns: Sequence[str]) -> pd.Series:
     return frame.groupby(list(columns), dropna=False)[columns[0]].transform("size").astype("int32")
+
+
+def _compute_value_primitives(frame: pd.DataFrame, *, block: str) -> dict[str, pd.Series]:
+    service_columns = (
+        "OnlineSecurity",
+        "OnlineBackup",
+        "DeviceProtection",
+        "TechSupport",
+        "StreamingTV",
+        "StreamingMovies",
+    )
+    required = ("tenure", "InternetService", "PhoneService", "MultipleLines", "PaymentMethod", "MonthlyCharges", "TotalCharges")
+    _require_columns(frame, required + service_columns, block=block)
+
+    tenure_values = pd.to_numeric(frame["tenure"], errors="coerce").fillna(0.0)
+    tenure_safe = tenure_values.clip(lower=1.0)
+    monthly_charges = pd.to_numeric(frame["MonthlyCharges"], errors="coerce").fillna(0.0)
+    total_charges = pd.to_numeric(frame["TotalCharges"], errors="coerce").fillna(0.0)
+
+    has_internet = frame["InternetService"].astype(str).str.lower().ne("no").astype("int8")
+    has_phone = _yes_no_flag(frame["PhoneService"])
+    has_multiple_lines = _yes_no_flag(frame["MultipleLines"])
+
+    support_services_count = np.zeros(len(frame), dtype=np.int16)
+    entertainment_services_count = np.zeros(len(frame), dtype=np.int16)
+    for column in ("OnlineSecurity", "OnlineBackup", "DeviceProtection", "TechSupport"):
+        support_services_count += _yes_no_flag(frame[column]).to_numpy(dtype=np.int16)
+    for column in ("StreamingTV", "StreamingMovies"):
+        entertainment_services_count += _yes_no_flag(frame[column]).to_numpy(dtype=np.int16)
+
+    paid_services_count = (
+        has_internet.to_numpy(dtype=np.int16)
+        + has_phone.to_numpy(dtype=np.int16)
+        + has_multiple_lines.to_numpy(dtype=np.int16)
+        + support_services_count
+        + entertainment_services_count
+    ).astype("int16")
+    paid_services_safe = np.clip(paid_services_count, 1, None)
+
+    effective_monthly_charge = (total_charges / tenure_safe).astype("float64")
+    monthly_per_active_service = (monthly_charges / paid_services_safe).astype("float64")
+    payment_friction_index = frame["PaymentMethod"].astype(str).map(
+        {
+            "Credit card (automatic)": 0,
+            "Bank transfer (automatic)": 0,
+            "Electronic check": 2,
+            "Mailed check": 3,
+        }
+    ).fillna(1).astype("int8")
+
+    return {
+        "tenure_values": tenure_values.astype("float64"),
+        "tenure_safe": tenure_safe.astype("float64"),
+        "monthly_charges": monthly_charges.astype("float64"),
+        "total_charges": total_charges.astype("float64"),
+        "has_internet": has_internet.astype("int8"),
+        "support_services_count": pd.Series(support_services_count, index=frame.index, dtype="int16"),
+        "entertainment_services_count": pd.Series(entertainment_services_count, index=frame.index, dtype="int16"),
+        "paid_services_count": pd.Series(paid_services_count, index=frame.index, dtype="int16"),
+        "support_deficit_count": pd.Series(
+            np.where(has_internet.to_numpy(dtype=np.int8) == 1, 4 - support_services_count, 0),
+            index=frame.index,
+            dtype="int16",
+        ),
+        "monthly_per_active_service": pd.Series(monthly_per_active_service, index=frame.index, dtype="float64"),
+        "effective_monthly_charge": pd.Series(effective_monthly_charge, index=frame.index, dtype="float64"),
+        "current_vs_effective_monthly_delta": pd.Series(
+            monthly_charges - effective_monthly_charge,
+            index=frame.index,
+            dtype="float64",
+        ),
+        "current_vs_effective_monthly_ratio": pd.Series(
+            monthly_charges / np.clip(effective_monthly_charge, 1.0, None),
+            index=frame.index,
+            dtype="float64",
+        ),
+        "payment_friction_index": payment_friction_index.astype("int8"),
+    }
 
 
 def _build_segment3_key(frame: pd.DataFrame) -> pd.Series:
@@ -866,58 +960,22 @@ def _apply_block_v(frame: pd.DataFrame) -> pd.DataFrame:
     _require_columns(frame, required + service_columns, block=BLOCK_V)
     out = frame.copy()
 
-    tenure_values = pd.to_numeric(out["tenure"], errors="coerce").fillna(0.0)
-    tenure_safe = tenure_values.clip(lower=1.0)
-    monthly_charges = pd.to_numeric(out["MonthlyCharges"], errors="coerce").fillna(0.0)
-    total_charges = pd.to_numeric(out["TotalCharges"], errors="coerce").fillna(0.0)
+    primitives = _compute_value_primitives(out, block=BLOCK_V)
+    tenure_values = primitives["tenure_values"]
+    monthly_charges = primitives["monthly_charges"]
     if "tenure_bin" not in out.columns:
         out["tenure_bin"] = _build_tenure_bin(tenure_values)
 
-    has_internet = out["InternetService"].astype(str).str.lower().ne("no").astype("int8")
-    has_phone = _yes_no_flag(out["PhoneService"])
-    has_multiple_lines = _yes_no_flag(out["MultipleLines"])
-    support_services_count = np.zeros(len(out), dtype=np.int16)
-    entertainment_services_count = np.zeros(len(out), dtype=np.int16)
-    for column in ("OnlineSecurity", "OnlineBackup", "DeviceProtection", "TechSupport"):
-        support_services_count += _yes_no_flag(out[column]).to_numpy(dtype=np.int16)
-    for column in ("StreamingTV", "StreamingMovies"):
-        entertainment_services_count += _yes_no_flag(out[column]).to_numpy(dtype=np.int16)
-
-    paid_services_count = (
-        has_internet.to_numpy(dtype=np.int16)
-        + has_phone.to_numpy(dtype=np.int16)
-        + has_multiple_lines.to_numpy(dtype=np.int16)
-        + support_services_count
-        + entertainment_services_count
-    ).astype("int16")
-    paid_services_safe = np.clip(paid_services_count, 1, None)
-
-    payment_friction_index = out["PaymentMethod"].astype(str).map(
-        {
-            "Credit card (automatic)": 0,
-            "Bank transfer (automatic)": 0,
-            "Electronic check": 2,
-            "Mailed check": 3,
-        }
-    ).fillna(1).astype("int8")
-
-    out["support_services_count"] = support_services_count.astype("int16")
-    out["entertainment_services_count"] = entertainment_services_count.astype("int16")
-    out["paid_services_count"] = paid_services_count.astype("int16")
-    out["support_deficit_count"] = np.where(
-        has_internet.to_numpy(dtype=np.int8) == 1,
-        4 - support_services_count,
-        0,
-    ).astype("int16")
-    out["monthly_per_active_service"] = (monthly_charges / paid_services_safe).astype("float64")
-    out["effective_monthly_charge"] = (total_charges / tenure_safe).astype("float64")
-    out["current_vs_effective_monthly_delta"] = (
-        monthly_charges - out["effective_monthly_charge"]
-    ).astype("float64")
-    out["current_vs_effective_monthly_ratio"] = (
-        monthly_charges / out["effective_monthly_charge"].clip(lower=1.0)
-    ).astype("float64")
-    out["payment_friction_index"] = payment_friction_index
+    has_internet = primitives["has_internet"]
+    out["support_services_count"] = primitives["support_services_count"].astype("int16")
+    out["entertainment_services_count"] = primitives["entertainment_services_count"].astype("int16")
+    out["paid_services_count"] = primitives["paid_services_count"].astype("int16")
+    out["support_deficit_count"] = primitives["support_deficit_count"].astype("int16")
+    out["monthly_per_active_service"] = primitives["monthly_per_active_service"].astype("float64")
+    out["effective_monthly_charge"] = primitives["effective_monthly_charge"].astype("float64")
+    out["current_vs_effective_monthly_delta"] = primitives["current_vs_effective_monthly_delta"].astype("float64")
+    out["current_vs_effective_monthly_ratio"] = primitives["current_vs_effective_monthly_ratio"].astype("float64")
+    out["payment_friction_index"] = primitives["payment_friction_index"].astype("int8")
     out["is_support_light"] = (
         (has_internet == 1) & (out["support_services_count"] <= 1)
     ).astype("int8")
@@ -974,6 +1032,156 @@ def _apply_block_v(frame: pd.DataFrame) -> pd.DataFrame:
     ).astype("float64")
     out["paid_services_minus_cohort"] = (
         out["paid_services_count"].astype("float64") - cohort_service_median
+    ).astype("float64")
+
+    return out
+
+
+def _apply_block_f(frame: pd.DataFrame) -> pd.DataFrame:
+    service_columns = (
+        "OnlineSecurity",
+        "OnlineBackup",
+        "DeviceProtection",
+        "TechSupport",
+        "StreamingTV",
+        "StreamingMovies",
+    )
+    required = (
+        "PaymentMethod",
+        "Contract",
+        "InternetService",
+        "PaperlessBilling",
+        "tenure",
+        "PhoneService",
+        "MultipleLines",
+        "MonthlyCharges",
+        "TotalCharges",
+    )
+    _require_columns(frame, required + service_columns, block=BLOCK_F)
+    out = frame.copy()
+
+    primitives = _compute_value_primitives(out, block=BLOCK_F)
+    tenure_values = primitives["tenure_values"]
+    monthly_charges = primitives["monthly_charges"]
+    total_charges = primitives["total_charges"]
+    if "tenure_bin" not in out.columns:
+        out["tenure_bin"] = _build_tenure_bin(tenure_values)
+
+    macro_mask = (
+        out["PaymentMethod"].astype(str).eq("Electronic check")
+        & out["Contract"].astype(str).eq("Month-to-month")
+        & out["InternetService"].astype(str).eq("Fiber optic")
+    )
+    fine_tenure_bin = _build_surface_tenure_bin(tenure_values)
+    out["ec_surface_is_family"] = macro_mask.astype("int8")
+    out["ec_surface_is_paperless_family"] = (
+        macro_mask & out["PaperlessBilling"].astype(str).eq("Yes")
+    ).astype("int8")
+    out["ec_surface_tenure_bin_fine"] = pd.Series(
+        np.where(macro_mask, fine_tenure_bin, "other"),
+        index=out.index,
+        dtype="object",
+    ).astype(str)
+    out["ec_surface_segment"] = pd.Series(
+        np.where(
+            macro_mask,
+            out["PaperlessBilling"].astype(str) + "__" + out["ec_surface_tenure_bin_fine"].astype(str),
+            "other",
+        ),
+        index=out.index,
+        dtype="object",
+    ).astype(str)
+
+    out["ec_surface_rows"] = 0
+    out["ec_surface_used_fallback"] = 0
+    out["ec_surface_monthly_minus_median"] = 0.0
+    out["ec_surface_monthly_over_median"] = 1.0
+    out["ec_surface_monthly_rank"] = 0.5
+    out["ec_surface_total_minus_median"] = 0.0
+    out["ec_surface_total_rank"] = 0.5
+    out["ec_surface_mpas_minus_median"] = 0.0
+    out["ec_surface_mpas_rank"] = 0.5
+    out["ec_surface_paid_minus_median"] = 0.0
+    out["ec_surface_support_minus_median"] = 0.0
+    out["ec_surface_delta_minus_median"] = 0.0
+    out["ec_surface_delta_rank"] = 0.5
+    out["ec_surface_pressure_x_support_deficit"] = 0.0
+
+    if not macro_mask.any():
+        return out
+
+    macro_df = pd.DataFrame(
+        {
+            "_paperless": out.loc[macro_mask, "PaperlessBilling"].astype(str),
+            "_fine_tenure": fine_tenure_bin.loc[macro_mask].astype(str),
+            "_coarse_tenure": out.loc[macro_mask, "tenure_bin"].astype(str),
+            "monthly_charges": monthly_charges.loc[macro_mask].astype("float64"),
+            "total_charges": total_charges.loc[macro_mask].astype("float64"),
+            "monthly_per_active_service": primitives["monthly_per_active_service"].loc[macro_mask].astype("float64"),
+            "support_services_count": primitives["support_services_count"].loc[macro_mask].astype("float64"),
+            "paid_services_count": primitives["paid_services_count"].loc[macro_mask].astype("float64"),
+            "current_vs_effective_monthly_delta": primitives["current_vs_effective_monthly_delta"].loc[macro_mask].astype("float64"),
+            "support_deficit_count": primitives["support_deficit_count"].loc[macro_mask].astype("float64"),
+        },
+        index=out.index[macro_mask],
+    )
+    detailed_group = ["_paperless", "_fine_tenure"]
+    fallback_group = ["_paperless", "_coarse_tenure"]
+    detailed_rows = macro_df.groupby(detailed_group, dropna=False)["_paperless"].transform("size")
+    fallback_rows = macro_df.groupby(fallback_group, dropna=False)["_paperless"].transform("size")
+    use_detailed = detailed_rows >= 75
+
+    feature_specs = (
+        ("monthly_charges", "monthly"),
+        ("total_charges", "total"),
+        ("monthly_per_active_service", "mpas"),
+        ("support_services_count", "support"),
+        ("paid_services_count", "paid"),
+        ("current_vs_effective_monthly_delta", "delta"),
+    )
+
+    macro_features: dict[str, pd.Series] = {
+        "rows": pd.Series(np.where(use_detailed, detailed_rows, fallback_rows), index=macro_df.index, dtype="float64"),
+        "used_fallback": pd.Series((~use_detailed).astype("int8"), index=macro_df.index, dtype="int8"),
+    }
+    for source_column, prefix in feature_specs:
+        detailed_median = macro_df.groupby(detailed_group, dropna=False)[source_column].transform("median")
+        fallback_median = macro_df.groupby(fallback_group, dropna=False)[source_column].transform("median")
+        detailed_rank = macro_df.groupby(detailed_group, dropna=False)[source_column].rank(method="average", pct=True)
+        fallback_rank = macro_df.groupby(fallback_group, dropna=False)[source_column].rank(method="average", pct=True)
+
+        cohort_median = pd.Series(
+            np.where(use_detailed, detailed_median, fallback_median),
+            index=macro_df.index,
+            dtype="float64",
+        )
+        cohort_rank = pd.Series(
+            np.where(use_detailed, detailed_rank, fallback_rank),
+            index=macro_df.index,
+            dtype="float64",
+        )
+        macro_features[f"{prefix}_minus_median"] = (macro_df[source_column] - cohort_median).astype("float64")
+        macro_features[f"{prefix}_rank"] = cohort_rank.astype("float64")
+        if prefix == "monthly":
+            macro_features["monthly_over_median"] = (
+                macro_df[source_column] / cohort_median.clip(lower=1.0)
+            ).astype("float64")
+
+    out.loc[macro_df.index, "ec_surface_rows"] = macro_features["rows"].astype("int32")
+    out.loc[macro_df.index, "ec_surface_used_fallback"] = macro_features["used_fallback"].astype("int8")
+    out.loc[macro_df.index, "ec_surface_monthly_minus_median"] = macro_features["monthly_minus_median"].astype("float64")
+    out.loc[macro_df.index, "ec_surface_monthly_over_median"] = macro_features["monthly_over_median"].astype("float64")
+    out.loc[macro_df.index, "ec_surface_monthly_rank"] = macro_features["monthly_rank"].astype("float64")
+    out.loc[macro_df.index, "ec_surface_total_minus_median"] = macro_features["total_minus_median"].astype("float64")
+    out.loc[macro_df.index, "ec_surface_total_rank"] = macro_features["total_rank"].astype("float64")
+    out.loc[macro_df.index, "ec_surface_mpas_minus_median"] = macro_features["mpas_minus_median"].astype("float64")
+    out.loc[macro_df.index, "ec_surface_mpas_rank"] = macro_features["mpas_rank"].astype("float64")
+    out.loc[macro_df.index, "ec_surface_paid_minus_median"] = macro_features["paid_minus_median"].astype("float64")
+    out.loc[macro_df.index, "ec_surface_support_minus_median"] = macro_features["support_minus_median"].astype("float64")
+    out.loc[macro_df.index, "ec_surface_delta_minus_median"] = macro_features["delta_minus_median"].astype("float64")
+    out.loc[macro_df.index, "ec_surface_delta_rank"] = macro_features["delta_rank"].astype("float64")
+    out.loc[macro_df.index, "ec_surface_pressure_x_support_deficit"] = (
+        macro_features["monthly_over_median"] * macro_df["support_deficit_count"]
     ).astype("float64")
 
     return out

--- a/src/churn_baseline/feature_engineering.py
+++ b/src/churn_baseline/feature_engineering.py
@@ -15,6 +15,7 @@ BLOCK_B: Final[str] = "B"
 BLOCK_C: Final[str] = "C"
 BLOCK_F: Final[str] = "F"
 BLOCK_G: Final[str] = "G"
+BLOCK_T: Final[str] = "T"
 BLOCK_H: Final[str] = "H"
 BLOCK_R: Final[str] = "R"
 BLOCK_S: Final[str] = "S"
@@ -27,6 +28,7 @@ SUPPORTED_BLOCKS: Final[tuple[str, ...]] = (
     BLOCK_C,
     BLOCK_F,
     BLOCK_G,
+    BLOCK_T,
     BLOCK_H,
     BLOCK_R,
     BLOCK_S,
@@ -62,6 +64,9 @@ BLOCK_ALIASES: Final[dict[str, str]] = {
     "SURFACE": BLOCK_F,
     "FOCUS": BLOCK_F,
     "EC_SURFACE": BLOCK_F,
+    "SURFACE_FIT": BLOCK_T,
+    "TRAIN_SURFACE": BLOCK_T,
+    "EC_SURFACE_FIT": BLOCK_T,
     "HARD": BLOCK_H,
     "CONTRAST": BLOCK_H,
     "COHORT": BLOCK_H,
@@ -74,7 +79,7 @@ BLOCK_ALIASES: Final[dict[str, str]] = {
     "PRESSURE": BLOCK_V,
     "FRICTION": BLOCK_V,
 }
-STATEFUL_BLOCKS: Final[tuple[str, ...]] = (BLOCK_G,)
+STATEFUL_BLOCKS: Final[tuple[str, ...]] = (BLOCK_G, BLOCK_T)
 
 
 @dataclass(frozen=True)
@@ -84,6 +89,37 @@ class CoverageBackoffState:
     min_segment5_support: int
     segment3_counts: dict[str, int]
     segment5_counts: dict[str, int]
+
+
+@dataclass(frozen=True)
+class SurfaceProfile:
+    """Train-fitted summary stats for one EC surface cohort."""
+
+    rows: int
+    medians: dict[str, float]
+    quantile_edges: dict[str, tuple[float, ...]]
+
+
+@dataclass(frozen=True)
+class ECSurfaceFitState:
+    """Train-only surface profiles for EC/MTM/Fiber cohorts."""
+
+    min_detailed_support: int
+    min_coarse_support: int
+    detailed_profiles: dict[str, SurfaceProfile]
+    coarse_profiles: dict[str, SurfaceProfile]
+    paperless_profiles: dict[str, SurfaceProfile]
+
+
+EC_SURFACE_FEATURE_SPECS: Final[tuple[tuple[str, str], ...]] = (
+    ("monthly_charges", "monthly"),
+    ("total_charges", "total"),
+    ("monthly_per_active_service", "mpas"),
+    ("support_services_count", "support"),
+    ("paid_services_count", "paid"),
+    ("current_vs_effective_monthly_delta", "delta"),
+)
+EC_SURFACE_QUANTILES: Final[tuple[float, ...]] = tuple(round(step / 10.0, 1) for step in range(1, 10))
 
 
 def normalize_feature_blocks(feature_blocks: Sequence[str] | None) -> tuple[str, ...]:
@@ -141,6 +177,11 @@ def apply_feature_engineering(
                 "Feature block G requires train-fitted coverage state; "
                 "use pipeline helpers that fit on the training split first."
             )
+        if block == BLOCK_T:
+            raise ValueError(
+                "Feature block T requires train-fitted EC surface state; "
+                "use pipeline helpers that fit on the training split first."
+            )
         if block == BLOCK_H:
             out = _apply_block_h(out)
             continue
@@ -182,6 +223,14 @@ def _build_surface_tenure_bin(tenure_values: pd.Series) -> pd.Series:
         bins=[-np.inf, 2, 6, 12, 18, 24, 36, 48, 60, np.inf],
         labels=["0_2", "3_6", "7_12", "13_18", "19_24", "25_36", "37_48", "49_60", "61_plus"],
     ).astype(str)
+
+
+def _build_ec_surface_macro_mask(frame: pd.DataFrame) -> pd.Series:
+    return (
+        frame["PaymentMethod"].astype(str).eq("Electronic check")
+        & frame["Contract"].astype(str).eq("Month-to-month")
+        & frame["InternetService"].astype(str).eq("Fiber optic")
+    )
 
 
 def _ensure_tenure_bin(frame: pd.DataFrame) -> pd.Series:
@@ -344,6 +393,57 @@ def _support_bucket(counts: pd.Series) -> pd.Series:
     return buckets.astype(str)
 
 
+def _compute_quantile_edges(
+    values: pd.Series,
+    *,
+    quantiles: Sequence[float] = EC_SURFACE_QUANTILES,
+) -> tuple[float, ...]:
+    numeric = pd.to_numeric(values, errors="coerce").replace([np.inf, -np.inf], np.nan).dropna()
+    if numeric.empty:
+        return ()
+    edges = numeric.quantile(list(quantiles)).astype("float64").to_numpy()
+    if edges.size == 0:
+        return ()
+    unique_edges = np.unique(edges[np.isfinite(edges)])
+    return tuple(float(edge) for edge in unique_edges.tolist())
+
+
+def _fit_surface_profiles(
+    keys: pd.Series,
+    values: pd.DataFrame,
+) -> dict[str, SurfaceProfile]:
+    profiles: dict[str, SurfaceProfile] = {}
+    for key, group in values.groupby(keys.astype(str), dropna=False):
+        medians: dict[str, float] = {}
+        quantile_edges: dict[str, tuple[float, ...]] = {}
+        for source_column, _ in EC_SURFACE_FEATURE_SPECS:
+            series = pd.to_numeric(group[source_column], errors="coerce").fillna(0.0).astype("float64")
+            medians[source_column] = float(series.median())
+            quantile_edges[source_column] = _compute_quantile_edges(series)
+        profiles[str(key)] = SurfaceProfile(
+            rows=int(len(group)),
+            medians=medians,
+            quantile_edges=quantile_edges,
+        )
+    return profiles
+
+
+def _approx_rank_from_edges(
+    values: pd.Series,
+    edge_series: pd.Series,
+) -> pd.Series:
+    numeric_values = pd.to_numeric(values, errors="coerce").fillna(0.0).astype("float64").to_numpy()
+    ranks = np.full(len(values), 0.5, dtype="float64")
+    for idx, (value, edges) in enumerate(zip(numeric_values, edge_series.tolist())):
+        if not isinstance(edges, (tuple, list, np.ndarray)) or len(edges) == 0:
+            continue
+        edges_arr = np.asarray(edges, dtype="float64")
+        if edges_arr.size == 0:
+            continue
+        ranks[idx] = (np.searchsorted(edges_arr, value, side="right") + 0.5) / float(edges_arr.size + 1)
+    return pd.Series(ranks, index=values.index, dtype="float64")
+
+
 def fit_coverage_backoff_state(
     frame: pd.DataFrame,
     *,
@@ -402,6 +502,246 @@ def apply_coverage_backoff_features(
         use_segment5,
         segment5.astype(str),
         "BACKOFF__" + segment3.astype(str),
+    )
+    return out
+
+
+def fit_ec_surface_state(
+    frame: pd.DataFrame,
+    *,
+    min_detailed_support: int = 75,
+    min_coarse_support: int = 75,
+) -> ECSurfaceFitState:
+    """Fit train-only surface profiles for EC/MTM/Fiber cohorts."""
+    service_columns = (
+        "OnlineSecurity",
+        "OnlineBackup",
+        "DeviceProtection",
+        "TechSupport",
+        "StreamingTV",
+        "StreamingMovies",
+    )
+    required = (
+        "PaymentMethod",
+        "Contract",
+        "InternetService",
+        "PaperlessBilling",
+        "tenure",
+        "PhoneService",
+        "MultipleLines",
+        "MonthlyCharges",
+        "TotalCharges",
+    )
+    _require_columns(frame, required + service_columns, block=BLOCK_T)
+
+    primitives = _compute_value_primitives(frame, block=BLOCK_T)
+    tenure_values = primitives["tenure_values"]
+    tenure_bin = _ensure_tenure_bin(frame)
+    macro_mask = _build_ec_surface_macro_mask(frame)
+    if not bool(macro_mask.any()):
+        return ECSurfaceFitState(
+            min_detailed_support=int(min_detailed_support),
+            min_coarse_support=int(min_coarse_support),
+            detailed_profiles={},
+            coarse_profiles={},
+            paperless_profiles={},
+        )
+
+    fine_tenure_bin = _build_surface_tenure_bin(tenure_values)
+    macro_df = pd.DataFrame(
+        {
+            "_paperless": frame.loc[macro_mask, "PaperlessBilling"].astype(str),
+            "_fine_tenure": fine_tenure_bin.loc[macro_mask].astype(str),
+            "_coarse_tenure": tenure_bin.loc[macro_mask].astype(str),
+            "monthly_charges": primitives["monthly_charges"].loc[macro_mask].astype("float64"),
+            "total_charges": primitives["total_charges"].loc[macro_mask].astype("float64"),
+            "monthly_per_active_service": primitives["monthly_per_active_service"].loc[macro_mask].astype("float64"),
+            "support_services_count": primitives["support_services_count"].loc[macro_mask].astype("float64"),
+            "paid_services_count": primitives["paid_services_count"].loc[macro_mask].astype("float64"),
+            "current_vs_effective_monthly_delta": primitives["current_vs_effective_monthly_delta"].loc[macro_mask].astype("float64"),
+        },
+        index=frame.index[macro_mask],
+    )
+
+    detailed_key = macro_df["_paperless"] + "__" + macro_df["_fine_tenure"]
+    coarse_key = macro_df["_paperless"] + "__" + macro_df["_coarse_tenure"]
+    paperless_key = macro_df["_paperless"]
+
+    return ECSurfaceFitState(
+        min_detailed_support=int(min_detailed_support),
+        min_coarse_support=int(min_coarse_support),
+        detailed_profiles=_fit_surface_profiles(detailed_key, macro_df),
+        coarse_profiles=_fit_surface_profiles(coarse_key, macro_df),
+        paperless_profiles=_fit_surface_profiles(paperless_key, macro_df),
+    )
+
+
+def apply_ec_surface_fit_features(
+    frame: pd.DataFrame,
+    state: ECSurfaceFitState,
+) -> pd.DataFrame:
+    """Append train-fitted EC surface features to any frame."""
+    service_columns = (
+        "OnlineSecurity",
+        "OnlineBackup",
+        "DeviceProtection",
+        "TechSupport",
+        "StreamingTV",
+        "StreamingMovies",
+    )
+    required = (
+        "PaymentMethod",
+        "Contract",
+        "InternetService",
+        "PaperlessBilling",
+        "tenure",
+        "PhoneService",
+        "MultipleLines",
+        "MonthlyCharges",
+        "TotalCharges",
+    )
+    _require_columns(frame, required + service_columns, block=BLOCK_T)
+
+    out = frame.copy()
+    primitives = _compute_value_primitives(out, block=BLOCK_T)
+    tenure_values = primitives["tenure_values"]
+    if "tenure_bin" not in out.columns:
+        out["tenure_bin"] = _build_tenure_bin(tenure_values)
+
+    macro_mask = _build_ec_surface_macro_mask(out)
+    fine_tenure_bin = _build_surface_tenure_bin(tenure_values)
+
+    out["ec_surface_fit_is_family"] = macro_mask.astype("int8")
+    out["ec_surface_fit_is_paperless_family"] = (
+        macro_mask & out["PaperlessBilling"].astype(str).eq("Yes")
+    ).astype("int8")
+    out["ec_surface_fit_level"] = "other"
+    out["ec_surface_fit_segment"] = "other"
+    out["ec_surface_fit_rows"] = 0
+    out["ec_surface_fit_support_bucket"] = "zero"
+    out["ec_surface_fit_used_coarse"] = 0
+    out["ec_surface_fit_used_paperless"] = 0
+    out["ec_surface_fit_monthly_minus_train_median"] = 0.0
+    out["ec_surface_fit_monthly_over_train_median"] = 1.0
+    out["ec_surface_fit_monthly_rank_fit"] = 0.5
+    out["ec_surface_fit_total_minus_train_median"] = 0.0
+    out["ec_surface_fit_total_rank_fit"] = 0.5
+    out["ec_surface_fit_mpas_minus_train_median"] = 0.0
+    out["ec_surface_fit_mpas_rank_fit"] = 0.5
+    out["ec_surface_fit_paid_minus_train_median"] = 0.0
+    out["ec_surface_fit_support_minus_train_median"] = 0.0
+    out["ec_surface_fit_delta_minus_train_median"] = 0.0
+    out["ec_surface_fit_delta_rank_fit"] = 0.5
+    out["ec_surface_fit_pressure_x_support_deficit"] = 0.0
+
+    if not bool(macro_mask.any()) or not state.paperless_profiles:
+        return out
+
+    macro_df = pd.DataFrame(
+        {
+            "_paperless": out.loc[macro_mask, "PaperlessBilling"].astype(str),
+            "_fine_tenure": fine_tenure_bin.loc[macro_mask].astype(str),
+            "_coarse_tenure": out.loc[macro_mask, "tenure_bin"].astype(str),
+            "monthly_charges": primitives["monthly_charges"].loc[macro_mask].astype("float64"),
+            "total_charges": primitives["total_charges"].loc[macro_mask].astype("float64"),
+            "monthly_per_active_service": primitives["monthly_per_active_service"].loc[macro_mask].astype("float64"),
+            "support_services_count": primitives["support_services_count"].loc[macro_mask].astype("float64"),
+            "paid_services_count": primitives["paid_services_count"].loc[macro_mask].astype("float64"),
+            "current_vs_effective_monthly_delta": primitives["current_vs_effective_monthly_delta"].loc[macro_mask].astype("float64"),
+            "support_deficit_count": primitives["support_deficit_count"].loc[macro_mask].astype("float64"),
+        },
+        index=out.index[macro_mask],
+    )
+
+    detailed_key = macro_df["_paperless"] + "__" + macro_df["_fine_tenure"]
+    coarse_key = macro_df["_paperless"] + "__" + macro_df["_coarse_tenure"]
+    paperless_key = macro_df["_paperless"]
+
+    detailed_rows_map = {key: profile.rows for key, profile in state.detailed_profiles.items()}
+    coarse_rows_map = {key: profile.rows for key, profile in state.coarse_profiles.items()}
+    paperless_rows_map = {key: profile.rows for key, profile in state.paperless_profiles.items()}
+
+    detailed_rows = detailed_key.map(detailed_rows_map).fillna(0).astype("int32")
+    coarse_rows = coarse_key.map(coarse_rows_map).fillna(0).astype("int32")
+    paperless_rows = paperless_key.map(paperless_rows_map).fillna(0).astype("int32")
+
+    use_detailed = detailed_rows.ge(int(state.min_detailed_support))
+    use_coarse = (~use_detailed) & coarse_rows.ge(int(state.min_coarse_support))
+    selected_level = pd.Series(
+        np.where(use_detailed, "detail", np.where(use_coarse, "coarse", "paperless")),
+        index=macro_df.index,
+        dtype="object",
+    )
+    selected_segment = pd.Series(
+        np.where(
+            use_detailed,
+            "detail__" + detailed_key.astype(str),
+            np.where(
+                use_coarse,
+                "coarse__" + coarse_key.astype(str),
+                "paperless__" + paperless_key.astype(str),
+            ),
+        ),
+        index=macro_df.index,
+        dtype="object",
+    )
+    selected_rows = pd.Series(
+        np.where(use_detailed, detailed_rows, np.where(use_coarse, coarse_rows, paperless_rows)),
+        index=macro_df.index,
+        dtype="int32",
+    )
+
+    out.loc[macro_df.index, "ec_surface_fit_level"] = selected_level.astype(str)
+    out.loc[macro_df.index, "ec_surface_fit_segment"] = selected_segment.astype(str)
+    out.loc[macro_df.index, "ec_surface_fit_rows"] = selected_rows.astype("int32")
+    out.loc[macro_df.index, "ec_surface_fit_support_bucket"] = _support_bucket(selected_rows)
+    out.loc[macro_df.index, "ec_surface_fit_used_coarse"] = use_coarse.astype("int8")
+    out.loc[macro_df.index, "ec_surface_fit_used_paperless"] = (~use_detailed & ~use_coarse).astype("int8")
+
+    combined_profiles: dict[str, SurfaceProfile] = {}
+    combined_profiles.update({f"detail__{key}": profile for key, profile in state.detailed_profiles.items()})
+    combined_profiles.update({f"coarse__{key}": profile for key, profile in state.coarse_profiles.items()})
+    combined_profiles.update({f"paperless__{key}": profile for key, profile in state.paperless_profiles.items()})
+
+    for source_column, prefix in EC_SURFACE_FEATURE_SPECS:
+        median_map = {
+            key: profile.medians[source_column]
+            for key, profile in combined_profiles.items()
+        }
+        edge_map = {
+            key: profile.quantile_edges[source_column]
+            for key, profile in combined_profiles.items()
+        }
+        selected_median = selected_segment.map(median_map)
+        selected_edges = selected_segment.map(edge_map)
+
+        selected_median = selected_median.fillna(macro_df[source_column]).astype("float64")
+        selected_rank = _approx_rank_from_edges(macro_df[source_column], selected_edges)
+        minus_series = (macro_df[source_column] - selected_median).astype("float64")
+
+        if prefix == "monthly":
+            out.loc[macro_df.index, "ec_surface_fit_monthly_minus_train_median"] = minus_series
+            out.loc[macro_df.index, "ec_surface_fit_monthly_over_train_median"] = (
+                macro_df[source_column] / selected_median.clip(lower=1.0)
+            ).astype("float64")
+            out.loc[macro_df.index, "ec_surface_fit_monthly_rank_fit"] = selected_rank.astype("float64")
+        elif prefix == "total":
+            out.loc[macro_df.index, "ec_surface_fit_total_minus_train_median"] = minus_series
+            out.loc[macro_df.index, "ec_surface_fit_total_rank_fit"] = selected_rank.astype("float64")
+        elif prefix == "mpas":
+            out.loc[macro_df.index, "ec_surface_fit_mpas_minus_train_median"] = minus_series
+            out.loc[macro_df.index, "ec_surface_fit_mpas_rank_fit"] = selected_rank.astype("float64")
+        elif prefix == "paid":
+            out.loc[macro_df.index, "ec_surface_fit_paid_minus_train_median"] = minus_series
+        elif prefix == "support":
+            out.loc[macro_df.index, "ec_surface_fit_support_minus_train_median"] = minus_series
+        elif prefix == "delta":
+            out.loc[macro_df.index, "ec_surface_fit_delta_minus_train_median"] = minus_series
+            out.loc[macro_df.index, "ec_surface_fit_delta_rank_fit"] = selected_rank.astype("float64")
+
+    out.loc[macro_df.index, "ec_surface_fit_pressure_x_support_deficit"] = (
+        out.loc[macro_df.index, "ec_surface_fit_monthly_over_train_median"].astype("float64")
+        * macro_df["support_deficit_count"].astype("float64")
     )
     return out
 
@@ -1131,20 +1471,11 @@ def _apply_block_f(frame: pd.DataFrame) -> pd.DataFrame:
     fallback_rows = macro_df.groupby(fallback_group, dropna=False)["_paperless"].transform("size")
     use_detailed = detailed_rows >= 75
 
-    feature_specs = (
-        ("monthly_charges", "monthly"),
-        ("total_charges", "total"),
-        ("monthly_per_active_service", "mpas"),
-        ("support_services_count", "support"),
-        ("paid_services_count", "paid"),
-        ("current_vs_effective_monthly_delta", "delta"),
-    )
-
     macro_features: dict[str, pd.Series] = {
         "rows": pd.Series(np.where(use_detailed, detailed_rows, fallback_rows), index=macro_df.index, dtype="float64"),
         "used_fallback": pd.Series((~use_detailed).astype("int8"), index=macro_df.index, dtype="int8"),
     }
-    for source_column, prefix in feature_specs:
+    for source_column, prefix in EC_SURFACE_FEATURE_SPECS:
         detailed_median = macro_df.groupby(detailed_group, dropna=False)[source_column].transform("median")
         fallback_median = macro_df.groupby(fallback_group, dropna=False)[source_column].transform("median")
         detailed_rank = macro_df.groupby(detailed_group, dropna=False)[source_column].rank(method="average", pct=True)

--- a/src/churn_baseline/feature_engineering.py
+++ b/src/churn_baseline/feature_engineering.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Final
 
 import numpy as np
@@ -12,9 +13,25 @@ import pandas as pd
 BLOCK_A: Final[str] = "A"
 BLOCK_B: Final[str] = "B"
 BLOCK_C: Final[str] = "C"
+BLOCK_G: Final[str] = "G"
+BLOCK_H: Final[str] = "H"
+BLOCK_R: Final[str] = "R"
+BLOCK_S: Final[str] = "S"
+BLOCK_V: Final[str] = "V"
 BLOCK_O: Final[str] = "O"
 BLOCK_P: Final[str] = "P"
-SUPPORTED_BLOCKS: Final[tuple[str, ...]] = (BLOCK_A, BLOCK_B, BLOCK_C, BLOCK_O, BLOCK_P)
+SUPPORTED_BLOCKS: Final[tuple[str, ...]] = (
+    BLOCK_A,
+    BLOCK_B,
+    BLOCK_C,
+    BLOCK_G,
+    BLOCK_H,
+    BLOCK_R,
+    BLOCK_S,
+    BLOCK_V,
+    BLOCK_O,
+    BLOCK_P,
+)
 
 # p01/p99 thresholds estimated from train.csv during outlier audit.
 OUTLIER_FLAG_BOUNDS_P01_P99: Final[dict[str, tuple[float, float]]] = {
@@ -33,7 +50,35 @@ BLOCK_ALIASES: Final[dict[str, str]] = {
     "CLIP": BLOCK_P,
     "CLIPPING": BLOCK_P,
     "PERCENTILE_CLIP": BLOCK_P,
+    "RENEWAL": BLOCK_R,
+    "LIFECYCLE": BLOCK_R,
+    "CYCLE": BLOCK_R,
+    "COVERAGE": BLOCK_G,
+    "BACKOFF": BLOCK_G,
+    "SUPPORT": BLOCK_G,
+    "FAMILY": BLOCK_G,
+    "HARD": BLOCK_H,
+    "CONTRAST": BLOCK_H,
+    "COHORT": BLOCK_H,
+    "COHORT_CONTRAST": BLOCK_H,
+    "SERVICE": BLOCK_S,
+    "SERVICES": BLOCK_S,
+    "BUNDLE": BLOCK_S,
+    "TOPOLOGY": BLOCK_S,
+    "VALUE": BLOCK_V,
+    "PRESSURE": BLOCK_V,
+    "FRICTION": BLOCK_V,
 }
+STATEFUL_BLOCKS: Final[tuple[str, ...]] = (BLOCK_G,)
+
+
+@dataclass(frozen=True)
+class CoverageBackoffState:
+    """Train-fitted support maps for family coverage/backoff features."""
+
+    min_segment5_support: int
+    segment3_counts: dict[str, int]
+    segment5_counts: dict[str, int]
 
 
 def normalize_feature_blocks(feature_blocks: Sequence[str] | None) -> tuple[str, ...]:
@@ -56,6 +101,16 @@ def normalize_feature_blocks(feature_blocks: Sequence[str] | None) -> tuple[str,
     return tuple(normalized)
 
 
+def partition_feature_blocks(
+    feature_blocks: Sequence[str] | None,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Split requested blocks into stateless and fit-aware subsets."""
+    normalized = normalize_feature_blocks(feature_blocks)
+    stateless = tuple(block for block in normalized if block not in STATEFUL_BLOCKS)
+    stateful = tuple(block for block in normalized if block in STATEFUL_BLOCKS)
+    return stateless, stateful
+
+
 def apply_feature_engineering(
     features: pd.DataFrame,
     feature_blocks: Sequence[str] | None,
@@ -73,6 +128,23 @@ def apply_feature_engineering(
         if block == BLOCK_C:
             out = _apply_block_c(out)
             continue
+        if block == BLOCK_G:
+            raise ValueError(
+                "Feature block G requires train-fitted coverage state; "
+                "use pipeline helpers that fit on the training split first."
+            )
+        if block == BLOCK_H:
+            out = _apply_block_h(out)
+            continue
+        if block == BLOCK_R:
+            out = _apply_block_r(out)
+            continue
+        if block == BLOCK_S:
+            out = _apply_block_s(out)
+            continue
+        if block == BLOCK_V:
+            out = _apply_block_v(out)
+            continue
         if block == BLOCK_O:
             out = _apply_block_o(out)
             continue
@@ -88,17 +160,132 @@ def _require_columns(frame: pd.DataFrame, columns: Sequence[str], block: str) ->
         raise ValueError(f"Feature block {block} requires columns not present in dataframe: {missing}")
 
 
+def _build_tenure_bin(tenure_values: pd.Series) -> pd.Series:
+    return pd.cut(
+        tenure_values,
+        bins=[-np.inf, 6, 12, 24, 48, np.inf],
+        labels=["0_6", "7_12", "13_24", "25_48", "49_plus"],
+    ).astype(str)
+
+
+def _ensure_tenure_bin(frame: pd.DataFrame) -> pd.Series:
+    if "tenure_bin" in frame.columns:
+        return frame["tenure_bin"].astype(str)
+    _require_columns(frame, ("tenure",), block=BLOCK_G)
+    tenure_values = pd.to_numeric(frame["tenure"], errors="coerce")
+    return _build_tenure_bin(tenure_values)
+
+
+def _yes_no_flag(series: pd.Series, positive_value: str = "yes") -> pd.Series:
+    return series.astype(str).str.lower().eq(positive_value).astype("int8")
+
+
+def _group_size(frame: pd.DataFrame, columns: Sequence[str]) -> pd.Series:
+    return frame.groupby(list(columns), dropna=False)[columns[0]].transform("size").astype("int32")
+
+
+def _build_segment3_key(frame: pd.DataFrame) -> pd.Series:
+    return (
+        frame["PaymentMethod"].astype(str)
+        + "__"
+        + frame["Contract"].astype(str)
+        + "__"
+        + frame["InternetService"].astype(str)
+    )
+
+
+def _build_segment5_key(frame: pd.DataFrame, tenure_bin: pd.Series) -> pd.Series:
+    return (
+        frame["PaymentMethod"].astype(str)
+        + "__"
+        + frame["Contract"].astype(str)
+        + "__"
+        + frame["InternetService"].astype(str)
+        + "__"
+        + frame["PaperlessBilling"].astype(str)
+        + "__"
+        + tenure_bin.astype(str)
+    )
+
+
+def _support_bucket(counts: pd.Series) -> pd.Series:
+    labels = ["zero", "1_4", "5_24", "25_74", "75_199", "200p"]
+    buckets = pd.cut(
+        counts.astype("float64"),
+        bins=[-0.1, 0.5, 4.5, 24.5, 74.5, 199.5, np.inf],
+        labels=labels,
+    )
+    return buckets.astype(str)
+
+
+def fit_coverage_backoff_state(
+    frame: pd.DataFrame,
+    *,
+    min_segment5_support: int = 75,
+) -> CoverageBackoffState:
+    """Fit train-only support maps for detailed and parent families."""
+    required = ("PaymentMethod", "Contract", "InternetService", "PaperlessBilling")
+    _require_columns(frame, required + ("tenure",), block=BLOCK_G)
+
+    tenure_bin = _ensure_tenure_bin(frame)
+    segment3 = _build_segment3_key(frame)
+    segment5 = _build_segment5_key(frame, tenure_bin)
+
+    segment3_counts = segment3.value_counts(dropna=False).astype(int).to_dict()
+    segment5_counts = segment5.value_counts(dropna=False).astype(int).to_dict()
+    return CoverageBackoffState(
+        min_segment5_support=int(min_segment5_support),
+        segment3_counts=segment3_counts,
+        segment5_counts=segment5_counts,
+    )
+
+
+def apply_coverage_backoff_features(
+    frame: pd.DataFrame,
+    state: CoverageBackoffState,
+) -> pd.DataFrame:
+    """Append train-fitted coverage and backoff features to any frame."""
+    required = ("PaymentMethod", "Contract", "InternetService", "PaperlessBilling")
+    _require_columns(frame, required + ("tenure",), block=BLOCK_G)
+
+    out = frame.copy()
+    tenure_bin = _ensure_tenure_bin(out)
+    if "tenure_bin" not in out.columns:
+        out["tenure_bin"] = tenure_bin
+
+    segment3 = _build_segment3_key(out)
+    segment5 = _build_segment5_key(out, tenure_bin)
+    segment3_rows = segment3.map(state.segment3_counts).fillna(0).astype("int32")
+    segment5_rows = segment5.map(state.segment5_counts).fillna(0).astype("int32")
+    use_segment5 = segment5_rows >= int(state.min_segment5_support)
+    segment3_rows_safe = segment3_rows.clip(lower=1)
+
+    out["segment3_family"] = segment3.astype(str)
+    out["segment5_family"] = segment5.astype(str)
+    out["segment3_train_rows"] = segment3_rows
+    out["segment5_train_rows"] = segment5_rows
+    out["segment5_seen_in_fit"] = segment5_rows.gt(0).astype("int8")
+    out["segment5_low_support_in_fit"] = segment5_rows.lt(int(state.min_segment5_support)).astype("int8")
+    out["segment5_backoff_to_segment3"] = (~use_segment5).astype("int8")
+    out["segment5_share_within_segment3"] = (
+        segment5_rows.astype("float64") / segment3_rows_safe.astype("float64")
+    ).astype("float64")
+    out["segment3_support_bucket"] = _support_bucket(segment3_rows)
+    out["segment5_support_bucket"] = _support_bucket(segment5_rows)
+    out["segment5_backoff_family"] = np.where(
+        use_segment5,
+        segment5.astype(str),
+        "BACKOFF__" + segment3.astype(str),
+    )
+    return out
+
+
 def _apply_block_a(frame: pd.DataFrame) -> pd.DataFrame:
     _require_columns(frame, ("tenure", "MonthlyCharges", "Contract"), block=BLOCK_A)
     out = frame.copy()
 
     tenure_values = pd.to_numeric(out["tenure"], errors="coerce")
-    tenure_labels = ["0_6", "7_12", "13_24", "25_48", "49_plus"]
-    out["tenure_bin"] = pd.cut(
-        tenure_values,
-        bins=[-np.inf, 6, 12, 24, 48, np.inf],
-        labels=tenure_labels,
-    ).astype(str)
+    out["tenure_bin"] = _build_tenure_bin(tenure_values)
 
     out["is_new_customer"] = (tenure_values <= 6).fillna(False).astype("int8")
 
@@ -148,6 +335,615 @@ def _apply_block_c(frame: pd.DataFrame) -> pd.DataFrame:
     out["techsupport_x_onlinesecurity"] = (
         out["TechSupport"].astype(str) + "__" + out["OnlineSecurity"].astype(str)
     )
+    return out
+
+
+def _apply_block_h(frame: pd.DataFrame) -> pd.DataFrame:
+    service_columns = (
+        "OnlineSecurity",
+        "OnlineBackup",
+        "DeviceProtection",
+        "TechSupport",
+        "StreamingTV",
+        "StreamingMovies",
+    )
+    required = (
+        "PaymentMethod",
+        "Contract",
+        "InternetService",
+        "PaperlessBilling",
+        "tenure",
+        "PhoneService",
+        "MultipleLines",
+    )
+    _require_columns(frame, required + service_columns, block=BLOCK_H)
+    out = frame.copy()
+
+    tenure_values = pd.to_numeric(out["tenure"], errors="coerce").fillna(0.0)
+    if "tenure_bin" not in out.columns:
+        out["tenure_bin"] = _build_tenure_bin(tenure_values)
+
+    has_internet = out["InternetService"].astype(str).str.lower().ne("no").astype("int8")
+    has_phone = _yes_no_flag(out["PhoneService"])
+    has_multiple_lines = _yes_no_flag(out["MultipleLines"])
+
+    support_count = np.zeros(len(out), dtype=np.int16)
+    entertainment_count = np.zeros(len(out), dtype=np.int16)
+    for column in ("OnlineSecurity", "OnlineBackup", "DeviceProtection", "TechSupport"):
+        support_count += _yes_no_flag(out[column]).to_numpy(dtype=np.int16)
+    for column in ("StreamingTV", "StreamingMovies"):
+        entertainment_count += _yes_no_flag(out[column]).to_numpy(dtype=np.int16)
+
+    paid_services_count = (
+        has_internet.to_numpy(dtype=np.int16)
+        + has_phone.to_numpy(dtype=np.int16)
+        + has_multiple_lines.to_numpy(dtype=np.int16)
+        + support_count
+        + entertainment_count
+    ).astype("int16")
+    addon_total = support_count.astype("float64") + entertainment_count.astype("float64")
+    support_share = np.divide(
+        support_count.astype("float64"),
+        np.clip(addon_total, 1.0, None),
+    )
+
+    support_signature = (
+        out["OnlineSecurity"].astype(str).str.slice(0, 1).str.upper()
+        + out["OnlineBackup"].astype(str).str.slice(0, 1).str.upper()
+        + out["DeviceProtection"].astype(str).str.slice(0, 1).str.upper()
+        + out["TechSupport"].astype(str).str.slice(0, 1).str.upper()
+    )
+    streaming_signature = (
+        out["StreamingTV"].astype(str).str.slice(0, 1).str.upper()
+        + out["StreamingMovies"].astype(str).str.slice(0, 1).str.upper()
+    )
+    bundle_archetype = np.select(
+        condlist=[
+            has_internet.to_numpy(dtype=np.int8) == 0,
+            (support_count == 0) & (entertainment_count == 0),
+            (support_count == 0) & (entertainment_count >= 1),
+            (support_count >= 1) & (entertainment_count == 0),
+            support_count >= (entertainment_count + 2),
+            entertainment_count >= (support_count + 1),
+        ],
+        choicelist=[
+            "no_internet",
+            "connectivity_only",
+            "streaming_only",
+            "support_only",
+            "support_heavy",
+            "entertainment_heavy",
+        ],
+        default="balanced",
+    )
+
+    detailed_group = ["PaymentMethod", "Contract", "InternetService", "PaperlessBilling", "tenure_bin"]
+    fallback_group = ["Contract", "InternetService", "tenure_bin"]
+    detailed_rows = _group_size(out, detailed_group)
+    fallback_rows = _group_size(out, fallback_group)
+    use_detailed = detailed_rows >= 75
+
+    support_series = pd.Series(support_count, index=out.index, dtype="float64")
+    entertainment_series = pd.Series(entertainment_count, index=out.index, dtype="float64")
+    paid_services_series = pd.Series(paid_services_count, index=out.index, dtype="float64")
+    support_share_series = pd.Series(support_share, index=out.index, dtype="float64")
+    service_mix_series = pd.Series(support_count - entertainment_count, index=out.index, dtype="float64")
+
+    detailed_support_median = support_series.groupby(
+        [out[column] for column in detailed_group],
+        dropna=False,
+    ).transform("median")
+    fallback_support_median = support_series.groupby(
+        [out[column] for column in fallback_group],
+        dropna=False,
+    ).transform("median")
+    detailed_entertainment_median = entertainment_series.groupby(
+        [out[column] for column in detailed_group],
+        dropna=False,
+    ).transform("median")
+    fallback_entertainment_median = entertainment_series.groupby(
+        [out[column] for column in fallback_group],
+        dropna=False,
+    ).transform("median")
+    detailed_paid_services_median = paid_services_series.groupby(
+        [out[column] for column in detailed_group],
+        dropna=False,
+    ).transform("median")
+    fallback_paid_services_median = paid_services_series.groupby(
+        [out[column] for column in fallback_group],
+        dropna=False,
+    ).transform("median")
+    detailed_support_share_mean = support_share_series.groupby(
+        [out[column] for column in detailed_group],
+        dropna=False,
+    ).transform("mean")
+    fallback_support_share_mean = support_share_series.groupby(
+        [out[column] for column in fallback_group],
+        dropna=False,
+    ).transform("mean")
+    detailed_service_mix_mean = service_mix_series.groupby(
+        [out[column] for column in detailed_group],
+        dropna=False,
+    ).transform("mean")
+    fallback_service_mix_mean = service_mix_series.groupby(
+        [out[column] for column in fallback_group],
+        dropna=False,
+    ).transform("mean")
+
+    detailed_support_rank = support_series.groupby(
+        [out[column] for column in detailed_group],
+        dropna=False,
+    ).rank(method="average", pct=True)
+    fallback_support_rank = support_series.groupby(
+        [out[column] for column in fallback_group],
+        dropna=False,
+    ).rank(method="average", pct=True)
+    detailed_entertainment_rank = entertainment_series.groupby(
+        [out[column] for column in detailed_group],
+        dropna=False,
+    ).rank(method="average", pct=True)
+    fallback_entertainment_rank = entertainment_series.groupby(
+        [out[column] for column in fallback_group],
+        dropna=False,
+    ).rank(method="average", pct=True)
+    detailed_service_mix_rank = service_mix_series.groupby(
+        [out[column] for column in detailed_group],
+        dropna=False,
+    ).rank(method="average", pct=True)
+    fallback_service_mix_rank = service_mix_series.groupby(
+        [out[column] for column in fallback_group],
+        dropna=False,
+    ).rank(method="average", pct=True)
+
+    bundle_key = pd.Series(bundle_archetype, index=out.index, dtype="object")
+    service_signature_key = (
+        out["InternetService"].astype(str)
+        + "__"
+        + support_signature.astype(str)
+        + "__"
+        + streaming_signature.astype(str)
+        + "__"
+        + out["MultipleLines"].astype(str)
+    )
+    detailed_bundle_rows = _group_size(out.assign(_contrast_bundle_key=bundle_key), detailed_group + ["_contrast_bundle_key"])
+    fallback_bundle_rows = _group_size(out.assign(_contrast_bundle_key=bundle_key), fallback_group + ["_contrast_bundle_key"])
+    detailed_signature_rows = _group_size(
+        out.assign(_contrast_signature_key=service_signature_key),
+        detailed_group + ["_contrast_signature_key"],
+    )
+    fallback_signature_rows = _group_size(
+        out.assign(_contrast_signature_key=service_signature_key),
+        fallback_group + ["_contrast_signature_key"],
+    )
+
+    cohort_rows = pd.Series(
+        np.where(use_detailed, detailed_rows, fallback_rows),
+        index=out.index,
+        dtype="float64",
+    )
+    support_median = pd.Series(
+        np.where(use_detailed, detailed_support_median, fallback_support_median),
+        index=out.index,
+        dtype="float64",
+    )
+    entertainment_median = pd.Series(
+        np.where(use_detailed, detailed_entertainment_median, fallback_entertainment_median),
+        index=out.index,
+        dtype="float64",
+    )
+    paid_services_median = pd.Series(
+        np.where(use_detailed, detailed_paid_services_median, fallback_paid_services_median),
+        index=out.index,
+        dtype="float64",
+    )
+    support_share_mean = pd.Series(
+        np.where(use_detailed, detailed_support_share_mean, fallback_support_share_mean),
+        index=out.index,
+        dtype="float64",
+    )
+    service_mix_mean = pd.Series(
+        np.where(use_detailed, detailed_service_mix_mean, fallback_service_mix_mean),
+        index=out.index,
+        dtype="float64",
+    )
+    support_rank = pd.Series(
+        np.where(use_detailed, detailed_support_rank, fallback_support_rank),
+        index=out.index,
+        dtype="float64",
+    )
+    entertainment_rank = pd.Series(
+        np.where(use_detailed, detailed_entertainment_rank, fallback_entertainment_rank),
+        index=out.index,
+        dtype="float64",
+    )
+    service_mix_rank = pd.Series(
+        np.where(use_detailed, detailed_service_mix_rank, fallback_service_mix_rank),
+        index=out.index,
+        dtype="float64",
+    )
+    bundle_rows = pd.Series(
+        np.where(use_detailed, detailed_bundle_rows, fallback_bundle_rows),
+        index=out.index,
+        dtype="float64",
+    )
+    signature_rows = pd.Series(
+        np.where(use_detailed, detailed_signature_rows, fallback_signature_rows),
+        index=out.index,
+        dtype="float64",
+    )
+
+    out["contrast_cohort_rows"] = cohort_rows.astype("int32")
+    out["contrast_used_fallback_cohort"] = (~use_detailed).astype("int8")
+    out["support_count_minus_contrast_cohort"] = (support_series - support_median).astype("float64")
+    out["entertainment_count_minus_contrast_cohort"] = (
+        entertainment_series - entertainment_median
+    ).astype("float64")
+    out["paid_services_minus_contrast_cohort"] = (paid_services_series - paid_services_median).astype("float64")
+    out["support_share_minus_contrast_cohort"] = (support_share_series - support_share_mean).astype("float64")
+    out["service_mix_minus_contrast_cohort"] = (service_mix_series - service_mix_mean).astype("float64")
+    out["support_count_rank_in_contrast_cohort"] = support_rank.astype("float64")
+    out["entertainment_count_rank_in_contrast_cohort"] = entertainment_rank.astype("float64")
+    out["service_mix_rank_in_contrast_cohort"] = service_mix_rank.astype("float64")
+    out["bundle_archetype_rows_in_contrast_cohort"] = bundle_rows.astype("int32")
+    out["bundle_archetype_share_in_contrast_cohort"] = (
+        bundle_rows / cohort_rows.clip(lower=1.0)
+    ).astype("float64")
+    out["service_signature_rows_in_contrast_cohort"] = signature_rows.astype("int32")
+    out["service_signature_share_in_contrast_cohort"] = (
+        signature_rows / cohort_rows.clip(lower=1.0)
+    ).astype("float64")
+    out["is_rare_bundle_archetype_in_contrast_cohort"] = (
+        out["bundle_archetype_share_in_contrast_cohort"] <= 0.15
+    ).astype("int8")
+    out["is_rare_service_signature_in_contrast_cohort"] = (
+        out["service_signature_share_in_contrast_cohort"] <= 0.10
+    ).astype("int8")
+
+    return out
+
+
+def _apply_block_r(frame: pd.DataFrame) -> pd.DataFrame:
+    _require_columns(frame, ("tenure", "Contract"), block=BLOCK_R)
+    out = frame.copy()
+
+    tenure_values = pd.to_numeric(out["tenure"], errors="coerce").fillna(0.0)
+    contract_text = out["Contract"].astype(str)
+    contract_months = contract_text.map(
+        {
+            "Month-to-month": 1,
+            "One year": 12,
+            "Two year": 24,
+        }
+    ).fillna(1).astype("int16")
+
+    out["contract_months"] = contract_months
+    out["has_contract_cycle"] = (contract_months > 1).astype("int8")
+
+    out["tenure_mod_12"] = np.mod(tenure_values, 12).astype("int16")
+    out["tenure_mod_24"] = np.mod(tenure_values, 24).astype("int16")
+    out["months_to_12_boundary"] = np.mod(12 - out["tenure_mod_12"], 12).astype("int16")
+    out["months_to_24_boundary"] = np.mod(24 - out["tenure_mod_24"], 24).astype("int16")
+    out["annual_cycle_progress"] = (out["tenure_mod_12"] / 12.0).astype("float64")
+    out["two_year_cycle_progress"] = (out["tenure_mod_24"] / 24.0).astype("float64")
+
+    contract_months_safe = contract_months.clip(lower=1)
+    contract_cycle_position = np.mod(tenure_values, contract_months_safe).astype("int16")
+    months_to_contract_boundary = np.mod(
+        contract_months_safe - contract_cycle_position,
+        contract_months_safe,
+    ).astype("int16")
+    months_to_contract_boundary = np.where(
+        contract_months_safe > 1,
+        months_to_contract_boundary,
+        0,
+    ).astype("int16")
+    contract_cycle_progress = np.where(
+        contract_months_safe > 1,
+        contract_cycle_position / contract_months_safe,
+        0.0,
+    )
+
+    out["contract_cycle_position"] = contract_cycle_position
+    out["months_to_contract_boundary"] = months_to_contract_boundary
+    out["contract_cycle_progress"] = pd.Series(contract_cycle_progress, index=out.index).astype("float64")
+    out["near_contract_boundary_1"] = (
+        (out["has_contract_cycle"] == 1) & (out["months_to_contract_boundary"] <= 1)
+    ).astype("int8")
+    out["near_contract_boundary_2"] = (
+        (out["has_contract_cycle"] == 1) & (out["months_to_contract_boundary"] <= 2)
+    ).astype("int8")
+    out["near_contract_boundary_3"] = (
+        (out["has_contract_cycle"] == 1) & (out["months_to_contract_boundary"] <= 3)
+    ).astype("int8")
+
+    out["annual_boundary_bin"] = pd.cut(
+        out["months_to_12_boundary"],
+        bins=[-1, 0, 2, 5, 11],
+        labels=["now", "near_2", "near_5", "far"],
+    ).astype(str)
+    out["contract_boundary_bin"] = np.where(
+        out["has_contract_cycle"] == 1,
+        pd.cut(
+            out["months_to_contract_boundary"],
+            bins=[-1, 0, 2, 5, 24],
+            labels=["now", "near_2", "near_5", "far"],
+        ).astype(str),
+        "no_cycle",
+    )
+    out["contract_x_boundary_bin"] = (
+        contract_text + "__" + out["contract_boundary_bin"].astype(str)
+    )
+    return out
+
+
+def _apply_block_s(frame: pd.DataFrame) -> pd.DataFrame:
+    service_columns = (
+        "OnlineSecurity",
+        "OnlineBackup",
+        "DeviceProtection",
+        "TechSupport",
+        "StreamingTV",
+        "StreamingMovies",
+    )
+    required = (
+        "InternetService",
+        "Contract",
+        "PaymentMethod",
+        "PhoneService",
+        "MultipleLines",
+    )
+    _require_columns(frame, required + service_columns, block=BLOCK_S)
+    out = frame.copy()
+
+    has_internet = out["InternetService"].astype(str).str.lower().ne("no").astype("int8")
+    has_phone = _yes_no_flag(out["PhoneService"])
+    has_multiple_lines = _yes_no_flag(out["MultipleLines"])
+    support_columns = ("OnlineSecurity", "OnlineBackup", "DeviceProtection", "TechSupport")
+    entertainment_columns = ("StreamingTV", "StreamingMovies")
+
+    support_count = np.zeros(len(out), dtype=np.int16)
+    entertainment_count = np.zeros(len(out), dtype=np.int16)
+    for column in support_columns:
+        support_count += _yes_no_flag(out[column]).to_numpy(dtype=np.int16)
+    for column in entertainment_columns:
+        entertainment_count += _yes_no_flag(out[column]).to_numpy(dtype=np.int16)
+
+    paid_services_count = (
+        has_internet.to_numpy(dtype=np.int16)
+        + has_phone.to_numpy(dtype=np.int16)
+        + has_multiple_lines.to_numpy(dtype=np.int16)
+        + support_count
+        + entertainment_count
+    ).astype("int16")
+    manual_payment = out["PaymentMethod"].astype(str).str.contains("automatic", case=False, regex=False).map(
+        {True: 0, False: 1}
+    ).astype("int8")
+
+    support_signature = (
+        out["OnlineSecurity"].astype(str).str.slice(0, 1).str.upper()
+        + out["OnlineBackup"].astype(str).str.slice(0, 1).str.upper()
+        + out["DeviceProtection"].astype(str).str.slice(0, 1).str.upper()
+        + out["TechSupport"].astype(str).str.slice(0, 1).str.upper()
+    )
+    streaming_signature = (
+        out["StreamingTV"].astype(str).str.slice(0, 1).str.upper()
+        + out["StreamingMovies"].astype(str).str.slice(0, 1).str.upper()
+    )
+
+    support_count_bin = pd.cut(
+        support_count,
+        bins=[-1, 0, 1, 2, 4],
+        labels=["0", "1", "2", "3p"],
+    ).astype(str)
+    entertainment_count_bin = pd.cut(
+        entertainment_count,
+        bins=[-1, 0, 1, 2],
+        labels=["0", "1", "2"],
+    ).astype(str)
+
+    bundle_archetype = np.select(
+        condlist=[
+            has_internet.to_numpy(dtype=np.int8) == 0,
+            (support_count == 0) & (entertainment_count == 0),
+            (support_count == 0) & (entertainment_count >= 1),
+            (support_count >= 1) & (entertainment_count == 0),
+            support_count >= (entertainment_count + 2),
+            entertainment_count >= (support_count + 1),
+        ],
+        choicelist=[
+            "no_internet",
+            "connectivity_only",
+            "streaming_only",
+            "support_only",
+            "support_heavy",
+            "entertainment_heavy",
+        ],
+        default="balanced",
+    )
+
+    support_total = support_count.astype("float64") + entertainment_count.astype("float64")
+    support_share = np.divide(
+        support_count.astype("float64"),
+        np.clip(support_total, 1.0, None),
+    )
+
+    out["support_minus_entertainment"] = (support_count - entertainment_count).astype("int16")
+    out["support_share_of_addons"] = pd.Series(support_share, index=out.index).astype("float64")
+    out["is_support_gap_high"] = (
+        (has_internet == 1) & (support_count <= 1)
+    ).astype("int8")
+    out["is_securityless_fiber"] = (
+        out["InternetService"].astype(str).eq("Fiber optic") & (support_count == 0)
+    ).astype("int8")
+    out["is_manual_basic_service"] = (
+        (manual_payment == 1) & (paid_services_count <= 1)
+    ).astype("int8")
+    out["is_manual_streaming_light_support"] = (
+        (manual_payment == 1)
+        & (entertainment_count >= 1)
+        & (support_count <= 1)
+        & (has_internet == 1)
+    ).astype("int8")
+    out["bundle_archetype"] = pd.Series(bundle_archetype, index=out.index).astype(str)
+    out["support_signature"] = support_signature.astype(str)
+    out["streaming_signature"] = streaming_signature.astype(str)
+    out["service_topology"] = (
+        out["InternetService"].astype(str)
+        + "__"
+        + out["bundle_archetype"]
+        + "__"
+        + out["Contract"].astype(str)
+        + "__"
+        + out["MultipleLines"].astype(str)
+    )
+    out["service_signature"] = (
+        out["InternetService"].astype(str)
+        + "__"
+        + support_count_bin
+        + "__"
+        + entertainment_count_bin
+        + "__"
+        + support_signature
+        + "__"
+        + streaming_signature
+    )
+
+    return out
+
+
+def _apply_block_v(frame: pd.DataFrame) -> pd.DataFrame:
+    service_columns = (
+        "OnlineSecurity",
+        "OnlineBackup",
+        "DeviceProtection",
+        "TechSupport",
+        "StreamingTV",
+        "StreamingMovies",
+    )
+    required = (
+        "PaymentMethod",
+        "Contract",
+        "InternetService",
+        "PaperlessBilling",
+        "tenure",
+        "PhoneService",
+        "MultipleLines",
+        "MonthlyCharges",
+        "TotalCharges",
+    )
+    _require_columns(frame, required + service_columns, block=BLOCK_V)
+    out = frame.copy()
+
+    tenure_values = pd.to_numeric(out["tenure"], errors="coerce").fillna(0.0)
+    tenure_safe = tenure_values.clip(lower=1.0)
+    monthly_charges = pd.to_numeric(out["MonthlyCharges"], errors="coerce").fillna(0.0)
+    total_charges = pd.to_numeric(out["TotalCharges"], errors="coerce").fillna(0.0)
+    if "tenure_bin" not in out.columns:
+        out["tenure_bin"] = _build_tenure_bin(tenure_values)
+
+    has_internet = out["InternetService"].astype(str).str.lower().ne("no").astype("int8")
+    has_phone = _yes_no_flag(out["PhoneService"])
+    has_multiple_lines = _yes_no_flag(out["MultipleLines"])
+    support_services_count = np.zeros(len(out), dtype=np.int16)
+    entertainment_services_count = np.zeros(len(out), dtype=np.int16)
+    for column in ("OnlineSecurity", "OnlineBackup", "DeviceProtection", "TechSupport"):
+        support_services_count += _yes_no_flag(out[column]).to_numpy(dtype=np.int16)
+    for column in ("StreamingTV", "StreamingMovies"):
+        entertainment_services_count += _yes_no_flag(out[column]).to_numpy(dtype=np.int16)
+
+    paid_services_count = (
+        has_internet.to_numpy(dtype=np.int16)
+        + has_phone.to_numpy(dtype=np.int16)
+        + has_multiple_lines.to_numpy(dtype=np.int16)
+        + support_services_count
+        + entertainment_services_count
+    ).astype("int16")
+    paid_services_safe = np.clip(paid_services_count, 1, None)
+
+    payment_friction_index = out["PaymentMethod"].astype(str).map(
+        {
+            "Credit card (automatic)": 0,
+            "Bank transfer (automatic)": 0,
+            "Electronic check": 2,
+            "Mailed check": 3,
+        }
+    ).fillna(1).astype("int8")
+
+    out["support_services_count"] = support_services_count.astype("int16")
+    out["entertainment_services_count"] = entertainment_services_count.astype("int16")
+    out["paid_services_count"] = paid_services_count.astype("int16")
+    out["support_deficit_count"] = np.where(
+        has_internet.to_numpy(dtype=np.int8) == 1,
+        4 - support_services_count,
+        0,
+    ).astype("int16")
+    out["monthly_per_active_service"] = (monthly_charges / paid_services_safe).astype("float64")
+    out["effective_monthly_charge"] = (total_charges / tenure_safe).astype("float64")
+    out["current_vs_effective_monthly_delta"] = (
+        monthly_charges - out["effective_monthly_charge"]
+    ).astype("float64")
+    out["current_vs_effective_monthly_ratio"] = (
+        monthly_charges / out["effective_monthly_charge"].clip(lower=1.0)
+    ).astype("float64")
+    out["payment_friction_index"] = payment_friction_index
+    out["is_support_light"] = (
+        (has_internet == 1) & (out["support_services_count"] <= 1)
+    ).astype("int8")
+    out["is_streaming_heavy_support_light"] = (
+        (has_internet == 1)
+        & (out["entertainment_services_count"] >= 1)
+        & (out["support_services_count"] == 0)
+    ).astype("int8")
+
+    detailed_group = ["PaymentMethod", "Contract", "InternetService", "PaperlessBilling", "tenure_bin"]
+    fallback_group = ["Contract", "InternetService", "tenure_bin"]
+    detailed_rows = _group_size(out, detailed_group)
+
+    detailed_monthly_median = out.groupby(detailed_group, dropna=False)["MonthlyCharges"].transform("median")
+    fallback_monthly_median = out.groupby(fallback_group, dropna=False)["MonthlyCharges"].transform("median")
+    detailed_mpas_median = out.groupby(detailed_group, dropna=False)["monthly_per_active_service"].transform("median")
+    fallback_mpas_median = out.groupby(fallback_group, dropna=False)["monthly_per_active_service"].transform("median")
+    detailed_service_median = out.groupby(detailed_group, dropna=False)["paid_services_count"].transform("median")
+    fallback_service_median = out.groupby(fallback_group, dropna=False)["paid_services_count"].transform("median")
+    detailed_monthly_rank = out.groupby(detailed_group, dropna=False)["MonthlyCharges"].rank(method="average", pct=True)
+    fallback_monthly_rank = out.groupby(fallback_group, dropna=False)["MonthlyCharges"].rank(method="average", pct=True)
+
+    use_detailed = detailed_rows >= 75
+    cohort_monthly_median = pd.Series(
+        np.where(use_detailed, detailed_monthly_median, fallback_monthly_median),
+        index=out.index,
+        dtype="float64",
+    )
+    cohort_mpas_median = pd.Series(
+        np.where(use_detailed, detailed_mpas_median, fallback_mpas_median),
+        index=out.index,
+        dtype="float64",
+    )
+    cohort_service_median = pd.Series(
+        np.where(use_detailed, detailed_service_median, fallback_service_median),
+        index=out.index,
+        dtype="float64",
+    )
+    cohort_monthly_rank = pd.Series(
+        np.where(use_detailed, detailed_monthly_rank, fallback_monthly_rank),
+        index=out.index,
+        dtype="float64",
+    )
+
+    out["value_cohort_rows"] = detailed_rows
+    out["value_low_support_cohort"] = (~use_detailed).astype("int8")
+    out["monthly_minus_value_cohort_median"] = (monthly_charges - cohort_monthly_median).astype("float64")
+    out["monthly_over_value_cohort_median"] = (
+        monthly_charges / cohort_monthly_median.clip(lower=1.0)
+    ).astype("float64")
+    out["monthly_rank_in_value_cohort"] = cohort_monthly_rank.astype("float64")
+    out["monthly_per_active_service_minus_cohort"] = (
+        out["monthly_per_active_service"] - cohort_mpas_median
+    ).astype("float64")
+    out["paid_services_minus_cohort"] = (
+        out["paid_services_count"].astype("float64") - cohort_service_median
+    ).astype("float64")
+
     return out
 
 

--- a/src/churn_baseline/fm_probe.py
+++ b/src/churn_baseline/fm_probe.py
@@ -1,0 +1,319 @@
+"""River FM/FFM probes for orthogonal tabular signals."""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+from river import facto, optim
+from sklearn.model_selection import StratifiedKFold
+
+from .artifacts import ensure_parent_dir, write_json
+from .config import ID_COLUMN, TARGET_COLUMN
+from .data import infer_categorical_columns, load_csv, prepare_train_features
+from .evaluation import binary_auc
+from .feature_engineering import normalize_feature_blocks
+
+FM = "fm"
+FFM = "ffm"
+FM_PROBE_FAMILIES: tuple[str, ...] = (FM, FFM)
+
+
+def list_fm_probe_families() -> tuple[str, ...]:
+    """Return supported factorization-model families."""
+    return FM_PROBE_FAMILIES
+
+
+def _save_pickle(path: str | Path, payload: Any) -> Path:
+    out_path = ensure_parent_dir(path)
+    with out_path.open("wb") as fh:
+        pickle.dump(payload, fh)
+    return out_path
+
+
+def _build_fm_model(
+    *,
+    model_family: str,
+    n_factors: int,
+    weight_lr: float,
+    latent_lr: float,
+    l2_weight: float,
+    l2_latent: float,
+    sample_normalization: bool,
+    seed: int,
+) -> Any:
+    family = str(model_family).strip().lower()
+    common_kwargs = {
+        "n_factors": int(n_factors),
+        "weight_optimizer": optim.AdaGrad(lr=float(weight_lr)),
+        "latent_optimizer": optim.AdaGrad(lr=float(latent_lr)),
+        "l2_weight": float(l2_weight),
+        "l2_latent": float(l2_latent),
+        "sample_normalization": bool(sample_normalization),
+        "seed": int(seed),
+    }
+    if family == FM:
+        return facto.FMClassifier(**common_kwargs)
+    if family == FFM:
+        return facto.FFMClassifier(**common_kwargs)
+    raise ValueError(f"Unsupported model_family '{model_family}'. Available: {FM_PROBE_FAMILIES}")
+
+
+def _prepare_fold_frames(
+    frame: pd.DataFrame,
+    *,
+    categorical_columns: Sequence[str],
+    numeric_columns: Sequence[str],
+    medians: pd.Series,
+    means: pd.Series,
+    stds: pd.Series,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    categorical_frame = frame.loc[:, list(categorical_columns)].copy() if categorical_columns else pd.DataFrame(index=frame.index)
+    if categorical_columns:
+        categorical_frame = categorical_frame.fillna("__MISSING__").astype(str)
+
+    numeric_frame = frame.loc[:, list(numeric_columns)].copy() if numeric_columns else pd.DataFrame(index=frame.index)
+    if numeric_columns:
+        numeric_frame = numeric_frame.fillna(medians)
+        numeric_frame = (numeric_frame - means) / stds
+        numeric_frame = numeric_frame.replace([np.inf, -np.inf], 0.0).fillna(0.0)
+    return categorical_frame, numeric_frame
+
+
+def _iter_feature_dicts(
+    categorical_frame: pd.DataFrame,
+    numeric_frame: pd.DataFrame,
+) -> Sequence[dict[str, Any]]:
+    cat_columns = list(categorical_frame.columns)
+    num_columns = list(numeric_frame.columns)
+    cat_keys = [f"f{i:03d}_{column}" for i, column in enumerate(cat_columns)]
+    num_offset = len(cat_keys)
+    num_keys = [f"f{num_offset + i:03d}_{column}" for i, column in enumerate(num_columns)]
+
+    cat_values = categorical_frame.to_numpy(dtype=object, copy=False) if cat_columns else np.empty((len(categorical_frame), 0), dtype=object)
+    num_values = numeric_frame.to_numpy(dtype="float64", copy=False) if num_columns else np.empty((len(numeric_frame), 0), dtype="float64")
+
+    for row_idx in range(len(categorical_frame.index)):
+        payload: dict[str, Any] = {}
+        for col_idx, key in enumerate(cat_keys):
+            payload[key] = str(cat_values[row_idx, col_idx])
+        for col_idx, key in enumerate(num_keys):
+            value = float(num_values[row_idx, col_idx])
+            if value != 0.0:
+                payload[key] = value
+        yield payload
+
+
+def _predict_positive_probability(model: Any, features: dict[str, Any]) -> float:
+    proba = model.predict_proba_one(features)
+    return float(proba.get(True, proba.get(1, 0.0)))
+
+
+def run_fm_probe_cv(
+    *,
+    train_csv_path: str | Path,
+    model_path: str | Path,
+    metrics_path: str | Path,
+    oof_path: str | Path,
+    feature_blocks: Sequence[str] | None,
+    folds: int,
+    random_state: int,
+    model_family: str,
+    n_factors: int,
+    epochs: int,
+    weight_lr: float,
+    latent_lr: float,
+    l2_weight: float,
+    l2_latent: float,
+    sample_normalization: bool,
+    reference_pred: pd.Series | None = None,
+    alpha_grid: Sequence[float] | None = None,
+) -> dict[str, Any]:
+    """Train a River FM/FFM probe with OOF evaluation and optional blend scan."""
+    if folds < 2:
+        raise ValueError("folds must be >= 2")
+    if epochs < 1:
+        raise ValueError("epochs must be >= 1")
+
+    train_df = load_csv(train_csv_path)
+    normalized_blocks = normalize_feature_blocks(feature_blocks)
+    x, y = prepare_train_features(train_df, drop_id=True, feature_blocks=normalized_blocks)
+    categorical_columns = infer_categorical_columns(x)
+    numeric_columns = [column for column in x.columns if column not in categorical_columns]
+
+    splitter = StratifiedKFold(n_splits=folds, shuffle=True, random_state=random_state)
+    oof_pred = pd.Series(index=x.index, dtype="float64", name="oof_pred")
+    fold_rows: list[dict[str, Any]] = []
+
+    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x, y), start=1):
+        x_train = x.iloc[train_idx]
+        y_train = y.iloc[train_idx].astype(bool)
+        x_valid = x.iloc[valid_idx]
+        y_valid = y.iloc[valid_idx]
+
+        medians = x_train.loc[:, numeric_columns].median() if numeric_columns else pd.Series(dtype="float64")
+        means = x_train.loc[:, numeric_columns].mean() if numeric_columns else pd.Series(dtype="float64")
+        stds = x_train.loc[:, numeric_columns].std(ddof=0).replace(0.0, 1.0) if numeric_columns else pd.Series(dtype="float64")
+
+        cat_train, num_train = _prepare_fold_frames(
+            x_train,
+            categorical_columns=categorical_columns,
+            numeric_columns=numeric_columns,
+            medians=medians,
+            means=means,
+            stds=stds,
+        )
+        cat_valid, num_valid = _prepare_fold_frames(
+            x_valid,
+            categorical_columns=categorical_columns,
+            numeric_columns=numeric_columns,
+            medians=medians,
+            means=means,
+            stds=stds,
+        )
+
+        model = _build_fm_model(
+            model_family=model_family,
+            n_factors=n_factors,
+            weight_lr=weight_lr,
+            latent_lr=latent_lr,
+            l2_weight=l2_weight,
+            l2_latent=l2_latent,
+            sample_normalization=sample_normalization,
+            seed=random_state,
+        )
+
+        train_target = y_train.tolist()
+        for _ in range(int(epochs)):
+            for features, target in zip(_iter_feature_dicts(cat_train, num_train), train_target):
+                model.learn_one(features, target)
+
+        valid_predictions = [
+            _predict_positive_probability(model, features)
+            for features in _iter_feature_dicts(cat_valid, num_valid)
+        ]
+        fold_pred = pd.Series(valid_predictions, index=x_valid.index, dtype="float64")
+        oof_pred.iloc[valid_idx] = fold_pred.values
+        fold_rows.append(
+            {
+                "fold": int(fold_number),
+                "valid_rows": int(len(valid_idx)),
+                "auc": float(binary_auc(y_valid, fold_pred)),
+            }
+        )
+
+    if oof_pred.isna().any():
+        raise RuntimeError("OOF predictions contain missing values for FM probe.")
+
+    full_medians = x.loc[:, numeric_columns].median() if numeric_columns else pd.Series(dtype="float64")
+    full_means = x.loc[:, numeric_columns].mean() if numeric_columns else pd.Series(dtype="float64")
+    full_stds = x.loc[:, numeric_columns].std(ddof=0).replace(0.0, 1.0) if numeric_columns else pd.Series(dtype="float64")
+    cat_full, num_full = _prepare_fold_frames(
+        x,
+        categorical_columns=categorical_columns,
+        numeric_columns=numeric_columns,
+        medians=full_medians,
+        means=full_means,
+        stds=full_stds,
+    )
+    full_model = _build_fm_model(
+        model_family=model_family,
+        n_factors=n_factors,
+        weight_lr=weight_lr,
+        latent_lr=latent_lr,
+        l2_weight=l2_weight,
+        l2_latent=l2_latent,
+        sample_normalization=sample_normalization,
+        seed=random_state,
+    )
+    full_target = y.astype(bool).tolist()
+    for _ in range(int(epochs)):
+        for features, target in zip(_iter_feature_dicts(cat_full, num_full), full_target):
+            full_model.learn_one(features, target)
+
+    _save_pickle(
+        model_path,
+        {
+            "model_family": str(model_family),
+            "model": full_model,
+            "feature_blocks": list(normalized_blocks),
+            "categorical_columns": list(categorical_columns),
+            "numeric_columns": list(numeric_columns),
+            "medians": full_medians.to_dict(),
+            "means": full_means.to_dict(),
+            "stds": full_stds.to_dict(),
+        },
+    )
+
+    oof_output = pd.DataFrame(
+        {
+            ID_COLUMN: train_df[ID_COLUMN].values,
+            "target": y.astype(int).values,
+            "oof_pred": oof_pred.values,
+        }
+    )
+    ensure_parent_dir(oof_path)
+    oof_output.to_csv(oof_path, index=False)
+
+    metrics: dict[str, Any] = {
+        "train_rows": int(len(train_df)),
+        "feature_count": int(x.shape[1]),
+        "feature_blocks": list(normalized_blocks),
+        "categorical_columns": list(categorical_columns),
+        "numeric_columns": list(numeric_columns),
+        "cv_folds": int(folds),
+        "cv_fold_metrics": fold_rows,
+        "cv_mean_auc": float(np.mean([row["auc"] for row in fold_rows])),
+        "cv_std_auc": float(np.std([row["auc"] for row in fold_rows])),
+        "oof_auc": float(binary_auc(y, oof_pred)),
+        "model_path": str(model_path),
+        "oof_path": str(oof_path),
+        "target_column": TARGET_COLUMN,
+        "id_column": ID_COLUMN,
+        "model_family": str(model_family),
+        "params": {
+            "n_factors": int(n_factors),
+            "epochs": int(epochs),
+            "weight_lr": float(weight_lr),
+            "latent_lr": float(latent_lr),
+            "l2_weight": float(l2_weight),
+            "l2_latent": float(l2_latent),
+            "sample_normalization": bool(sample_normalization),
+        },
+    }
+
+    if reference_pred is not None:
+        reference_by_id = pd.Series(reference_pred, copy=True)
+        aligned_reference = train_df[ID_COLUMN].map(reference_by_id)
+        if aligned_reference.isna().any():
+            missing_ids = train_df.loc[aligned_reference.isna(), ID_COLUMN].head(5).tolist()
+            raise ValueError(f"reference_pred missing ids from train: {missing_ids}")
+        aligned_reference = pd.Series(aligned_reference.values, index=x.index, dtype="float64")
+        metrics["reference_oof_auc"] = float(binary_auc(y, aligned_reference))
+        metrics["pearson_corr_vs_reference"] = float(aligned_reference.corr(oof_pred))
+        metrics["spearman_corr_vs_reference"] = float(aligned_reference.corr(oof_pred, method="spearman"))
+
+        if alpha_grid:
+            alpha_rows: list[dict[str, Any]] = []
+            for alpha in alpha_grid:
+                alpha_value = float(alpha)
+                candidate = (1.0 - alpha_value) * aligned_reference + alpha_value * oof_pred
+                alpha_rows.append(
+                    {
+                        "alpha": alpha_value,
+                        "oof_auc": float(binary_auc(y, candidate)),
+                    }
+                )
+            best_alpha_row = max(alpha_rows, key=lambda row: row["oof_auc"])
+            metrics["blend_scan"] = alpha_rows
+            metrics["best_blend_alpha"] = float(best_alpha_row["alpha"])
+            metrics["best_blend_oof_auc"] = float(best_alpha_row["oof_auc"])
+            metrics["delta_best_blend_vs_reference"] = float(
+                best_alpha_row["oof_auc"] - binary_auc(y, aligned_reference)
+            )
+
+    write_json(metrics_path, metrics)
+    return metrics

--- a/src/churn_baseline/gnn_probe.py
+++ b/src/churn_baseline/gnn_probe.py
@@ -1,0 +1,496 @@
+"""Minimal transductive GraphSAGE probe for the churn competition."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from pynndescent import NNDescent
+from sklearn.model_selection import StratifiedKFold
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+from torch_geometric.nn import SAGEConv
+
+from .artifacts import ensure_parent_dir, write_json
+from .config import ID_COLUMN, TARGET_COLUMN
+from .data import encode_target, load_csv
+from .evaluation import binary_auc
+
+
+BASE_NUMERIC_COLUMNS: tuple[str, ...] = ("tenure", "MonthlyCharges", "TotalCharges")
+BASE_CATEGORICAL_COLUMNS: tuple[str, ...] = (
+    "gender",
+    "SeniorCitizen",
+    "Partner",
+    "Dependents",
+    "PhoneService",
+    "MultipleLines",
+    "InternetService",
+    "OnlineSecurity",
+    "OnlineBackup",
+    "DeviceProtection",
+    "TechSupport",
+    "StreamingTV",
+    "StreamingMovies",
+    "Contract",
+    "PaperlessBilling",
+    "PaymentMethod",
+)
+
+
+@dataclass(frozen=True)
+class GNNProbeParams:
+    """Hyperparameters for the minimal GraphSAGE smoke."""
+
+    hidden_dim: int = 32
+    dropout: float = 0.15
+    learning_rate: float = 1e-3
+    weight_decay: float = 3e-4
+    epochs: int = 8
+    patience: int = 3
+    k_neighbors: int = 8
+    graph_numeric_multiplier: float = 3.0
+    random_state: int = 42
+
+
+def _set_reproducible_seed(seed: int) -> None:
+    np.random.seed(int(seed))
+    torch.manual_seed(int(seed))
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(int(seed))
+
+
+def _clip_probability(values: np.ndarray, epsilon: float = 1e-6) -> np.ndarray:
+    return np.clip(values.astype("float64"), epsilon, 1.0 - epsilon)
+
+
+def _clean_total_charges(frame: pd.DataFrame) -> pd.DataFrame:
+    out = frame.copy()
+    if "TotalCharges" in out.columns:
+        out["TotalCharges"] = pd.to_numeric(out["TotalCharges"], errors="coerce")
+    return out
+
+
+def _prepare_base_frames(
+    train_df: pd.DataFrame,
+    test_df: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    train = _clean_total_charges(train_df.copy())
+    test = _clean_total_charges(test_df.copy())
+
+    for column in BASE_NUMERIC_COLUMNS:
+        train[column] = pd.to_numeric(train[column], errors="coerce")
+        test[column] = pd.to_numeric(test[column], errors="coerce")
+
+    for column in BASE_CATEGORICAL_COLUMNS:
+        train[column] = train[column].fillna("missing").astype(str).str.strip()
+        test[column] = test[column].fillna("missing").astype(str).str.strip()
+
+    return train, test
+
+
+def _encode_categorical_node_features(
+    train_frame: pd.DataFrame,
+    test_frame: pd.DataFrame,
+) -> tuple[np.ndarray, np.ndarray, list[int]]:
+    train_codes: list[np.ndarray] = []
+    test_codes: list[np.ndarray] = []
+    cardinalities: list[int] = []
+
+    for column in BASE_CATEGORICAL_COLUMNS:
+        combined = pd.concat(
+            [train_frame[column].astype(str), test_frame[column].astype(str)],
+            axis=0,
+            ignore_index=True,
+        )
+        unique_values = combined.unique().tolist()
+        mapping = {value: index for index, value in enumerate(unique_values)}
+        train_codes.append(train_frame[column].astype(str).map(mapping).astype(np.int64).to_numpy())
+        test_codes.append(test_frame[column].astype(str).map(mapping).astype(np.int64).to_numpy())
+        cardinalities.append(int(len(mapping)))
+
+    x_cat_train = np.stack(train_codes, axis=1)
+    x_cat_test = np.stack(test_codes, axis=1)
+    return x_cat_train, x_cat_test, cardinalities
+
+
+def _build_graph_matrix(
+    fit_frame: pd.DataFrame,
+    query_frames: Sequence[pd.DataFrame],
+    *,
+    graph_numeric_multiplier: float,
+) -> tuple[np.ndarray, list[np.ndarray], StandardScaler]:
+    try:
+        ohe = OneHotEncoder(handle_unknown="ignore", sparse_output=False, dtype=np.float32)
+    except TypeError:
+        ohe = OneHotEncoder(handle_unknown="ignore", sparse=False, dtype=np.float32)
+    fit_cat = fit_frame.loc[:, list(BASE_CATEGORICAL_COLUMNS)]
+    x_cat_fit = ohe.fit_transform(fit_cat).astype(np.float32)
+    x_cat_queries = [
+        ohe.transform(frame.loc[:, list(BASE_CATEGORICAL_COLUMNS)]).astype(np.float32) for frame in query_frames
+    ]
+
+    scaler = StandardScaler()
+    x_num_fit = scaler.fit_transform(fit_frame.loc[:, list(BASE_NUMERIC_COLUMNS)].to_numpy(dtype=np.float32)).astype(
+        np.float32
+    )
+    x_num_fit *= float(graph_numeric_multiplier)
+    x_num_queries = [
+        scaler.transform(frame.loc[:, list(BASE_NUMERIC_COLUMNS)].to_numpy(dtype=np.float32)).astype(np.float32)
+        * float(graph_numeric_multiplier)
+        for frame in query_frames
+    ]
+
+    fit_matrix = np.concatenate([x_cat_fit, x_num_fit], axis=1).astype(np.float32)
+    query_matrices = [
+        np.concatenate([cat_block, num_block], axis=1).astype(np.float32)
+        for cat_block, num_block in zip(x_cat_queries, x_num_queries, strict=True)
+    ]
+    return fit_matrix, query_matrices, scaler
+
+
+def _build_neighbor_graph(
+    fit_graph_matrix: np.ndarray,
+    query_graph_matrices: Sequence[np.ndarray],
+    *,
+    k_neighbors: int,
+    random_state: int,
+) -> tuple[np.ndarray, list[np.ndarray]]:
+    index = NNDescent(
+        fit_graph_matrix,
+        n_neighbors=int(k_neighbors) + 1,
+        metric="euclidean",
+        random_state=int(random_state),
+        n_jobs=-1,
+    )
+    neighbor_indices, _ = index.neighbor_graph
+    fit_size = fit_graph_matrix.shape[0]
+    cleaned_fit = np.empty((fit_size, int(k_neighbors)), dtype=np.int64)
+
+    for node in range(fit_size):
+        row = [int(value) for value in neighbor_indices[node] if int(value) != node]
+        if len(row) < int(k_neighbors):
+            row.extend([node] * (int(k_neighbors) - len(row)))
+        cleaned_fit[node] = np.asarray(row[: int(k_neighbors)], dtype=np.int64)
+
+    query_neighbors: list[np.ndarray] = []
+    for matrix in query_graph_matrices:
+        indices, _ = index.query(matrix, k=int(k_neighbors))
+        query_neighbors.append(indices.astype(np.int64))
+    return cleaned_fit, query_neighbors
+
+
+def _build_edge_index(
+    fit_neighbors: np.ndarray,
+    valid_neighbors: np.ndarray,
+    test_neighbors: np.ndarray,
+    *,
+    fit_size: int,
+    valid_size: int,
+    device: torch.device,
+) -> torch.Tensor:
+    fit_targets = np.repeat(np.arange(fit_size, dtype=np.int64), fit_neighbors.shape[1])
+    valid_targets = np.repeat(np.arange(fit_size, fit_size + valid_size, dtype=np.int64), valid_neighbors.shape[1])
+    test_start = fit_size + valid_size
+    test_targets = np.repeat(np.arange(test_start, test_start + test_neighbors.shape[0], dtype=np.int64), test_neighbors.shape[1])
+
+    source = np.concatenate(
+        [
+            fit_neighbors.reshape(-1).astype(np.int64),
+            valid_neighbors.reshape(-1).astype(np.int64),
+            test_neighbors.reshape(-1).astype(np.int64),
+        ],
+        axis=0,
+    )
+    destination = np.concatenate([fit_targets, valid_targets, test_targets], axis=0)
+    edge_index = np.vstack([source, destination])
+    return torch.tensor(edge_index, dtype=torch.long, device=device)
+
+
+def _resolve_device(device: str) -> torch.device:
+    normalized = str(device).strip().lower()
+    if normalized in {"auto", ""}:
+        normalized = "cuda" if torch.cuda.is_available() else "cpu"
+    if normalized == "cuda" and not torch.cuda.is_available():
+        normalized = "cpu"
+    return torch.device(normalized)
+
+
+def _embedding_dim(cardinality: int) -> int:
+    return int(min(12, max(2, round(cardinality ** 0.5))))
+
+
+class GraphSageWithCategoricals(nn.Module):
+    """Small GraphSAGE with categorical embeddings and numeric inputs."""
+
+    def __init__(
+        self,
+        *,
+        numeric_dim: int,
+        cardinalities: Sequence[int],
+        hidden_dim: int,
+        dropout: float,
+    ) -> None:
+        super().__init__()
+        self.embeddings = nn.ModuleList(
+            [nn.Embedding(int(cardinality), _embedding_dim(int(cardinality))) for cardinality in cardinalities]
+        )
+        embedding_dim = sum(embedding.embedding_dim for embedding in self.embeddings)
+        self.input_linear = nn.Linear(int(numeric_dim) + int(embedding_dim), int(hidden_dim))
+        self.conv1 = SAGEConv(int(hidden_dim), int(hidden_dim))
+        self.conv2 = SAGEConv(int(hidden_dim), int(hidden_dim))
+        self.output = nn.Linear(int(hidden_dim), 1)
+        self.dropout = float(dropout)
+
+    def forward(
+        self,
+        x_num: torch.Tensor,
+        x_cat: torch.Tensor,
+        edge_index: torch.Tensor,
+    ) -> torch.Tensor:
+        embedded = [embedding(x_cat[:, index]) for index, embedding in enumerate(self.embeddings)]
+        x = torch.cat([x_num, *embedded], dim=1)
+        x = F.relu(self.input_linear(x))
+        x = F.dropout(x, p=self.dropout, training=self.training)
+        x = F.relu(self.conv1(x, edge_index))
+        x = F.dropout(x, p=self.dropout, training=self.training)
+        x = F.relu(self.conv2(x, edge_index))
+        x = F.dropout(x, p=self.dropout, training=self.training)
+        return self.output(x).squeeze(-1)
+
+
+def _to_analysis_oof(
+    *,
+    reference_v3_oof_path: str | Path,
+    candidate_oof_path: str | Path,
+    analysis_oof_path: str | Path,
+) -> str:
+    reference = pd.read_csv(reference_v3_oof_path)[[ID_COLUMN, "target", "candidate_pred"]].rename(
+        columns={"candidate_pred": "reference_pred"}
+    )
+    candidate = pd.read_csv(candidate_oof_path)[[ID_COLUMN, "target", "oof_pred"]].rename(
+        columns={"oof_pred": "candidate_pred"}
+    )
+    merged = reference.merge(candidate, on=[ID_COLUMN, "target"], how="inner", validate="one_to_one")
+    out_path = ensure_parent_dir(analysis_oof_path)
+    merged.to_csv(out_path, index=False)
+    return str(out_path)
+
+
+def train_gnn_probe_cv(
+    *,
+    train_csv_path: str | Path,
+    test_csv_path: str | Path,
+    metrics_path: str | Path,
+    oof_path: str | Path,
+    test_pred_path: str | Path | None = None,
+    analysis_oof_path: str | Path | None = None,
+    reference_v3_oof_path: str | Path | None = None,
+    params: GNNProbeParams | None = None,
+    folds: int = 2,
+    random_state: int = 42,
+    device: str = "auto",
+) -> dict[str, Any]:
+    """Train the minimal transductive GraphSAGE probe with outer CV."""
+    params = params or GNNProbeParams(random_state=random_state)
+    _set_reproducible_seed(int(params.random_state))
+
+    train_df = load_csv(train_csv_path)
+    test_df = load_csv(test_csv_path)
+    train_df, test_df = _prepare_base_frames(train_df, test_df)
+    y = encode_target(train_df[TARGET_COLUMN]).astype("float32")
+
+    train_ids = train_df[ID_COLUMN].astype("int64").reset_index(drop=True)
+    test_ids = test_df[ID_COLUMN].astype("int64").reset_index(drop=True)
+
+    train_features = train_df.drop(columns=[TARGET_COLUMN]).reset_index(drop=True)
+    test_features = test_df.reset_index(drop=True)
+    n_train = int(len(train_features))
+    model_device = _resolve_device(device)
+    x_cat_train_all, x_cat_test_all, cardinalities = _encode_categorical_node_features(train_features, test_features)
+
+    splitter = StratifiedKFold(n_splits=int(folds), shuffle=True, random_state=int(random_state))
+    oof_pred = np.zeros(n_train, dtype=np.float32)
+    test_pred = np.zeros(len(test_features), dtype=np.float32)
+    fold_aucs: list[float] = []
+    best_epochs: list[int] = []
+    graph_feature_dim: int | None = None
+
+    for fold_idx, (fit_idx, valid_idx) in enumerate(splitter.split(np.zeros(n_train), y.to_numpy(dtype=np.int8)), start=1):
+        _set_reproducible_seed(int(params.random_state) + fold_idx)
+        fit_frame = train_features.iloc[fit_idx].reset_index(drop=True)
+        valid_frame = train_features.iloc[valid_idx].reset_index(drop=True)
+        test_frame = test_features.reset_index(drop=True)
+
+        fill_values = fit_frame.loc[:, list(BASE_NUMERIC_COLUMNS)].median(numeric_only=True)
+        for column in BASE_NUMERIC_COLUMNS:
+            fill_value = float(fill_values.get(column, 0.0))
+            fit_frame[column] = fit_frame[column].fillna(fill_value).astype(np.float32)
+            valid_frame[column] = valid_frame[column].fillna(fill_value).astype(np.float32)
+            test_frame[column] = test_frame[column].fillna(fill_value).astype(np.float32)
+
+        fit_graph, query_graphs, scaler = _build_graph_matrix(
+            fit_frame,
+            [valid_frame, test_frame],
+            graph_numeric_multiplier=params.graph_numeric_multiplier,
+        )
+        if graph_feature_dim is None:
+            graph_feature_dim = int(fit_graph.shape[1])
+        fit_neighbors, query_neighbors = _build_neighbor_graph(
+            fit_graph,
+            query_graphs,
+            k_neighbors=params.k_neighbors,
+            random_state=params.random_state + fold_idx,
+        )
+        valid_neighbors, test_neighbors = query_neighbors
+
+        x_num_fit = scaler.transform(fit_frame.loc[:, list(BASE_NUMERIC_COLUMNS)].to_numpy(dtype=np.float32)).astype(np.float32)
+        x_num_valid = scaler.transform(valid_frame.loc[:, list(BASE_NUMERIC_COLUMNS)].to_numpy(dtype=np.float32)).astype(np.float32)
+        x_num_test = scaler.transform(test_frame.loc[:, list(BASE_NUMERIC_COLUMNS)].to_numpy(dtype=np.float32)).astype(np.float32)
+
+        x_cat_fit = x_cat_train_all[fit_idx]
+        x_cat_valid = x_cat_train_all[valid_idx]
+        x_cat_test = x_cat_test_all
+
+        all_num = np.vstack([x_num_fit, x_num_valid, x_num_test]).astype(np.float32)
+        all_cat = np.vstack([x_cat_fit, x_cat_valid, x_cat_test]).astype(np.int64)
+        fit_size = int(len(fit_idx))
+        valid_size = int(len(valid_idx))
+        total_nodes = int(all_num.shape[0])
+        valid_local_index = torch.arange(fit_size, fit_size + valid_size, dtype=torch.long, device=model_device)
+        fit_local_index = torch.arange(0, fit_size, dtype=torch.long, device=model_device)
+        test_local_index = torch.arange(fit_size + valid_size, total_nodes, dtype=torch.long, device=model_device)
+
+        x_num_tensor = torch.tensor(all_num, dtype=torch.float32, device=model_device)
+        x_cat_tensor = torch.tensor(all_cat, dtype=torch.long, device=model_device)
+        y_tensor = torch.tensor(y.iloc[fit_idx].to_numpy(dtype=np.float32), dtype=torch.float32, device=model_device)
+        edge_index = _build_edge_index(
+            fit_neighbors,
+            valid_neighbors,
+            test_neighbors,
+            fit_size=fit_size,
+            valid_size=valid_size,
+            device=model_device,
+        )
+
+        model = GraphSageWithCategoricals(
+            numeric_dim=all_num.shape[1],
+            cardinalities=cardinalities,
+            hidden_dim=params.hidden_dim,
+            dropout=params.dropout,
+        ).to(model_device)
+        optimizer = torch.optim.AdamW(
+            model.parameters(),
+            lr=params.learning_rate,
+            weight_decay=params.weight_decay,
+        )
+        loss_fn = nn.BCEWithLogitsLoss()
+
+        best_auc = -np.inf
+        best_epoch = 0
+        best_state: dict[str, torch.Tensor] | None = None
+        bad_epochs = 0
+
+        for epoch in range(1, int(params.epochs) + 1):
+            model.train()
+            optimizer.zero_grad(set_to_none=True)
+            logits = model(x_num_tensor, x_cat_tensor, edge_index)
+            loss = loss_fn(logits[fit_local_index], y_tensor)
+            loss.backward()
+            optimizer.step()
+
+            model.eval()
+            with torch.no_grad():
+                logits = model(x_num_tensor, x_cat_tensor, edge_index)
+                valid_prob = torch.sigmoid(logits[valid_local_index]).detach().cpu().numpy()
+            valid_auc = float(binary_auc(y.iloc[valid_idx], valid_prob))
+
+            if valid_auc > best_auc + 1e-6:
+                best_auc = valid_auc
+                best_epoch = epoch
+                best_state = {key: value.detach().cpu().clone() for key, value in model.state_dict().items()}
+                bad_epochs = 0
+            else:
+                bad_epochs += 1
+                if bad_epochs >= int(params.patience):
+                    break
+
+        if best_state is None:
+            raise RuntimeError(f"Fold {fold_idx} failed to produce a best state.")
+
+        model.load_state_dict(best_state)
+        model.eval()
+        with torch.no_grad():
+            logits = model(x_num_tensor, x_cat_tensor, edge_index)
+            valid_prob = torch.sigmoid(logits[valid_local_index]).detach().cpu().numpy().astype(np.float32)
+            test_prob = torch.sigmoid(logits[test_local_index]).detach().cpu().numpy().astype(np.float32)
+
+        oof_pred[valid_idx] = valid_prob
+        test_pred += test_prob / float(folds)
+        fold_aucs.append(float(binary_auc(y.iloc[valid_idx], valid_prob)))
+        best_epochs.append(int(best_epoch))
+
+        del model, optimizer, fit_local_index, valid_local_index, test_local_index
+        if model_device.type == "cuda":
+            torch.cuda.empty_cache()
+
+    metrics = {
+        "experiment_name": "gnn_probe",
+        "model_family": "gnn_graphsage",
+        "train_csv_path": str(train_csv_path),
+        "test_csv_path": str(test_csv_path),
+        "folds": int(folds),
+        "random_state": int(random_state),
+        "device": str(model_device),
+        "oof_auc": float(binary_auc(y, oof_pred)),
+        "cv_mean_auc": float(np.mean(fold_aucs)),
+        "cv_std_auc": float(np.std(fold_aucs, ddof=0)),
+        "fold_aucs": [float(value) for value in fold_aucs],
+        "best_epochs": [int(value) for value in best_epochs],
+        "train_rows": int(n_train),
+        "test_rows": int(len(test_features)),
+        "total_nodes": int(n_train + len(test_features)),
+        "graph_feature_dim": int(graph_feature_dim or 0),
+        "edge_count_per_fold": int(params.k_neighbors * (n_train + len(test_features))),
+        "categorical_columns": list(BASE_CATEGORICAL_COLUMNS),
+        "numeric_columns": list(BASE_NUMERIC_COLUMNS),
+        "categorical_cardinalities": [int(value) for value in cardinalities],
+        "params": asdict(params),
+        "oof_path": str(oof_path),
+        "metrics_path": str(metrics_path),
+    }
+
+    oof_frame = pd.DataFrame(
+        {
+            ID_COLUMN: train_ids,
+            "target": y.astype("int8"),
+            "oof_pred": _clip_probability(oof_pred),
+        }
+    )
+    oof_out = ensure_parent_dir(oof_path)
+    oof_frame.to_csv(oof_out, index=False)
+
+    if test_pred_path:
+        test_out = ensure_parent_dir(test_pred_path)
+        pd.DataFrame(
+            {
+                ID_COLUMN: test_ids,
+                TARGET_COLUMN: _clip_probability(test_pred),
+            }
+        ).to_csv(test_out, index=False)
+        metrics["test_pred_path"] = str(test_pred_path)
+
+    if analysis_oof_path and reference_v3_oof_path:
+        metrics["analysis_oof_path"] = _to_analysis_oof(
+            reference_v3_oof_path=reference_v3_oof_path,
+            candidate_oof_path=oof_path,
+            analysis_oof_path=analysis_oof_path,
+        )
+
+    write_json(metrics_path, metrics)
+    return metrics

--- a/src/churn_baseline/hard_example_stability.py
+++ b/src/churn_baseline/hard_example_stability.py
@@ -1,0 +1,452 @@
+"""Example-stability scoring and local reranking against incumbent v3."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+from catboost import CatBoostRegressor
+from sklearn.model_selection import StratifiedKFold
+
+from .artifacts import ensure_parent_dir, write_json
+from .config import CatBoostHyperParams, ID_COLUMN, TARGET_COLUMN
+from .data import infer_categorical_columns, load_csv
+from .diagnostics import build_family_frame
+from .evaluation import binary_auc
+from .modeling import best_iteration_or_default, fit_with_validation, save_model
+from .pipeline import _prepare_train_matrix, _transform_pair_with_stateful_blocks, _transform_single_with_stateful_blocks
+from .specialist import _append_reference_features, _clip_probability
+from .uncertainty_band import _align_reference_prediction, _build_component_stats
+
+
+MIN_MASKED_TRAIN_ROWS = 2000
+MIN_MASKED_VALID_ROWS = 500
+
+
+def _build_stability_oof(
+    *,
+    train_df: pd.DataFrame,
+    feature_blocks: Sequence[str] | None,
+    params: CatBoostHyperParams,
+    folds: int,
+    repeats: int,
+    random_state: int,
+    early_stopping_rounds: int,
+    verbose: int,
+) -> tuple[pd.DataFrame, pd.Series, tuple[str, ...], tuple[str, ...], pd.DataFrame, dict[str, Any]]:
+    normalized_blocks, _, stateful_blocks, x, y = _prepare_train_matrix(train_df, feature_blocks)
+    pred_matrix = np.full((len(x), int(repeats)), np.nan, dtype="float64")
+    repeat_rows: list[dict[str, Any]] = []
+
+    for repeat in range(int(repeats)):
+        splitter = StratifiedKFold(
+            n_splits=int(folds),
+            shuffle=True,
+            random_state=int(random_state) + repeat,
+        )
+        repeat_pred = pd.Series(index=x.index, dtype="float64", name=f"repeat_{repeat}_pred")
+        fold_iterations: list[int] = []
+        fold_aucs: list[float] = []
+
+        for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x, y), start=1):
+            x_train = x.iloc[train_idx]
+            y_train = y.iloc[train_idx]
+            x_valid = x.iloc[valid_idx]
+            y_valid = y.iloc[valid_idx]
+            x_train, x_valid = _transform_pair_with_stateful_blocks(x_train, x_valid, stateful_blocks)
+            cat_columns = infer_categorical_columns(x_train)
+
+            fold_params = CatBoostHyperParams(
+                iterations=params.iterations,
+                learning_rate=params.learning_rate,
+                depth=params.depth,
+                l2_leaf_reg=params.l2_leaf_reg,
+                random_seed=int(random_state) + repeat * 100 + fold_number,
+            )
+            model = fit_with_validation(
+                x_train,
+                y_train,
+                x_valid,
+                y_valid,
+                cat_columns,
+                fold_params,
+                early_stopping_rounds=early_stopping_rounds,
+                verbose=verbose,
+            )
+            valid_pred = pd.Series(
+                model.predict_proba(x_valid)[:, 1],
+                index=x_valid.index,
+                dtype="float64",
+            )
+            repeat_pred.iloc[valid_idx] = valid_pred.values
+            fold_iterations.append(best_iteration_or_default(model, fold_params.iterations))
+            fold_aucs.append(float(binary_auc(y_valid, valid_pred)))
+
+        if repeat_pred.isna().any():
+            raise RuntimeError(f"stability OOF repeat {repeat} contains missing values")
+        pred_matrix[:, repeat] = repeat_pred.to_numpy(dtype="float64")
+        repeat_rows.append(
+            {
+                "repeat": int(repeat),
+                "mean_auc": float(np.mean(fold_aucs)),
+                "min_auc": float(np.min(fold_aucs)),
+                "max_auc": float(np.max(fold_aucs)),
+                "mean_final_iterations": float(np.mean(fold_iterations)),
+            }
+        )
+
+    pred_mean = pred_matrix.mean(axis=1)
+    pred_std = pred_matrix.std(axis=1)
+    pred_min = pred_matrix.min(axis=1)
+    pred_max = pred_matrix.max(axis=1)
+    vote_share = (pred_matrix >= 0.5).mean(axis=1)
+
+    stability_frame = pd.DataFrame(
+        {
+            "stability_pred_mean": pred_mean,
+            "stability_pred_std": pred_std,
+            "stability_pred_min": pred_min,
+            "stability_pred_max": pred_max,
+            "stability_pred_range": pred_max - pred_min,
+            "stability_positive_vote_share": vote_share,
+            "stability_flip_rate": np.minimum(vote_share, 1.0 - vote_share),
+            "hard_example_score": pred_std + np.minimum(vote_share, 1.0 - vote_share),
+        },
+        index=x.index,
+    )
+
+    metadata = {
+        "feature_blocks": list(normalized_blocks),
+        "feature_count": int(x.shape[1]),
+        "feature_columns": list(x.columns),
+        "repeats": int(repeats),
+        "folds": int(folds),
+        "repeat_metrics": repeat_rows,
+    }
+    return x, y, tuple(normalized_blocks), tuple(stateful_blocks), stability_frame, metadata
+
+
+def _build_hard_example_mask(
+    *,
+    train_df: pd.DataFrame,
+    reference_pred: pd.Series,
+    family_level: str,
+    family_value: str,
+    stability_frame: pd.DataFrame,
+    hard_score_quantile: float,
+    reference_band_half_width: float | None,
+) -> tuple[pd.Series, dict[str, Any]]:
+    if family_level not in {"segment3", "segment5"}:
+        raise ValueError("family_level must be 'segment3' or 'segment5'")
+    if float(hard_score_quantile) <= 0.0 or float(hard_score_quantile) >= 1.0:
+        raise ValueError(f"hard_score_quantile must be in (0,1), got {hard_score_quantile}")
+    if reference_band_half_width is not None and (float(reference_band_half_width) <= 0.0 or float(reference_band_half_width) >= 0.5):
+        raise ValueError(f"reference_band_half_width must be in (0,0.5), got {reference_band_half_width}")
+
+    family_frame = build_family_frame(train_df)
+    family_mask = family_frame[family_level].astype(str).eq(str(family_value))
+    family_rows = int(family_mask.sum())
+    if family_rows <= 0:
+        raise ValueError(f"family '{family_value}' not found in train.csv for level '{family_level}'")
+
+    family_scores = stability_frame.loc[family_mask, "hard_example_score"].astype("float64")
+    score_threshold = float(family_scores.quantile(float(hard_score_quantile)))
+    mask = family_mask & stability_frame["hard_example_score"].ge(score_threshold)
+
+    reference_uncertainty = reference_pred.sub(0.5).abs()
+    band_rows = None
+    if reference_band_half_width is not None:
+        band_mask = reference_uncertainty.le(float(reference_band_half_width))
+        band_rows = int((family_mask & band_mask).sum())
+        mask = mask & band_mask
+
+    mask_rows = int(mask.sum())
+    mask_summary = {
+        "family_level": str(family_level),
+        "family_value": str(family_value),
+        "family_rows": family_rows,
+        "hard_score_quantile": float(hard_score_quantile),
+        "score_threshold": score_threshold,
+        "reference_band_half_width": None if reference_band_half_width is None else float(reference_band_half_width),
+        "reference_band_rows_within_family": band_rows,
+        "mask_rows": mask_rows,
+        "mask_rate": float(mask_rows / max(len(train_df), 1)),
+        "family_rate": float(family_rows / max(len(train_df), 1)),
+        "hard_score_mean_on_mask": float(stability_frame.loc[mask, "hard_example_score"].mean()) if mask_rows else None,
+        "hard_score_mean_in_family": float(family_scores.mean()),
+        "stability_std_mean_on_mask": float(stability_frame.loc[mask, "stability_pred_std"].mean()) if mask_rows else None,
+        "flip_rate_mean_on_mask": float(stability_frame.loc[mask, "stability_flip_rate"].mean()) if mask_rows else None,
+        "reference_uncertainty_mean_on_mask": float(reference_uncertainty.loc[mask].mean()) if mask_rows else None,
+    }
+    return mask.astype(bool), mask_summary
+
+
+def run_hard_example_stability_reranker_cv(
+    *,
+    train_csv_path: str | Path,
+    reference_frame: pd.DataFrame,
+    reference_component_frame: pd.DataFrame | None,
+    stability_feature_blocks: Sequence[str] | None,
+    stability_params: CatBoostHyperParams,
+    stability_repeats: int,
+    reranker_feature_blocks: Sequence[str] | None,
+    reranker_params: CatBoostHyperParams,
+    folds: int,
+    random_state: int,
+    early_stopping_rounds: int,
+    verbose: int,
+    alpha_grid: Sequence[float],
+    family_level: str,
+    family_value: str,
+    hard_score_quantile: float,
+    reference_band_half_width: float | None,
+    model_path: str | Path,
+    metrics_path: str | Path,
+    oof_path: str | Path,
+) -> dict[str, Any]:
+    if folds < 2:
+        raise ValueError("folds must be >= 2")
+    if not alpha_grid:
+        raise ValueError("alpha_grid must contain at least one value")
+
+    train_df = load_csv(train_csv_path)
+    reference_pred = _align_reference_prediction(train_df, reference_frame)
+    component_frame, _ = _build_component_stats(train_df[ID_COLUMN], reference_component_frame)
+
+    _, _, stability_blocks_norm, _, stability_frame, stability_meta = _build_stability_oof(
+        train_df=train_df,
+        feature_blocks=stability_feature_blocks,
+        params=stability_params,
+        folds=folds,
+        repeats=stability_repeats,
+        random_state=random_state,
+        early_stopping_rounds=early_stopping_rounds,
+        verbose=verbose,
+    )
+
+    reranker_blocks_norm, _, stateful_blocks, x, y = _prepare_train_matrix(train_df, reranker_feature_blocks)
+    x = x.copy()
+    x[stability_frame.columns] = stability_frame.astype("float64")
+    x["stability_mean_minus_reference"] = stability_frame["stability_pred_mean"].astype("float64") - reference_pred.astype("float64")
+    x["stability_mean_minus_reference_abs"] = x["stability_mean_minus_reference"].abs()
+
+    hard_mask, mask_summary = _build_hard_example_mask(
+        train_df=train_df,
+        reference_pred=reference_pred,
+        family_level=family_level,
+        family_value=family_value,
+        stability_frame=stability_frame,
+        hard_score_quantile=hard_score_quantile,
+        reference_band_half_width=reference_band_half_width,
+    )
+
+    masked_rows = int(hard_mask.sum())
+    if masked_rows < MIN_MASKED_TRAIN_ROWS:
+        raise ValueError(f"hard-example mask selects only {masked_rows} rows. Minimum required: {MIN_MASKED_TRAIN_ROWS}")
+    if y.loc[hard_mask].nunique() < 2:
+        raise ValueError("hard-example mask must contain both classes")
+
+    splitter = StratifiedKFold(n_splits=folds, shuffle=True, random_state=random_state)
+    residual_pred = pd.Series(index=x.index, dtype="float64", name="residual_pred")
+    fold_rows: list[dict[str, Any]] = []
+    fold_iterations: list[int] = []
+    disagreement_columns: list[str] = []
+
+    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x, y), start=1):
+        x_train = x.iloc[train_idx]
+        y_train = y.iloc[train_idx]
+        x_valid = x.iloc[valid_idx]
+        y_valid = y.iloc[valid_idx]
+        x_train, x_valid = _transform_pair_with_stateful_blocks(x_train, x_valid, stateful_blocks)
+
+        train_mask = hard_mask.iloc[train_idx].to_numpy(dtype=bool)
+        valid_mask = hard_mask.iloc[valid_idx].to_numpy(dtype=bool)
+        train_rows = int(np.sum(train_mask))
+        valid_rows = int(np.sum(valid_mask))
+        if train_rows < MIN_MASKED_TRAIN_ROWS:
+            raise ValueError(f"Fold {fold_number} masked train rows {train_rows} below minimum {MIN_MASKED_TRAIN_ROWS}")
+        if valid_rows < MIN_MASKED_VALID_ROWS:
+            raise ValueError(f"Fold {fold_number} masked valid rows {valid_rows} below minimum {MIN_MASKED_VALID_ROWS}")
+        if y_train.iloc[train_mask].nunique() < 2 or y_valid.iloc[valid_mask].nunique() < 2:
+            raise ValueError(f"Fold {fold_number} hard-example mask lost one class in train or valid")
+
+        train_reference = reference_pred.iloc[train_idx]
+        valid_reference = reference_pred.iloc[valid_idx]
+        train_components = component_frame.iloc[train_idx] if component_frame is not None else None
+        valid_components = component_frame.iloc[valid_idx] if component_frame is not None else None
+
+        x_train, train_disagreement_columns = _append_reference_features(
+            x_train,
+            reference_pred=train_reference,
+            reference_component_frame=train_components,
+            include_logit=True,
+        )
+        x_valid, valid_disagreement_columns = _append_reference_features(
+            x_valid,
+            reference_pred=valid_reference,
+            reference_component_frame=valid_components,
+            include_logit=True,
+        )
+        if train_disagreement_columns != valid_disagreement_columns:
+            raise RuntimeError("Teacher disagreement feature mismatch between train and valid folds")
+        if not disagreement_columns:
+            disagreement_columns = list(train_disagreement_columns)
+
+        cat_columns = infer_categorical_columns(x_train)
+        y_train_residual = y_train.iloc[train_mask].astype("float64") - train_reference.iloc[train_mask].astype("float64")
+        y_valid_residual = y_valid.iloc[valid_mask].astype("float64") - valid_reference.iloc[valid_mask].astype("float64")
+
+        model = CatBoostRegressor(
+            iterations=reranker_params.iterations,
+            learning_rate=reranker_params.learning_rate,
+            depth=reranker_params.depth,
+            l2_leaf_reg=reranker_params.l2_leaf_reg,
+            random_seed=int(random_state) + fold_number,
+            loss_function="RMSE",
+            eval_metric="RMSE",
+            verbose=verbose,
+        )
+        model.fit(
+            x_train.iloc[train_mask],
+            y_train_residual,
+            cat_features=cat_columns,
+            eval_set=(x_valid.iloc[valid_mask], y_valid_residual),
+            use_best_model=True,
+            early_stopping_rounds=early_stopping_rounds,
+            verbose=verbose,
+        )
+
+        valid_residual_pred = pd.Series(
+            model.predict(x_valid.iloc[valid_mask]),
+            index=x_valid.iloc[valid_mask].index,
+            dtype="float64",
+        )
+        residual_pred.iloc[np.asarray(valid_idx)[valid_mask]] = valid_residual_pred.values
+        final_iterations = best_iteration_or_default(model, reranker_params.iterations)
+        fold_iterations.append(int(final_iterations))
+
+        reference_auc = binary_auc(y_valid.iloc[valid_mask], valid_reference.iloc[valid_mask])
+        reranked_valid = _clip_probability(valid_reference.iloc[valid_mask] + valid_residual_pred)
+        reranked_auc = binary_auc(y_valid.iloc[valid_mask], reranked_valid)
+        fold_rows.append(
+            {
+                "fold": int(fold_number),
+                "masked_train_rows": train_rows,
+                "masked_valid_rows": valid_rows,
+                "masked_positive_rate_train": float(y_train.iloc[train_mask].mean()),
+                "masked_positive_rate_valid": float(y_valid.iloc[valid_mask].mean()),
+                "reference_auc_on_mask": reference_auc,
+                "reranked_auc_on_mask": reranked_auc,
+                "delta_auc_on_mask": float(reranked_auc - reference_auc),
+                "final_iterations": int(final_iterations),
+            }
+        )
+
+    if residual_pred.loc[hard_mask].isna().any():
+        raise RuntimeError("Residual OOF predictions contain missing values inside the hard-example mask")
+
+    alpha_scan_rows: list[dict[str, Any]] = []
+    for alpha in alpha_grid:
+        alpha_value = float(alpha)
+        candidate = reference_pred.copy()
+        candidate.loc[hard_mask] = _clip_probability(
+            reference_pred.loc[hard_mask] + alpha_value * residual_pred.loc[hard_mask]
+        ).values
+        alpha_scan_rows.append(
+            {
+                "alpha": alpha_value,
+                "oof_auc": float(binary_auc(y, candidate)),
+                "oof_auc_on_mask": float(binary_auc(y.loc[hard_mask], candidate.loc[hard_mask])),
+                "reference_auc_on_mask": float(binary_auc(y.loc[hard_mask], reference_pred.loc[hard_mask])),
+            }
+        )
+
+    best_alpha_row = max(alpha_scan_rows, key=lambda row: row["oof_auc"])
+    best_alpha = float(best_alpha_row["alpha"])
+    candidate_best = reference_pred.copy()
+    candidate_best.loc[hard_mask] = _clip_probability(
+        reference_pred.loc[hard_mask] + best_alpha * residual_pred.loc[hard_mask]
+    ).values
+
+    x_full = _transform_single_with_stateful_blocks(x, stateful_blocks)
+    x_full, disagreement_columns_full = _append_reference_features(
+        x_full,
+        reference_pred=reference_pred,
+        reference_component_frame=component_frame,
+        include_logit=True,
+    )
+    if disagreement_columns and disagreement_columns_full != disagreement_columns:
+        raise RuntimeError("Teacher disagreement feature mismatch between CV folds and full train")
+    if not disagreement_columns:
+        disagreement_columns = list(disagreement_columns_full)
+
+    full_iterations = max(int(round(float(np.mean(fold_iterations)))), 1)
+    cat_columns = infer_categorical_columns(x_full)
+    full_model = CatBoostRegressor(
+        iterations=full_iterations,
+        learning_rate=reranker_params.learning_rate,
+        depth=reranker_params.depth,
+        l2_leaf_reg=reranker_params.l2_leaf_reg,
+        random_seed=reranker_params.random_seed,
+        loss_function="RMSE",
+        eval_metric="RMSE",
+        verbose=verbose,
+    )
+    full_model.fit(
+        x_full.loc[hard_mask],
+        (y.loc[hard_mask].astype("float64") - reference_pred.loc[hard_mask].astype("float64")),
+        cat_features=cat_columns,
+        verbose=verbose,
+    )
+    model_out_path = ensure_parent_dir(model_path)
+    save_model(full_model, model_out_path)
+
+    family_frame = build_family_frame(train_df)
+    oof_output = pd.DataFrame(
+        {
+            ID_COLUMN: train_df[ID_COLUMN].values,
+            "target": y.astype(int).values,
+            "reference_pred": reference_pred.values,
+            "candidate_pred": candidate_best.values,
+            "residual_pred": residual_pred.values,
+            "specialist_mask": hard_mask.astype("int8").values,
+            family_level: family_frame[family_level].astype(str).values,
+        }
+    )
+    oof_output = pd.concat([oof_output, stability_frame.reset_index(drop=True)], axis=1)
+    oof_out_path = ensure_parent_dir(oof_path)
+    oof_output.to_csv(oof_out_path, index=False)
+
+    metrics: dict[str, Any] = {
+        "approach": "hard_example_stability_residual",
+        "train_rows": int(len(train_df)),
+        "stability_feature_blocks": list(stability_blocks_norm),
+        "reranker_feature_blocks": list(reranker_blocks_norm),
+        "stability_metadata": stability_meta,
+        "mask_summary": mask_summary,
+        "masked_positive_rate": float(y.loc[hard_mask].mean()),
+        "feature_count": int(x_full.shape[1]),
+        "feature_columns": list(x_full.columns),
+        "teacher_disagreement_columns": list(disagreement_columns),
+        "categorical_columns": cat_columns,
+        "cv_folds": int(folds),
+        "stability_repeats": int(stability_repeats),
+        "cv_fold_metrics": fold_rows,
+        "fold_final_iterations": [int(value) for value in fold_iterations],
+        "final_iterations": int(full_iterations),
+        "alpha_scan": alpha_scan_rows,
+        "best_alpha": best_alpha,
+        "reference_oof_auc": float(binary_auc(y, reference_pred)),
+        "reference_oof_auc_on_mask": float(binary_auc(y.loc[hard_mask], reference_pred.loc[hard_mask])),
+        "candidate_oof_auc": float(binary_auc(y, candidate_best)),
+        "candidate_oof_auc_on_mask": float(binary_auc(y.loc[hard_mask], candidate_best.loc[hard_mask])),
+        "delta_vs_reference_oof_auc": float(binary_auc(y, candidate_best) - binary_auc(y, reference_pred)),
+        "model_path": str(model_out_path),
+        "oof_path": str(oof_out_path),
+        "target_column": TARGET_COLUMN,
+        "id_column": ID_COLUMN,
+    }
+    write_json(metrics_path, metrics)
+    return metrics

--- a/src/churn_baseline/incumbent_v3.py
+++ b/src/churn_baseline/incumbent_v3.py
@@ -1,0 +1,337 @@
+"""Helpers to compare challenger residual chains directly against incumbent v3."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import StratifiedKFold
+
+from .artifacts import ensure_parent_dir, write_json
+from .config import ID_COLUMN
+from .diagnostics import OOF_TARGET_COLUMN
+from .evaluation import binary_auc
+from .validation_protocol import DOMINANT_MACROFAMILY, SUPPORTED_STAGES, evaluate_validation_protocol
+
+
+V3_ORDER: tuple[str, ...] = (
+    "early_all_internet",
+    "fiber_paperless_early",
+    "late_mtm_fiber",
+    "late_mtm_fiber_paperless",
+)
+
+V3_STEP_OOF_PATHS: dict[str, str] = {
+    "early_all_internet": "artifacts/reports/residual_reranker_early_all_internet_midcap_oof.csv",
+    "fiber_paperless_early": "artifacts/reports/residual_reranker_fiber_paperless_early_teacher_midcap_oof.csv",
+    "late_mtm_fiber": "artifacts/reports/residual_reranker_late_mtm_fiber_teacher_midcap_oof.csv",
+    "late_mtm_fiber_paperless": "artifacts/reports/residual_reranker_late_mtm_fiber_paperless_teacher_midcap_oof.csv",
+}
+
+_STEP_REQUIRED_COLUMNS = {
+    ID_COLUMN,
+    OOF_TARGET_COLUMN,
+    "specialist_mask",
+    "candidate_pred",
+    "reference_pred",
+}
+_REFERENCE_ATOL = 1e-8
+
+
+def _load_step_oof_frame(path: str | Path) -> pd.DataFrame:
+    frame = pd.read_csv(path)
+    missing = sorted(_STEP_REQUIRED_COLUMNS.difference(frame.columns))
+    if missing:
+        raise ValueError(f"{path} must contain columns {sorted(_STEP_REQUIRED_COLUMNS)}; missing {missing}")
+    return frame[list(_STEP_REQUIRED_COLUMNS)].sort_values(ID_COLUMN).reset_index(drop=True)
+
+
+def _validate_specialist_mask(frame: pd.DataFrame, *, step_name: str) -> None:
+    mask = frame["specialist_mask"]
+    if mask.isna().any():
+        raise ValueError(f"specialist_mask contains nulls in step '{step_name}'")
+    normalized = pd.to_numeric(mask, errors="coerce")
+    if normalized.isna().any():
+        invalid = sorted({str(value) for value in mask[normalized.isna()].unique()})
+        raise ValueError(f"specialist_mask must be boolean/0/1 in step '{step_name}'; invalid values: {invalid}")
+    if not np.all(np.isclose(normalized.to_numpy(dtype="float64"), np.round(normalized.to_numpy(dtype="float64")), atol=0.0)):
+        invalid = sorted({str(value) for value in mask[~np.isclose(normalized, np.round(normalized), atol=0.0)].unique()})
+        raise ValueError(
+            f"specialist_mask must be boolean/0/1 in step '{step_name}'; non-integer values: {invalid}"
+        )
+    valid_values = set(np.round(normalized.to_numpy(dtype="float64")).astype(int).tolist())
+    if not valid_values.issubset({0, 1}):
+        raise ValueError(
+            f"specialist_mask must contain only 0/1 in step '{step_name}'; got {sorted(valid_values)}"
+        )
+
+
+def _merge_step_oof_paths(candidate_step_oof_paths: Mapping[str, str | Path] | None) -> dict[str, str]:
+    merged = {name: str(path) for name, path in V3_STEP_OOF_PATHS.items()}
+    if candidate_step_oof_paths:
+        merged.update({str(name): str(path) for name, path in candidate_step_oof_paths.items()})
+    return merged
+
+
+def load_chain_step_frames(
+    candidate_step_oof_paths: Mapping[str, str | Path] | None = None,
+) -> dict[str, pd.DataFrame]:
+    """Load the default v3 step OOF frames plus any challenger overrides."""
+    step_paths = _merge_step_oof_paths(candidate_step_oof_paths)
+    loaded = {name: _load_step_oof_frame(path) for name, path in step_paths.items()}
+    _assert_compatible_step_frames(loaded)
+    return loaded
+
+
+def _assert_compatible_step_frames(step_frames: Mapping[str, pd.DataFrame]) -> None:
+    base_ids = None
+    base_target = None
+    base_reference = None
+
+    for name, frame in step_frames.items():
+        _validate_specialist_mask(frame, step_name=name)
+        ids = frame[ID_COLUMN].to_numpy()
+        target = frame[OOF_TARGET_COLUMN].astype(int).to_numpy()
+        reference = frame["reference_pred"].astype(float).to_numpy()
+        if base_ids is None:
+            base_ids = ids
+            base_target = target
+            base_reference = reference
+            continue
+        if not np.array_equal(base_ids, ids):
+            raise ValueError(f"id mismatch across step OOF frames; first mismatch at '{name}'")
+        if not np.array_equal(base_target, target):
+            raise ValueError(f"target mismatch across step OOF frames; first mismatch at '{name}'")
+        if not np.allclose(base_reference, reference, atol=_REFERENCE_ATOL, rtol=0.0):
+            max_abs_diff = float(np.max(np.abs(base_reference - reference)))
+            raise ValueError(
+                f"reference_pred mismatch across step OOF frames; first mismatch at '{name}', "
+                f"max_abs_diff={max_abs_diff:.3e}, atol={_REFERENCE_ATOL:.1e}"
+            )
+
+
+def _assert_same_incumbent_reference(
+    *,
+    reference_frames: Mapping[str, pd.DataFrame],
+    candidate_frames: Mapping[str, pd.DataFrame],
+) -> None:
+    reference_base = _get_base_reference(reference_frames).to_numpy(dtype="float64")
+    candidate_base = _get_base_reference(candidate_frames).to_numpy(dtype="float64")
+    if not np.allclose(reference_base, candidate_base, atol=_REFERENCE_ATOL, rtol=0.0):
+        max_abs_diff = float(np.max(np.abs(reference_base - candidate_base)))
+        raise ValueError(
+            "candidate step overrides changed the incumbent reference_pred base; "
+            f"max_abs_diff={max_abs_diff:.3e}, atol={_REFERENCE_ATOL:.1e}"
+        )
+
+
+def _validate_full_train_coverage(ids: pd.Series, *, train_csv_path: str | Path) -> None:
+    train_ids = (
+        pd.read_csv(train_csv_path, usecols=[ID_COLUMN])[ID_COLUMN]
+        .sort_values()
+        .reset_index(drop=True)
+        .astype(ids.dtype)
+    )
+    candidate_ids = ids.sort_values().reset_index(drop=True)
+    if len(candidate_ids) != len(train_ids):
+        raise ValueError(
+            "step OOF coverage does not match train.csv row count: "
+            f"{len(candidate_ids)} vs {len(train_ids)}"
+        )
+    if not np.array_equal(candidate_ids.to_numpy(), train_ids.to_numpy()):
+        raise ValueError("step OOF ids do not exactly cover train.csv ids")
+
+
+def _get_base_reference(step_frames: Mapping[str, pd.DataFrame]) -> pd.Series:
+    any_frame = next(iter(step_frames.values()))
+    return pd.Series(
+        any_frame["reference_pred"].astype(float).to_numpy(),
+        index=any_frame[ID_COLUMN].to_numpy(),
+        dtype="float64",
+        name="reference_pred",
+    )
+
+
+def _get_target_series(step_frames: Mapping[str, pd.DataFrame]) -> pd.Series:
+    any_frame = next(iter(step_frames.values()))
+    return pd.Series(
+        any_frame[OOF_TARGET_COLUMN].astype(int).to_numpy(),
+        index=any_frame[ID_COLUMN].to_numpy(),
+        dtype="int8",
+        name=OOF_TARGET_COLUMN,
+    )
+
+
+def build_chain_prediction(
+    order: Sequence[str],
+    step_frames: Mapping[str, pd.DataFrame],
+) -> pd.Series:
+    """Apply a challenger chain over the shared base reference prediction."""
+    if not order:
+        raise ValueError("order must contain at least one step name")
+
+    reference = _get_base_reference(step_frames)
+    current = reference.copy()
+
+    for name in order:
+        if name not in step_frames:
+            available = sorted(step_frames)
+            raise ValueError(f"Unknown step '{name}'. Available steps: {available}")
+        frame = step_frames[name]
+        mask = frame["specialist_mask"].astype(bool).to_numpy()
+        candidate = frame["candidate_pred"].astype(float).to_numpy()
+        current.loc[mask] = candidate[mask]
+    return current
+
+
+def compute_repeated_cv_auc_stats(
+    target: pd.Series,
+    prediction: pd.Series,
+    *,
+    repeats: int = 5,
+    folds: int = 5,
+    random_state: int = 42,
+) -> dict[str, Any]:
+    """Compute repeated-fold AUC summary for a fixed OOF prediction vector."""
+    y = target.astype(int).to_numpy()
+    pred = prediction.astype(float).to_numpy()
+    fold_aucs: list[float] = []
+
+    for repeat in range(int(repeats)):
+        splitter = StratifiedKFold(
+            n_splits=int(folds),
+            shuffle=True,
+            random_state=int(random_state) + repeat,
+        )
+        for _, valid_idx in splitter.split(np.zeros_like(y), y):
+            fold_aucs.append(float(binary_auc(y[valid_idx], pred[valid_idx])))
+
+    metrics = np.asarray(fold_aucs, dtype="float64")
+    return {
+        "repeats": int(repeats),
+        "folds": int(folds),
+        "random_state": int(random_state),
+        "cv_mean_auc": float(metrics.mean()),
+        "cv_std_auc": float(metrics.std(ddof=0)),
+        "cv_min_auc": float(metrics.min()),
+        "cv_max_auc": float(metrics.max()),
+        "full_auc": float(binary_auc(y, pred)),
+        "fold_aucs": [float(value) for value in metrics.tolist()],
+    }
+
+
+def evaluate_candidate_chain_against_v3(
+    *,
+    candidate_order: Sequence[str],
+    candidate_step_oof_paths: Mapping[str, str | Path] | None = None,
+    stage: str = "smoke",
+    train_csv_path: str | Path = "data/raw/train.csv",
+    test_csv_path: str | Path = "data/raw/test.csv",
+    target_family_level: str = "segment3",
+    target_family_value: str = DOMINANT_MACROFAMILY,
+    dominant_family_value: str = DOMINANT_MACROFAMILY,
+    label: str = "candidate",
+    out_dir: str | Path = "artifacts/reports",
+) -> dict[str, Any]:
+    """Compare a challenger residual chain directly against incumbent v3."""
+    if str(stage).strip().lower() not in SUPPORTED_STAGES:
+        raise ValueError(f"Unsupported stage '{stage}'. Supported: {SUPPORTED_STAGES}")
+    if not candidate_order:
+        raise ValueError("candidate_order must contain at least one step name")
+
+    out_root = Path(out_dir)
+    reference_step_frames = load_chain_step_frames()
+    candidate_step_frames = load_chain_step_frames(candidate_step_oof_paths)
+    _assert_same_incumbent_reference(
+        reference_frames=reference_step_frames,
+        candidate_frames=candidate_step_frames,
+    )
+    target = _get_target_series(reference_step_frames)
+    ids = pd.Series(target.index.to_numpy(), index=target.index, dtype="int64", name=ID_COLUMN)
+    _validate_full_train_coverage(ids, train_csv_path=train_csv_path)
+
+    v3_pred = build_chain_prediction(V3_ORDER, reference_step_frames)
+    candidate_pred = build_chain_prediction(candidate_order, candidate_step_frames)
+    delta_auc = float(binary_auc(target, candidate_pred) - binary_auc(target, v3_pred))
+
+    v3_frame = pd.DataFrame(
+        {
+            ID_COLUMN: ids.values,
+            OOF_TARGET_COLUMN: target.values,
+            "candidate_pred": v3_pred.values,
+        }
+    )
+    candidate_frame = pd.DataFrame(
+        {
+            ID_COLUMN: ids.values,
+            OOF_TARGET_COLUMN: target.values,
+            "candidate_pred": candidate_pred.values,
+        }
+    )
+
+    analysis_frame = pd.DataFrame(
+        {
+            ID_COLUMN: ids.values,
+            OOF_TARGET_COLUMN: target.values,
+            "reference_pred": v3_pred.values,
+            "candidate_pred": candidate_pred.values,
+        }
+    )
+
+    v3_oof_path = ensure_parent_dir(out_root / "validation_protocol_v3_chain_oof.csv")
+    candidate_oof_path = ensure_parent_dir(out_root / f"validation_protocol_{label}_chain_oof.csv")
+    analysis_oof_path = ensure_parent_dir(out_root / f"validation_protocol_{label}_vs_v3_analysis_oof.csv")
+    v3_frame.to_csv(v3_oof_path, index=False)
+    candidate_frame.to_csv(candidate_oof_path, index=False)
+    analysis_frame.to_csv(analysis_oof_path, index=False)
+
+    reference_metrics = {
+        "generated_for": "validation_protocol_v3_chain_reference",
+        "order": list(V3_ORDER),
+        **compute_repeated_cv_auc_stats(target, v3_pred),
+    }
+    candidate_metrics = {
+        "generated_for": "validation_protocol_chain_candidate",
+        "order": [str(step) for step in candidate_order],
+        **compute_repeated_cv_auc_stats(target, candidate_pred),
+    }
+    reference_metrics_path = ensure_parent_dir(out_root / "validation_protocol_v3_chain_metrics.json")
+    candidate_metrics_path = ensure_parent_dir(out_root / f"validation_protocol_{label}_chain_metrics.json")
+    write_json(reference_metrics_path, reference_metrics)
+    write_json(candidate_metrics_path, candidate_metrics)
+
+    verdict_path = ensure_parent_dir(out_root / f"validation_protocol_{label}_vs_v3_{stage}.json")
+    protocol_result = evaluate_validation_protocol(
+        train_csv_path=train_csv_path,
+        test_csv_path=test_csv_path,
+        stage=stage,
+        analysis_oof_path=analysis_oof_path,
+        target_family_level=target_family_level,
+        target_family_value=target_family_value,
+        dominant_family_value=dominant_family_value,
+        candidate_metrics_json=candidate_metrics_path,
+        reference_metrics_json=reference_metrics_path,
+        out_json_path=verdict_path,
+    )
+
+    summary = {
+        "label": str(label),
+        "stage": str(stage),
+        "candidate_order": [str(step) for step in candidate_order],
+        "v3_order": list(V3_ORDER),
+        "delta_vs_v3_oof_auc": delta_auc,
+        "v3_oof_path": str(v3_oof_path),
+        "candidate_oof_path": str(candidate_oof_path),
+        "analysis_oof_path": str(analysis_oof_path),
+        "reference_metrics_path": str(reference_metrics_path),
+        "candidate_metrics_path": str(candidate_metrics_path),
+        "verdict_path": str(verdict_path),
+        "verdict": protocol_result["verdict"],
+        "overall_metrics": protocol_result["overall_metrics"],
+    }
+    summary_path = ensure_parent_dir(out_root / f"validation_protocol_{label}_vs_v3_summary.json")
+    write_json(summary_path, summary)
+    summary["summary_path"] = str(summary_path)
+    return summary

--- a/src/churn_baseline/linear_probe.py
+++ b/src/churn_baseline/linear_probe.py
@@ -1,0 +1,314 @@
+"""Sparse linear probes for orthogonal tabular signals."""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import StratifiedKFold
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import OneHotEncoder, SplineTransformer, StandardScaler
+
+from .artifacts import ensure_parent_dir, write_json
+from .config import ID_COLUMN, TARGET_COLUMN
+from .data import infer_categorical_columns, load_csv, prepare_train_features
+from .evaluation import binary_auc
+from .feature_engineering import normalize_feature_blocks
+
+LOGISTIC = "logistic"
+SPLINE_LOGISTIC = "spline_logistic"
+LINEAR_PROBE_FAMILIES: tuple[str, ...] = (LOGISTIC, SPLINE_LOGISTIC)
+PREFERRED_SPLINE_COLUMNS: tuple[str, ...] = (
+    "tenure",
+    "MonthlyCharges",
+    "TotalCharges",
+    "effective_monthly_charge",
+    "current_vs_effective_monthly_delta",
+    "current_vs_effective_monthly_ratio",
+    "monthly_per_active_service",
+    "payment_friction_index",
+    "months_to_contract_boundary",
+    "contract_cycle_progress",
+    "annual_cycle_progress",
+    "two_year_cycle_progress",
+    "monthly_rank_in_value_cohort",
+)
+
+
+def _save_pickle(path: str | Path, payload: Any) -> Path:
+    out_path = ensure_parent_dir(path)
+    with out_path.open("wb") as fh:
+        pickle.dump(payload, fh)
+    return out_path
+
+
+def list_linear_probe_families() -> tuple[str, ...]:
+    """Return supported linear probe model families."""
+    return LINEAR_PROBE_FAMILIES
+
+
+def _resolve_spline_columns(numeric_columns: Sequence[str]) -> list[str]:
+    numeric_set = set(numeric_columns)
+    selected = [column for column in PREFERRED_SPLINE_COLUMNS if column in numeric_set]
+    if selected:
+        return selected
+    return list(numeric_columns[: min(len(numeric_columns), 4)])
+
+
+def _build_linear_pipeline(
+    *,
+    model_family: str,
+    categorical_columns: Sequence[str],
+    numeric_columns: Sequence[str],
+    c_value: float,
+    max_iter: int,
+    random_state: int,
+    tol: float,
+    verbose: int,
+    spline_n_knots: int,
+    spline_degree: int,
+) -> Pipeline:
+    categorical_pipeline = Pipeline(
+        steps=[
+            ("imputer", SimpleImputer(strategy="most_frequent")),
+            ("onehot", OneHotEncoder(handle_unknown="ignore")),
+        ]
+    )
+    model_family_value = str(model_family).strip().lower()
+    transformers: list[tuple[str, Pipeline, list[str]]] = []
+    if categorical_columns:
+        transformers.append(("cat", categorical_pipeline, list(categorical_columns)))
+
+    if model_family_value == LOGISTIC:
+        if numeric_columns:
+            transformers.append(
+                (
+                    "num",
+                    Pipeline(
+                        steps=[
+                            ("imputer", SimpleImputer(strategy="median")),
+                            ("scale", StandardScaler()),
+                        ]
+                    ),
+                    list(numeric_columns),
+                )
+            )
+    elif model_family_value == SPLINE_LOGISTIC:
+        spline_columns = _resolve_spline_columns(numeric_columns)
+        remaining_numeric = [column for column in numeric_columns if column not in set(spline_columns)]
+        if spline_columns:
+            transformers.append(
+                (
+                    "num_spline",
+                    Pipeline(
+                        steps=[
+                            ("imputer", SimpleImputer(strategy="median")),
+                            ("scale", StandardScaler()),
+                            (
+                                "spline",
+                                SplineTransformer(
+                                    n_knots=int(spline_n_knots),
+                                    degree=int(spline_degree),
+                                    knots="quantile",
+                                    extrapolation="constant",
+                                    include_bias=False,
+                                    sparse_output=True,
+                                ),
+                            ),
+                        ]
+                    ),
+                    list(spline_columns),
+                )
+            )
+        if remaining_numeric:
+            transformers.append(
+                (
+                    "num_linear",
+                    Pipeline(
+                        steps=[
+                            ("imputer", SimpleImputer(strategy="median")),
+                            ("scale", StandardScaler()),
+                        ]
+                    ),
+                    list(remaining_numeric),
+                )
+            )
+    else:
+        raise ValueError(f"Unsupported model_family '{model_family}'. Available: {LINEAR_PROBE_FAMILIES}")
+
+    preprocess = ColumnTransformer(transformers=transformers, remainder="drop", sparse_threshold=1.0)
+    classifier = LogisticRegression(
+        C=float(c_value),
+        solver="saga",
+        max_iter=int(max_iter),
+        tol=float(tol),
+        random_state=int(random_state),
+        verbose=int(verbose),
+    )
+    return Pipeline(
+        steps=[
+            ("preprocess", preprocess),
+            ("model", classifier),
+        ]
+    )
+
+
+def run_linear_probe_cv(
+    *,
+    train_csv_path: str | Path,
+    model_path: str | Path,
+    metrics_path: str | Path,
+    oof_path: str | Path,
+    feature_blocks: Sequence[str] | None,
+    folds: int,
+    random_state: int,
+    c_value: float,
+    max_iter: int,
+    tol: float,
+    verbose: int,
+    model_family: str,
+    spline_n_knots: int,
+    spline_degree: int,
+    reference_pred: pd.Series | None = None,
+    alpha_grid: Sequence[float] | None = None,
+) -> dict[str, Any]:
+    """Train a sparse linear probe with OOF evaluation and optional blend scan."""
+    if folds < 2:
+        raise ValueError("folds must be >= 2")
+
+    train_df = load_csv(train_csv_path)
+    normalized_blocks = normalize_feature_blocks(feature_blocks)
+    x, y = prepare_train_features(train_df, drop_id=True, feature_blocks=normalized_blocks)
+    categorical_columns = infer_categorical_columns(x)
+    numeric_columns = [column for column in x.columns if column not in categorical_columns]
+    splitter = StratifiedKFold(n_splits=folds, shuffle=True, random_state=random_state)
+
+    oof_pred = pd.Series(index=x.index, dtype="float64", name="oof_pred")
+    fold_rows: list[dict[str, Any]] = []
+
+    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x, y), start=1):
+        x_train = x.iloc[train_idx]
+        y_train = y.iloc[train_idx]
+        x_valid = x.iloc[valid_idx]
+        y_valid = y.iloc[valid_idx]
+
+        fold_pipeline = _build_linear_pipeline(
+            model_family=model_family,
+            categorical_columns=categorical_columns,
+            numeric_columns=numeric_columns,
+            c_value=c_value,
+            max_iter=max_iter,
+            random_state=random_state,
+            tol=tol,
+            verbose=verbose,
+            spline_n_knots=spline_n_knots,
+            spline_degree=spline_degree,
+        )
+        fold_pipeline.fit(x_train, y_train)
+        fold_pred = pd.Series(
+            fold_pipeline.predict_proba(x_valid)[:, 1],
+            index=x_valid.index,
+            dtype="float64",
+        )
+        oof_pred.iloc[valid_idx] = fold_pred.values
+        fold_rows.append(
+            {
+                "fold": int(fold_number),
+                "valid_rows": int(len(valid_idx)),
+                "auc": float(binary_auc(y_valid, fold_pred)),
+            }
+        )
+
+    if oof_pred.isna().any():
+        raise RuntimeError("OOF predictions contain missing values for linear probe.")
+
+    full_pipeline = _build_linear_pipeline(
+        model_family=model_family,
+        categorical_columns=categorical_columns,
+        numeric_columns=numeric_columns,
+        c_value=c_value,
+        max_iter=max_iter,
+        random_state=random_state,
+        tol=tol,
+        verbose=verbose,
+        spline_n_knots=spline_n_knots,
+        spline_degree=spline_degree,
+    )
+    full_pipeline.fit(x, y)
+    _save_pickle(model_path, full_pipeline)
+
+    oof_output = pd.DataFrame(
+        {
+            ID_COLUMN: train_df[ID_COLUMN].values,
+            "target": y.astype(int).values,
+            "oof_pred": oof_pred.values,
+        }
+    )
+    ensure_parent_dir(oof_path)
+    oof_output.to_csv(oof_path, index=False)
+
+    metrics: dict[str, Any] = {
+        "train_rows": int(len(train_df)),
+        "feature_count": int(x.shape[1]),
+        "feature_blocks": list(normalized_blocks),
+        "categorical_columns": list(categorical_columns),
+        "numeric_columns": list(numeric_columns),
+        "cv_folds": int(folds),
+        "cv_fold_metrics": fold_rows,
+        "cv_mean_auc": float(np.mean([row["auc"] for row in fold_rows])),
+        "cv_std_auc": float(np.std([row["auc"] for row in fold_rows])),
+        "oof_auc": float(binary_auc(y, oof_pred)),
+        "model_path": str(model_path),
+        "oof_path": str(oof_path),
+        "target_column": TARGET_COLUMN,
+        "id_column": ID_COLUMN,
+        "model_family": str(model_family),
+        "params": {
+            "C": float(c_value),
+            "max_iter": int(max_iter),
+            "tol": float(tol),
+            "solver": "saga",
+            "spline_n_knots": int(spline_n_knots),
+            "spline_degree": int(spline_degree),
+            "spline_columns": _resolve_spline_columns(numeric_columns) if model_family == SPLINE_LOGISTIC else [],
+        },
+    }
+
+    if reference_pred is not None:
+        reference_by_id = pd.Series(reference_pred, copy=True)
+        aligned_reference = train_df[ID_COLUMN].map(reference_by_id)
+        if aligned_reference.isna().any():
+            missing_ids = train_df.loc[aligned_reference.isna(), ID_COLUMN].head(5).tolist()
+            raise ValueError(f"reference_pred missing ids from train: {missing_ids}")
+        aligned_reference = pd.Series(aligned_reference.values, index=x.index, dtype="float64")
+        metrics["reference_oof_auc"] = float(binary_auc(y, aligned_reference))
+        metrics["pearson_corr_vs_reference"] = float(aligned_reference.corr(oof_pred))
+        metrics["spearman_corr_vs_reference"] = float(aligned_reference.corr(oof_pred, method="spearman"))
+
+        if alpha_grid:
+            alpha_rows: list[dict[str, Any]] = []
+            for alpha in alpha_grid:
+                alpha_value = float(alpha)
+                candidate = (1.0 - alpha_value) * aligned_reference + alpha_value * oof_pred
+                alpha_rows.append(
+                    {
+                        "alpha": alpha_value,
+                        "oof_auc": float(binary_auc(y, candidate)),
+                    }
+                )
+            best_alpha_row = max(alpha_rows, key=lambda row: row["oof_auc"])
+            metrics["blend_scan"] = alpha_rows
+            metrics["best_blend_alpha"] = float(best_alpha_row["alpha"])
+            metrics["best_blend_oof_auc"] = float(best_alpha_row["oof_auc"])
+            metrics["delta_best_blend_vs_reference"] = float(
+                best_alpha_row["oof_auc"] - binary_auc(y, aligned_reference)
+            )
+
+    write_json(metrics_path, metrics)
+    return metrics

--- a/src/churn_baseline/linear_probe.py
+++ b/src/churn_baseline/linear_probe.py
@@ -8,6 +8,7 @@ from typing import Any, Sequence
 
 import numpy as np
 import pandas as pd
+from catboost import CatBoostClassifier
 from sklearn.compose import ColumnTransformer
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import LogisticRegression
@@ -17,13 +18,18 @@ from sklearn.preprocessing import OneHotEncoder, SplineTransformer, StandardScal
 
 from .artifacts import ensure_parent_dir, write_json
 from .config import ID_COLUMN, TARGET_COLUMN
-from .data import infer_categorical_columns, load_csv, prepare_train_features
+from .data import encode_target, infer_categorical_columns, load_csv, prepare_train_features
 from .evaluation import binary_auc
 from .feature_engineering import normalize_feature_blocks
+from .specialist import _append_teacher_disagreement_features, _normalize_reference_component_frame, _prob_to_logit
 
 LOGISTIC = "logistic"
 SPLINE_LOGISTIC = "spline_logistic"
-LINEAR_PROBE_FAMILIES: tuple[str, ...] = (LOGISTIC, SPLINE_LOGISTIC)
+CATBOOST_META = "catboost_meta"
+LINEAR_PROBE_FAMILIES: tuple[str, ...] = (LOGISTIC, SPLINE_LOGISTIC, CATBOOST_META)
+FEATURE_MODE_RAW = "raw"
+FEATURE_MODE_TEACHER_META = "teacher_meta"
+LINEAR_PROBE_FEATURE_MODES: tuple[str, ...] = (FEATURE_MODE_RAW, FEATURE_MODE_TEACHER_META)
 PREFERRED_SPLINE_COLUMNS: tuple[str, ...] = (
     "tenure",
     "MonthlyCharges",
@@ -51,6 +57,72 @@ def _save_pickle(path: str | Path, payload: Any) -> Path:
 def list_linear_probe_families() -> tuple[str, ...]:
     """Return supported linear probe model families."""
     return LINEAR_PROBE_FAMILIES
+
+
+def list_linear_probe_feature_modes() -> tuple[str, ...]:
+    """Return supported feature modes for the linear probe."""
+    return LINEAR_PROBE_FEATURE_MODES
+
+
+def _build_tenure_bin(tenure_values: pd.Series) -> pd.Series:
+    bins = [-np.inf, 6, 12, 24, 48, np.inf]
+    labels = ["0_6", "7_12", "13_24", "25_48", "49_plus"]
+    return pd.cut(tenure_values, bins=bins, labels=labels).astype(str)
+
+
+def _prepare_teacher_meta_features(
+    *,
+    train_df: pd.DataFrame,
+    reference_pred: pd.Series,
+    teacher_component_frame: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.Series, list[str]]:
+    """Build a compact meta-model matrix from teacher components plus cohort keys."""
+    cohort = pd.DataFrame(
+        {
+            "PaymentMethod": train_df["PaymentMethod"].astype(str),
+            "Contract": train_df["Contract"].astype(str),
+            "InternetService": train_df["InternetService"].astype(str),
+            "PaperlessBilling": train_df["PaperlessBilling"].astype(str),
+            "tenure_bin": _build_tenure_bin(pd.to_numeric(train_df["tenure"], errors="coerce").fillna(0.0)),
+        },
+        index=train_df.index,
+    )
+    y = encode_target(train_df[TARGET_COLUMN])
+    aligned_reference = _align_reference_prediction(
+        train_ids=train_df[ID_COLUMN],
+        reference_pred=reference_pred,
+        index=cohort.index,
+    )
+    component_frame = _normalize_reference_component_frame(train_df[ID_COLUMN], teacher_component_frame)
+
+    x = cohort.copy()
+    x["reference_pred_feature"] = aligned_reference.values
+    x["reference_logit_feature"] = _prob_to_logit(aligned_reference)
+    x, disagreement_columns = _append_teacher_disagreement_features(x, aligned_reference, component_frame)
+    return x, y, disagreement_columns
+
+
+def _align_reference_prediction(
+    *,
+    train_ids: pd.Series,
+    reference_pred: pd.Series,
+    index: pd.Index,
+) -> pd.Series:
+    reference_by_id = pd.Series(reference_pred, copy=True)
+    if reference_by_id.index.has_duplicates:
+        duplicate_ids = pd.Index(reference_by_id.index[reference_by_id.index.duplicated()]).unique().tolist()[:5]
+        raise ValueError(
+            "reference_pred must be indexed by unique train ids and represent OOF predictions. "
+            f"Duplicate ids found: {duplicate_ids}"
+        )
+    aligned_reference = train_ids.map(reference_by_id)
+    if aligned_reference.isna().any():
+        missing_ids = train_ids.loc[aligned_reference.isna()].head(5).tolist()
+        raise ValueError(
+            "reference_pred must cover every train id with OOF-aligned predictions. "
+            f"Missing ids: {missing_ids}"
+        )
+    return pd.Series(aligned_reference.values, index=index, dtype="float64")
 
 
 def _resolve_spline_columns(numeric_columns: Sequence[str]) -> list[str]:
@@ -159,6 +231,27 @@ def _build_linear_pipeline(
     )
 
 
+def _build_catboost_meta_model(
+    *,
+    iterations: int,
+    learning_rate: float,
+    depth: int,
+    l2_leaf_reg: float,
+    random_state: int,
+) -> CatBoostClassifier:
+    return CatBoostClassifier(
+        iterations=int(iterations),
+        learning_rate=float(learning_rate),
+        depth=int(depth),
+        l2_leaf_reg=float(l2_leaf_reg),
+        loss_function="Logloss",
+        eval_metric="AUC",
+        random_seed=int(random_state),
+        allow_writing_files=False,
+        verbose=False,
+    )
+
+
 def run_linear_probe_cv(
     *,
     train_csv_path: str | Path,
@@ -175,22 +268,57 @@ def run_linear_probe_cv(
     model_family: str,
     spline_n_knots: int,
     spline_degree: int,
+    feature_mode: str = FEATURE_MODE_RAW,
     reference_pred: pd.Series | None = None,
+    teacher_component_frame: pd.DataFrame | None = None,
     alpha_grid: Sequence[float] | None = None,
+    reference_is_oof: bool = False,
+    tree_iterations: int = 300,
+    tree_depth: int = 4,
+    tree_learning_rate: float = 0.05,
+    tree_l2_leaf_reg: float = 8.0,
+    tree_early_stopping_rounds: int = 50,
 ) -> dict[str, Any]:
     """Train a sparse linear probe with OOF evaluation and optional blend scan."""
     if folds < 2:
         raise ValueError("folds must be >= 2")
 
     train_df = load_csv(train_csv_path)
-    normalized_blocks = normalize_feature_blocks(feature_blocks)
-    x, y = prepare_train_features(train_df, drop_id=True, feature_blocks=normalized_blocks)
+    model_family_value = str(model_family).strip().lower()
+    feature_mode_value = str(feature_mode).strip().lower()
+    disagreement_columns: list[str] = []
+    if model_family_value == CATBOOST_META and feature_mode_value != FEATURE_MODE_TEACHER_META:
+        raise ValueError("model_family=catboost_meta is only supported with feature_mode=teacher_meta")
+    if model_family_value == CATBOOST_META and int(tree_early_stopping_rounds) < 1:
+        raise ValueError("tree_early_stopping_rounds must be >= 1 for model_family=catboost_meta")
+    if reference_pred is not None and not reference_is_oof:
+        raise ValueError(
+            "reference_pred must be explicit OOF data. Pass reference_is_oof=True only after "
+            "verifying the reference predictions and teacher components are OOF-aligned."
+        )
+    if feature_mode_value == FEATURE_MODE_RAW:
+        normalized_blocks = normalize_feature_blocks(feature_blocks)
+        x, y = prepare_train_features(train_df, drop_id=True, feature_blocks=normalized_blocks)
+    elif feature_mode_value == FEATURE_MODE_TEACHER_META:
+        if reference_pred is None:
+            raise ValueError("feature_mode=teacher_meta requires reference_pred")
+        if teacher_component_frame is None:
+            raise ValueError("feature_mode=teacher_meta requires teacher_component_frame with pred_* columns")
+        normalized_blocks = ()
+        x, y, disagreement_columns = _prepare_teacher_meta_features(
+            train_df=train_df,
+            reference_pred=reference_pred,
+            teacher_component_frame=teacher_component_frame,
+        )
+    else:
+        raise ValueError(f"Unsupported feature_mode '{feature_mode}'. Available: {LINEAR_PROBE_FEATURE_MODES}")
     categorical_columns = infer_categorical_columns(x)
     numeric_columns = [column for column in x.columns if column not in categorical_columns]
     splitter = StratifiedKFold(n_splits=folds, shuffle=True, random_state=random_state)
 
     oof_pred = pd.Series(index=x.index, dtype="float64", name="oof_pred")
     fold_rows: list[dict[str, Any]] = []
+    fold_iterations: list[int] = []
 
     for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x, y), start=1):
         x_train = x.iloc[train_idx]
@@ -198,7 +326,79 @@ def run_linear_probe_cv(
         x_valid = x.iloc[valid_idx]
         y_valid = y.iloc[valid_idx]
 
-        fold_pipeline = _build_linear_pipeline(
+        if model_family_value == CATBOOST_META:
+            fold_model = _build_catboost_meta_model(
+                iterations=tree_iterations,
+                learning_rate=tree_learning_rate,
+                depth=tree_depth,
+                l2_leaf_reg=tree_l2_leaf_reg,
+                random_state=random_state,
+            )
+            fold_model.fit(
+                x_train,
+                y_train,
+                cat_features=list(categorical_columns),
+                eval_set=(x_valid, y_valid),
+                use_best_model=True,
+                early_stopping_rounds=int(tree_early_stopping_rounds),
+                verbose=False,
+            )
+            fold_pred = pd.Series(
+                fold_model.predict_proba(x_valid)[:, 1],
+                index=x_valid.index,
+                dtype="float64",
+            )
+            best_iter = fold_model.get_best_iteration()
+            final_iter = int(best_iter) + 1 if best_iter is not None and best_iter >= 0 else int(tree_iterations)
+            fold_iterations.append(max(final_iter, 1))
+        else:
+            fold_model = _build_linear_pipeline(
+                model_family=model_family,
+                categorical_columns=categorical_columns,
+                numeric_columns=numeric_columns,
+                c_value=c_value,
+                max_iter=max_iter,
+                random_state=random_state,
+                tol=tol,
+                verbose=verbose,
+                spline_n_knots=spline_n_knots,
+                spline_degree=spline_degree,
+            )
+            fold_model.fit(x_train, y_train)
+            fold_pred = pd.Series(
+                fold_model.predict_proba(x_valid)[:, 1],
+                index=x_valid.index,
+                dtype="float64",
+            )
+            best_iter = None
+            final_iter = None
+        oof_pred.iloc[valid_idx] = fold_pred.values
+        fold_row = {
+            "fold": int(fold_number),
+            "valid_rows": int(len(valid_idx)),
+            "auc": float(binary_auc(y_valid, fold_pred)),
+        }
+        if best_iter is not None:
+            fold_row["best_iteration"] = int(best_iter)
+            fold_row["final_iterations"] = int(max(final_iter or 1, 1))
+        fold_rows.append(fold_row)
+
+    if oof_pred.isna().any():
+        raise RuntimeError("OOF predictions contain missing values for linear probe.")
+
+    if model_family_value == CATBOOST_META:
+        full_iterations = max(int(round(float(np.mean(fold_iterations)))), 1) if fold_iterations else int(tree_iterations)
+        full_model = _build_catboost_meta_model(
+            iterations=full_iterations,
+            learning_rate=tree_learning_rate,
+            depth=tree_depth,
+            l2_leaf_reg=tree_l2_leaf_reg,
+            random_state=random_state,
+        )
+        full_model.fit(x, y, cat_features=list(categorical_columns), verbose=False)
+        _save_pickle(model_path, full_model)
+    else:
+        full_model = _build_linear_pipeline(
             model_family=model_family,
             categorical_columns=categorical_columns,
             numeric_columns=numeric_columns,
@@ -210,38 +410,9 @@ def run_linear_probe_cv(
             spline_n_knots=spline_n_knots,
             spline_degree=spline_degree,
         )
-        fold_pipeline.fit(x_train, y_train)
-        fold_pred = pd.Series(
-            fold_pipeline.predict_proba(x_valid)[:, 1],
-            index=x_valid.index,
-            dtype="float64",
-        )
-        oof_pred.iloc[valid_idx] = fold_pred.values
-        fold_rows.append(
-            {
-                "fold": int(fold_number),
-                "valid_rows": int(len(valid_idx)),
-                "auc": float(binary_auc(y_valid, fold_pred)),
-            }
-        )
-
-    if oof_pred.isna().any():
-        raise RuntimeError("OOF predictions contain missing values for linear probe.")
-
-    full_pipeline = _build_linear_pipeline(
-        model_family=model_family,
-        categorical_columns=categorical_columns,
-        numeric_columns=numeric_columns,
-        c_value=c_value,
-        max_iter=max_iter,
-        random_state=random_state,
-        tol=tol,
-        verbose=verbose,
-        spline_n_knots=spline_n_knots,
-        spline_degree=spline_degree,
-    )
-    full_pipeline.fit(x, y)
-    _save_pickle(model_path, full_pipeline)
+        full_model.fit(x, y)
+        _save_pickle(model_path, full_model)
+        full_iterations = None
 
     oof_output = pd.DataFrame(
         {
@@ -257,6 +428,8 @@ def run_linear_probe_cv(
         "train_rows": int(len(train_df)),
         "feature_count": int(x.shape[1]),
         "feature_blocks": list(normalized_blocks),
+        "feature_mode": feature_mode_value,
+        "teacher_disagreement_columns": disagreement_columns,
         "categorical_columns": list(categorical_columns),
         "numeric_columns": list(numeric_columns),
         "cv_folds": int(folds),
@@ -269,6 +442,7 @@ def run_linear_probe_cv(
         "target_column": TARGET_COLUMN,
         "id_column": ID_COLUMN,
         "model_family": str(model_family),
+        "reference_is_oof": bool(reference_is_oof),
         "params": {
             "C": float(c_value),
             "max_iter": int(max_iter),
@@ -276,17 +450,23 @@ def run_linear_probe_cv(
             "solver": "saga",
             "spline_n_knots": int(spline_n_knots),
             "spline_degree": int(spline_degree),
-            "spline_columns": _resolve_spline_columns(numeric_columns) if model_family == SPLINE_LOGISTIC else [],
+            "spline_columns": _resolve_spline_columns(numeric_columns) if model_family_value == SPLINE_LOGISTIC else [],
+            "tree_iterations": int(tree_iterations),
+            "tree_depth": int(tree_depth),
+            "tree_learning_rate": float(tree_learning_rate),
+            "tree_l2_leaf_reg": float(tree_l2_leaf_reg),
+            "tree_early_stopping_rounds": int(tree_early_stopping_rounds),
         },
     }
+    if full_iterations is not None:
+        metrics["final_iterations"] = int(full_iterations)
 
     if reference_pred is not None:
-        reference_by_id = pd.Series(reference_pred, copy=True)
-        aligned_reference = train_df[ID_COLUMN].map(reference_by_id)
-        if aligned_reference.isna().any():
-            missing_ids = train_df.loc[aligned_reference.isna(), ID_COLUMN].head(5).tolist()
-            raise ValueError(f"reference_pred missing ids from train: {missing_ids}")
-        aligned_reference = pd.Series(aligned_reference.values, index=x.index, dtype="float64")
+        aligned_reference = _align_reference_prediction(
+            train_ids=train_df[ID_COLUMN],
+            reference_pred=reference_pred,
+            index=x.index,
+        )
         metrics["reference_oof_auc"] = float(binary_auc(y, aligned_reference))
         metrics["pearson_corr_vs_reference"] = float(aligned_reference.corr(oof_pred))
         metrics["spearman_corr_vs_reference"] = float(aligned_reference.corr(oof_pred, method="spearman"))

--- a/src/churn_baseline/mlp_probe.py
+++ b/src/churn_baseline/mlp_probe.py
@@ -1,0 +1,475 @@
+"""PyTorch tabular MLP probe with categorical embeddings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+import torch
+from sklearn.model_selection import StratifiedKFold
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from .artifacts import ensure_parent_dir, write_json
+from .config import ID_COLUMN, TARGET_COLUMN
+from .data import infer_categorical_columns, load_csv, prepare_train_features
+from .evaluation import binary_auc
+from .feature_engineering import normalize_feature_blocks
+
+
+def _set_torch_seed(seed: int) -> None:
+    torch.manual_seed(int(seed))
+    np.random.seed(int(seed))
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(int(seed))
+
+
+def _resolve_device(device: str) -> torch.device:
+    device_value = str(device).strip().lower()
+    if device_value == "auto":
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    return torch.device(device_value)
+
+
+def _parse_hidden_dims(raw: Sequence[int] | str) -> list[int]:
+    if isinstance(raw, str):
+        parts = [part.strip() for part in raw.split(",") if part.strip()]
+        return [int(part) for part in parts]
+    return [int(value) for value in raw]
+
+
+def _embedding_dim(cardinality: int, max_dim: int) -> int:
+    return max(4, min(int(max_dim), int(round(1.6 * (int(cardinality) ** 0.56)))))
+
+
+def _fit_category_maps(frame: pd.DataFrame, categorical_columns: Sequence[str]) -> tuple[dict[str, dict[str, int]], list[int]]:
+    mappings: dict[str, dict[str, int]] = {}
+    cardinalities: list[int] = []
+    for column in categorical_columns:
+        values = frame[column].fillna("__MISSING__").astype(str)
+        unique_values = sorted(values.unique().tolist())
+        mapping = {value: idx + 1 for idx, value in enumerate(unique_values)}
+        mappings[str(column)] = mapping
+        cardinalities.append(len(mapping) + 1)
+    return mappings, cardinalities
+
+
+def _encode_categorical(
+    frame: pd.DataFrame,
+    categorical_columns: Sequence[str],
+    mappings: dict[str, dict[str, int]],
+) -> np.ndarray:
+    if not categorical_columns:
+        return np.zeros((len(frame), 0), dtype=np.int64)
+
+    encoded = np.zeros((len(frame), len(categorical_columns)), dtype=np.int64)
+    for col_idx, column in enumerate(categorical_columns):
+        series = frame[column].fillna("__MISSING__").astype(str)
+        mapping = mappings[str(column)]
+        encoded[:, col_idx] = series.map(mapping).fillna(0).astype(np.int64).to_numpy()
+    return encoded
+
+
+def _fit_numeric_stats(frame: pd.DataFrame, numeric_columns: Sequence[str]) -> tuple[pd.Series, pd.Series, pd.Series]:
+    if not numeric_columns:
+        empty = pd.Series(dtype="float64")
+        return empty, empty, empty
+    subset = frame.loc[:, list(numeric_columns)].copy()
+    medians = subset.median()
+    means = subset.fillna(medians).mean()
+    stds = subset.fillna(medians).std(ddof=0).replace(0.0, 1.0)
+    return medians, means, stds
+
+
+def _encode_numeric(
+    frame: pd.DataFrame,
+    numeric_columns: Sequence[str],
+    medians: pd.Series,
+    means: pd.Series,
+    stds: pd.Series,
+) -> np.ndarray:
+    if not numeric_columns:
+        return np.zeros((len(frame), 0), dtype=np.float32)
+    subset = frame.loc[:, list(numeric_columns)].copy()
+    subset = subset.fillna(medians)
+    subset = (subset - means) / stds
+    subset = subset.replace([np.inf, -np.inf], 0.0).fillna(0.0)
+    return subset.astype("float32").to_numpy()
+
+
+class TabularEmbeddingMLP(nn.Module):
+    def __init__(
+        self,
+        *,
+        cardinalities: Sequence[int],
+        numeric_dim: int,
+        hidden_dims: Sequence[int],
+        dropout: float,
+        max_embedding_dim: int,
+    ) -> None:
+        super().__init__()
+        self.embeddings = nn.ModuleList(
+            [nn.Embedding(int(cardinality), _embedding_dim(int(cardinality), max_embedding_dim)) for cardinality in cardinalities]
+        )
+        input_dim = sum(embedding.embedding_dim for embedding in self.embeddings) + int(numeric_dim)
+        layers: list[nn.Module] = []
+        hidden_dims_list = [int(value) for value in hidden_dims if int(value) > 0]
+        for hidden_dim in hidden_dims_list:
+            layers.extend(
+                [
+                    nn.Linear(input_dim, hidden_dim),
+                    nn.ReLU(),
+                    nn.BatchNorm1d(hidden_dim),
+                    nn.Dropout(float(dropout)),
+                ]
+            )
+            input_dim = hidden_dim
+        self.backbone = nn.Sequential(*layers) if layers else nn.Identity()
+        self.output = nn.Linear(input_dim, 1)
+
+    def forward(self, x_cat: torch.Tensor, x_num: torch.Tensor) -> torch.Tensor:
+        parts: list[torch.Tensor] = []
+        if self.embeddings:
+            embedded = [embedding(x_cat[:, index]) for index, embedding in enumerate(self.embeddings)]
+            parts.append(torch.cat(embedded, dim=1))
+        if x_num.shape[1] > 0:
+            parts.append(x_num)
+        if not parts:
+            raise ValueError("MLP probe requires at least one categorical or numeric feature.")
+        combined = torch.cat(parts, dim=1)
+        hidden = self.backbone(combined)
+        return self.output(hidden).squeeze(1)
+
+
+@dataclass(frozen=True)
+class MLPProbeParams:
+    hidden_dims: tuple[int, ...] = (128, 64)
+    dropout: float = 0.1
+    learning_rate: float = 1e-3
+    weight_decay: float = 1e-5
+    batch_size: int = 4096
+    epochs: int = 6
+    max_embedding_dim: int = 32
+    device: str = "auto"
+
+
+def _build_dataset(
+    x_cat: np.ndarray,
+    x_num: np.ndarray,
+    y: np.ndarray | None = None,
+) -> TensorDataset:
+    cat_tensor = torch.from_numpy(x_cat.astype(np.int64))
+    num_tensor = torch.from_numpy(x_num.astype(np.float32))
+    if y is None:
+        target_tensor = torch.zeros((len(x_cat),), dtype=torch.float32)
+    else:
+        target_tensor = torch.from_numpy(y.astype(np.float32))
+    return TensorDataset(cat_tensor, num_tensor, target_tensor)
+
+
+def _train_one_fold(
+    *,
+    x_train_cat: np.ndarray,
+    x_train_num: np.ndarray,
+    y_train: np.ndarray,
+    x_valid_cat: np.ndarray,
+    x_valid_num: np.ndarray,
+    y_valid: np.ndarray,
+    cardinalities: Sequence[int],
+    params: MLPProbeParams,
+    seed: int,
+    device: torch.device,
+) -> tuple[np.ndarray, int]:
+    _set_torch_seed(seed)
+    model = TabularEmbeddingMLP(
+        cardinalities=cardinalities,
+        numeric_dim=x_train_num.shape[1],
+        hidden_dims=params.hidden_dims,
+        dropout=params.dropout,
+        max_embedding_dim=params.max_embedding_dim,
+    ).to(device)
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=float(params.learning_rate),
+        weight_decay=float(params.weight_decay),
+    )
+    criterion = nn.BCEWithLogitsLoss()
+    dataset = _build_dataset(x_train_cat, x_train_num, y_train)
+    loader = DataLoader(
+        dataset,
+        batch_size=int(params.batch_size),
+        shuffle=True,
+        num_workers=0,
+        pin_memory=device.type == "cuda",
+    )
+
+    x_valid_cat_tensor = torch.from_numpy(x_valid_cat.astype(np.int64)).to(device)
+    x_valid_num_tensor = torch.from_numpy(x_valid_num.astype(np.float32)).to(device)
+    best_state: dict[str, torch.Tensor] | None = None
+    best_auc = -1.0
+    best_epoch = 1
+
+    for epoch in range(1, int(params.epochs) + 1):
+        model.train()
+        for batch_cat, batch_num, batch_target in loader:
+            batch_cat = batch_cat.to(device, non_blocking=device.type == "cuda")
+            batch_num = batch_num.to(device, non_blocking=device.type == "cuda")
+            batch_target = batch_target.to(device, non_blocking=device.type == "cuda")
+            optimizer.zero_grad(set_to_none=True)
+            logits = model(batch_cat, batch_num)
+            loss = criterion(logits, batch_target)
+            loss.backward()
+            optimizer.step()
+
+        model.eval()
+        with torch.no_grad():
+            valid_logits = model(x_valid_cat_tensor, x_valid_num_tensor)
+            valid_pred = torch.sigmoid(valid_logits).detach().cpu().numpy()
+        valid_auc = float(binary_auc(pd.Series(y_valid), pd.Series(valid_pred)))
+        if valid_auc > best_auc:
+            best_auc = valid_auc
+            best_epoch = int(epoch)
+            best_state = {key: value.detach().cpu().clone() for key, value in model.state_dict().items()}
+
+    if best_state is None:
+        raise RuntimeError("MLP probe did not produce a valid best_state.")
+    model.load_state_dict(best_state)
+    model.eval()
+    with torch.no_grad():
+        final_pred = torch.sigmoid(model(x_valid_cat_tensor, x_valid_num_tensor)).detach().cpu().numpy()
+    return final_pred.astype(np.float64), best_epoch
+
+
+def _fit_full_model(
+    *,
+    x_cat: np.ndarray,
+    x_num: np.ndarray,
+    y: np.ndarray,
+    cardinalities: Sequence[int],
+    params: MLPProbeParams,
+    final_epochs: int,
+    seed: int,
+    device: torch.device,
+) -> TabularEmbeddingMLP:
+    _set_torch_seed(seed)
+    model = TabularEmbeddingMLP(
+        cardinalities=cardinalities,
+        numeric_dim=x_num.shape[1],
+        hidden_dims=params.hidden_dims,
+        dropout=params.dropout,
+        max_embedding_dim=params.max_embedding_dim,
+    ).to(device)
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=float(params.learning_rate),
+        weight_decay=float(params.weight_decay),
+    )
+    criterion = nn.BCEWithLogitsLoss()
+    dataset = _build_dataset(x_cat, x_num, y)
+    loader = DataLoader(
+        dataset,
+        batch_size=int(params.batch_size),
+        shuffle=True,
+        num_workers=0,
+        pin_memory=device.type == "cuda",
+    )
+
+    for _ in range(int(final_epochs)):
+        model.train()
+        for batch_cat, batch_num, batch_target in loader:
+            batch_cat = batch_cat.to(device, non_blocking=device.type == "cuda")
+            batch_num = batch_num.to(device, non_blocking=device.type == "cuda")
+            batch_target = batch_target.to(device, non_blocking=device.type == "cuda")
+            optimizer.zero_grad(set_to_none=True)
+            logits = model(batch_cat, batch_num)
+            loss = criterion(logits, batch_target)
+            loss.backward()
+            optimizer.step()
+    return model.cpu()
+
+
+def run_mlp_probe_cv(
+    *,
+    train_csv_path: str | Path,
+    model_path: str | Path,
+    metrics_path: str | Path,
+    oof_path: str | Path,
+    feature_blocks: Sequence[str] | None,
+    folds: int,
+    random_state: int,
+    params: MLPProbeParams,
+    reference_pred: pd.Series | None = None,
+    alpha_grid: Sequence[float] | None = None,
+) -> dict[str, Any]:
+    """Train a shallow tabular MLP with categorical embeddings."""
+    if folds < 2:
+        raise ValueError("folds must be >= 2")
+
+    train_df = load_csv(train_csv_path)
+    normalized_blocks = normalize_feature_blocks(feature_blocks)
+    x, y = prepare_train_features(train_df, drop_id=True, feature_blocks=normalized_blocks)
+    categorical_columns = infer_categorical_columns(x)
+    numeric_columns = [column for column in x.columns if column not in categorical_columns]
+    splitter = StratifiedKFold(n_splits=folds, shuffle=True, random_state=random_state)
+    device = _resolve_device(params.device)
+
+    oof_pred = pd.Series(index=x.index, dtype="float64", name="oof_pred")
+    fold_rows: list[dict[str, Any]] = []
+    best_epochs: list[int] = []
+
+    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x, y), start=1):
+        x_train = x.iloc[train_idx]
+        y_train = y.iloc[train_idx]
+        x_valid = x.iloc[valid_idx]
+        y_valid = y.iloc[valid_idx]
+
+        mappings, cardinalities = _fit_category_maps(x_train, categorical_columns)
+        medians, means, stds = _fit_numeric_stats(x_train, numeric_columns)
+        x_train_cat = _encode_categorical(x_train, categorical_columns, mappings)
+        x_valid_cat = _encode_categorical(x_valid, categorical_columns, mappings)
+        x_train_num = _encode_numeric(x_train, numeric_columns, medians, means, stds)
+        x_valid_num = _encode_numeric(x_valid, numeric_columns, medians, means, stds)
+
+        fold_pred, best_epoch = _train_one_fold(
+            x_train_cat=x_train_cat,
+            x_train_num=x_train_num,
+            y_train=y_train.to_numpy(dtype=np.float32),
+            x_valid_cat=x_valid_cat,
+            x_valid_num=x_valid_num,
+            y_valid=y_valid.to_numpy(dtype=np.float32),
+            cardinalities=cardinalities,
+            params=params,
+            seed=random_state + fold_number,
+            device=device,
+        )
+        best_epochs.append(int(best_epoch))
+        fold_series = pd.Series(fold_pred, index=x_valid.index, dtype="float64")
+        oof_pred.iloc[valid_idx] = fold_series.values
+        fold_rows.append(
+            {
+                "fold": int(fold_number),
+                "valid_rows": int(len(valid_idx)),
+                "auc": float(binary_auc(y_valid, fold_series)),
+                "best_epoch": int(best_epoch),
+            }
+        )
+
+    if oof_pred.isna().any():
+        raise RuntimeError("OOF predictions contain missing values for MLP probe.")
+
+    final_epochs = max(int(round(float(np.mean(best_epochs)))), 1)
+    full_mappings, full_cardinalities = _fit_category_maps(x, categorical_columns)
+    full_medians, full_means, full_stds = _fit_numeric_stats(x, numeric_columns)
+    full_x_cat = _encode_categorical(x, categorical_columns, full_mappings)
+    full_x_num = _encode_numeric(x, numeric_columns, full_medians, full_means, full_stds)
+    full_model = _fit_full_model(
+        x_cat=full_x_cat,
+        x_num=full_x_num,
+        y=y.to_numpy(dtype=np.float32),
+        cardinalities=full_cardinalities,
+        params=params,
+        final_epochs=final_epochs,
+        seed=random_state,
+        device=device,
+    )
+    out_model_path = ensure_parent_dir(model_path)
+    torch.save(
+        {
+            "state_dict": full_model.state_dict(),
+            "categorical_columns": list(categorical_columns),
+            "numeric_columns": list(numeric_columns),
+            "category_mappings": full_mappings,
+            "cardinalities": list(full_cardinalities),
+            "medians": full_medians.to_dict(),
+            "means": full_means.to_dict(),
+            "stds": full_stds.to_dict(),
+            "params": {
+                "hidden_dims": list(params.hidden_dims),
+                "dropout": float(params.dropout),
+                "learning_rate": float(params.learning_rate),
+                "weight_decay": float(params.weight_decay),
+                "batch_size": int(params.batch_size),
+                "epochs": int(params.epochs),
+                "max_embedding_dim": int(params.max_embedding_dim),
+                "device": str(params.device),
+                "final_epochs": int(final_epochs),
+            },
+        },
+        out_model_path,
+    )
+
+    oof_output = pd.DataFrame(
+        {
+            ID_COLUMN: train_df[ID_COLUMN].values,
+            "target": y.astype(int).values,
+            "oof_pred": oof_pred.values,
+        }
+    )
+    out_oof_path = ensure_parent_dir(oof_path)
+    oof_output.to_csv(out_oof_path, index=False)
+
+    metrics: dict[str, Any] = {
+        "train_rows": int(len(train_df)),
+        "feature_count": int(x.shape[1]),
+        "feature_blocks": list(normalized_blocks),
+        "categorical_columns": list(categorical_columns),
+        "numeric_columns": list(numeric_columns),
+        "cv_folds": int(folds),
+        "cv_fold_metrics": fold_rows,
+        "cv_mean_auc": float(np.mean([row["auc"] for row in fold_rows])),
+        "cv_std_auc": float(np.std([row["auc"] for row in fold_rows])),
+        "oof_auc": float(binary_auc(y, oof_pred)),
+        "model_path": str(model_path),
+        "oof_path": str(oof_path),
+        "target_column": TARGET_COLUMN,
+        "id_column": ID_COLUMN,
+        "model_family": "tabular_embedding_mlp",
+        "params": {
+            "hidden_dims": list(params.hidden_dims),
+            "dropout": float(params.dropout),
+            "learning_rate": float(params.learning_rate),
+            "weight_decay": float(params.weight_decay),
+            "batch_size": int(params.batch_size),
+            "epochs": int(params.epochs),
+            "max_embedding_dim": int(params.max_embedding_dim),
+            "device": str(params.device),
+            "best_epochs": [int(epoch) for epoch in best_epochs],
+            "final_epochs": int(final_epochs),
+        },
+    }
+
+    if reference_pred is not None:
+        reference_by_id = pd.Series(reference_pred, copy=True)
+        aligned_reference = train_df[ID_COLUMN].map(reference_by_id)
+        if aligned_reference.isna().any():
+            missing_ids = train_df.loc[aligned_reference.isna(), ID_COLUMN].head(5).tolist()
+            raise ValueError(f"reference_pred missing ids from train: {missing_ids}")
+        aligned_reference = pd.Series(aligned_reference.values, index=x.index, dtype="float64")
+        metrics["reference_oof_auc"] = float(binary_auc(y, aligned_reference))
+        metrics["pearson_corr_vs_reference"] = float(aligned_reference.corr(oof_pred))
+        metrics["spearman_corr_vs_reference"] = float(aligned_reference.corr(oof_pred, method="spearman"))
+
+        if alpha_grid:
+            alpha_rows: list[dict[str, Any]] = []
+            for alpha in alpha_grid:
+                alpha_value = float(alpha)
+                candidate = (1.0 - alpha_value) * aligned_reference + alpha_value * oof_pred
+                alpha_rows.append(
+                    {
+                        "alpha": alpha_value,
+                        "oof_auc": float(binary_auc(y, candidate)),
+                    }
+                )
+            best_alpha_row = max(alpha_rows, key=lambda row: row["oof_auc"])
+            metrics["blend_scan"] = alpha_rows
+            metrics["best_blend_alpha"] = float(best_alpha_row["alpha"])
+            metrics["best_blend_oof_auc"] = float(best_alpha_row["oof_auc"])
+            metrics["delta_best_blend_vs_reference"] = float(
+                best_alpha_row["oof_auc"] - binary_auc(y, aligned_reference)
+            )
+
+    write_json(metrics_path, metrics)
+    return metrics

--- a/src/churn_baseline/modeling.py
+++ b/src/churn_baseline/modeling.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import pandas as pd
 from catboost import CatBoostClassifier, Pool
@@ -10,9 +10,36 @@ from catboost import CatBoostClassifier, Pool
 from .config import CatBoostHyperParams
 
 
-def build_model(params: CatBoostHyperParams) -> CatBoostClassifier:
+def _resolve_monotone_constraints(
+    params: CatBoostHyperParams,
+    feature_columns: pd.Index | None,
+) -> dict[int, int] | None:
+    constraints = params.monotone_constraints
+    if not constraints:
+        return None
+    if feature_columns is None:
+        raise ValueError("feature_columns are required to resolve monotone_constraints.")
+
+    missing_columns = [name for name in constraints if name not in feature_columns]
+    if missing_columns:
+        raise ValueError(
+            "Monotone constraints reference features not present in the training matrix: "
+            f"{missing_columns}"
+        )
+
+    return {int(feature_columns.get_loc(name)): int(direction) for name, direction in constraints.items()}
+
+
+def build_model(
+    params: CatBoostHyperParams,
+    *,
+    feature_columns: pd.Index | None = None,
+) -> CatBoostClassifier:
     """Create a CatBoost model from hyperparameters."""
-    return CatBoostClassifier(**params.to_catboost_kwargs())
+    kwargs = params.to_catboost_kwargs()
+    if params.monotone_constraints:
+        kwargs["monotone_constraints"] = _resolve_monotone_constraints(params, feature_columns)
+    return CatBoostClassifier(**kwargs)
 
 
 def fit_with_validation(
@@ -28,7 +55,7 @@ def fit_with_validation(
     sample_weight_valid: Sequence[float] | pd.Series | None = None,
 ) -> CatBoostClassifier:
     """Train CatBoost with validation and early stopping."""
-    model = build_model(params)
+    model = build_model(params, feature_columns=x_train.columns)
     eval_set: tuple[pd.DataFrame, pd.Series] | Pool
     if sample_weight_valid is None:
         eval_set = (x_valid, y_valid)
@@ -61,7 +88,7 @@ def fit_full_train(
     sample_weight: Sequence[float] | pd.Series | None = None,
 ) -> CatBoostClassifier:
     """Train CatBoost on the full train split without eval set."""
-    model = build_model(params)
+    model = build_model(params, feature_columns=x_train.columns)
     model.fit(
         x_train,
         y_train,

--- a/src/churn_baseline/modeling.py
+++ b/src/churn_baseline/modeling.py
@@ -1,10 +1,11 @@
 """Model training and inference helpers."""
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import List, Optional
 
 import pandas as pd
-from catboost import CatBoostClassifier
+from catboost import CatBoostClassifier, Pool
 
 from .config import CatBoostHyperParams
 
@@ -23,14 +24,27 @@ def fit_with_validation(
     params: CatBoostHyperParams,
     early_stopping_rounds: int,
     verbose: int,
+    sample_weight_train: Sequence[float] | pd.Series | None = None,
+    sample_weight_valid: Sequence[float] | pd.Series | None = None,
 ) -> CatBoostClassifier:
     """Train CatBoost with validation and early stopping."""
     model = build_model(params)
+    eval_set: tuple[pd.DataFrame, pd.Series] | Pool
+    if sample_weight_valid is None:
+        eval_set = (x_valid, y_valid)
+    else:
+        eval_set = Pool(
+            data=x_valid,
+            label=y_valid,
+            cat_features=cat_columns,
+            weight=sample_weight_valid,
+        )
     model.fit(
         x_train,
         y_train,
         cat_features=cat_columns,
-        eval_set=(x_valid, y_valid),
+        sample_weight=sample_weight_train,
+        eval_set=eval_set,
         use_best_model=True,
         early_stopping_rounds=early_stopping_rounds,
         verbose=verbose,
@@ -44,6 +58,7 @@ def fit_full_train(
     cat_columns: List[str],
     params: CatBoostHyperParams,
     verbose: int,
+    sample_weight: Sequence[float] | pd.Series | None = None,
 ) -> CatBoostClassifier:
     """Train CatBoost on the full train split without eval set."""
     model = build_model(params)
@@ -51,6 +66,7 @@ def fit_full_train(
         x_train,
         y_train,
         cat_features=cat_columns,
+        sample_weight=sample_weight,
         verbose=verbose,
     )
     return model

--- a/src/churn_baseline/ngram_xgb.py
+++ b/src/churn_baseline/ngram_xgb.py
@@ -1,0 +1,503 @@
+"""Bi-gram target-encoding XGBoost experiments."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from itertools import combinations
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+import xgboost as xgb
+from sklearn.model_selection import StratifiedKFold
+
+from .artifacts import ensure_parent_dir, write_json
+from .config import ID_COLUMN, TARGET_COLUMN
+from .data import encode_target, infer_categorical_columns, load_csv
+from .evaluation import binary_auc
+
+
+DEFAULT_NGRAM_BASE_COLUMNS: tuple[str, ...] = (
+    "Contract",
+    "InternetService",
+    "PaymentMethod",
+    "OnlineSecurity",
+    "TechSupport",
+    "PaperlessBilling",
+)
+
+
+@dataclass(frozen=True)
+class NgramXgbParams:
+    """Minimal XGBoost hyperparameters for the ngram+TE line."""
+
+    n_estimators: int = 1500
+    learning_rate: float = 0.03
+    max_depth: int = 4
+    min_child_weight: float = 4.0
+    subsample: float = 0.8
+    colsample_bytree: float = 0.6
+    reg_alpha: float = 1.0
+    reg_lambda: float = 4.0
+    gamma: float = 0.0
+    random_state: int = 42
+    n_jobs: int = -1
+    early_stopping_rounds: int = 100
+
+    def to_xgb_kwargs(self) -> dict[str, Any]:
+        """Return kwargs accepted by XGBClassifier."""
+        payload = asdict(self)
+        payload.update(
+            {
+                "objective": "binary:logistic",
+                "eval_metric": "auc",
+                "tree_method": "hist",
+                "verbosity": 0,
+            }
+        )
+        return payload
+
+
+def _clip_probability(values: np.ndarray, epsilon: float = 1e-6) -> np.ndarray:
+    return np.clip(values.astype("float64"), epsilon, 1.0 - epsilon)
+
+
+def _sanitize_total_charges(frame: pd.DataFrame, fallback_median: float | None = None) -> pd.DataFrame:
+    out = frame.copy()
+    if "TotalCharges" in out.columns:
+        out["TotalCharges"] = pd.to_numeric(out["TotalCharges"], errors="coerce")
+        median = float(out["TotalCharges"].median()) if fallback_median is None else float(fallback_median)
+        out["TotalCharges"] = out["TotalCharges"].fillna(median)
+    return out
+
+
+def _prepare_original_frame(original_df: pd.DataFrame, fallback_median: float) -> pd.DataFrame:
+    out = original_df.copy()
+    if "customerID" in out.columns and ID_COLUMN not in out.columns:
+        out = out.drop(columns=["customerID"])
+    if TARGET_COLUMN in out.columns:
+        out[TARGET_COLUMN] = encode_target(out[TARGET_COLUMN]).astype("int8")
+    out = _sanitize_total_charges(out, fallback_median=fallback_median)
+    return out
+
+
+def _drop_exact_original_overlaps(
+    original_df: pd.DataFrame,
+    *,
+    train_df: pd.DataFrame,
+    test_df: pd.DataFrame,
+) -> tuple[pd.DataFrame, int]:
+    common_columns = sorted(
+        (
+            set(original_df.columns)
+            & set(train_df.columns)
+            & set(test_df.columns)
+        )
+        - {ID_COLUMN, TARGET_COLUMN}
+    )
+    if not common_columns:
+        return original_df.copy(), 0
+
+    def _row_signature(frame: pd.DataFrame) -> pd.Series:
+        normalized = frame.loc[:, common_columns].copy()
+        for column in common_columns:
+            normalized[column] = normalized[column].fillna("__nan__").astype(str)
+        return pd.util.hash_pandas_object(normalized, index=False)
+
+    competition_signatures = pd.concat(
+        [_row_signature(train_df), _row_signature(test_df)],
+        axis=0,
+        ignore_index=True,
+    )
+    overlap_mask = _row_signature(original_df).isin(set(competition_signatures.tolist()))
+    filtered = original_df.loc[~overlap_mask].reset_index(drop=True)
+    return filtered, int(overlap_mask.sum())
+
+
+def _normalize_categorical_string(frame: pd.DataFrame, columns: Sequence[str]) -> pd.DataFrame:
+    out = frame.copy()
+    for column in columns:
+        if column not in out.columns:
+            continue
+        values = out[column]
+        if pd.api.types.is_categorical_dtype(values):
+            values = values.astype("object")
+        out[column] = values.fillna("__nan__").astype(str)
+    return out
+
+
+def _build_ngram_feature_names(
+    base_columns: Sequence[str],
+    *,
+    include_trigrams: bool,
+) -> list[tuple[str, tuple[str, ...]]]:
+    ngrams: list[tuple[str, tuple[str, ...]]] = []
+    for cols in combinations(base_columns, 2):
+        ngrams.append((f"BG_{'_'.join(cols)}", tuple(cols)))
+    if include_trigrams:
+        tri_base = list(base_columns)[:4]
+        for cols in combinations(tri_base, 3):
+            ngrams.append((f"TG_{'_'.join(cols)}", tuple(cols)))
+    return ngrams
+
+
+def _append_ngram_columns(frame: pd.DataFrame, specs: Sequence[tuple[str, tuple[str, ...]]]) -> pd.DataFrame:
+    out = frame.copy()
+    for name, parts in specs:
+        values = out.loc[:, list(parts)].astype(str)
+        out[name] = values.agg("__".join, axis=1)
+    return out
+
+
+def _resolve_te_columns(
+    train_df: pd.DataFrame,
+    *,
+    ngram_base_columns: Sequence[str] | None = None,
+    include_trigrams: bool = False,
+) -> tuple[list[str], list[str], list[tuple[str, tuple[str, ...]]]]:
+    categorical_columns = infer_categorical_columns(train_df.drop(columns=[TARGET_COLUMN], errors="ignore"))
+    numeric_columns = [
+        column
+        for column in train_df.columns
+        if column not in {ID_COLUMN, TARGET_COLUMN} and pd.api.types.is_numeric_dtype(train_df[column])
+    ]
+    ngram_base = [column for column in (ngram_base_columns or DEFAULT_NGRAM_BASE_COLUMNS) if column in categorical_columns]
+    ngram_specs = _build_ngram_feature_names(ngram_base, include_trigrams=include_trigrams)
+    return numeric_columns, categorical_columns, ngram_specs
+
+
+def _smoothed_mean_map(
+    values: pd.Series,
+    target: pd.Series,
+    *,
+    smoothing_alpha: float,
+) -> tuple[pd.Series, pd.Series, float]:
+    fit_frame = pd.DataFrame({"value": values.astype(str), "target": target.astype("float64")})
+    grouped = fit_frame.groupby("value", observed=False)["target"].agg(["mean", "count"])
+    prior = float(fit_frame["target"].mean())
+    smooth = (grouped["mean"] * grouped["count"] + prior * float(smoothing_alpha)) / (
+        grouped["count"] + float(smoothing_alpha)
+    )
+    count_log = np.log1p(grouped["count"].astype("float64"))
+    return smooth.astype("float64"), count_log.astype("float64"), prior
+
+
+def _concat_fit_inputs(
+    train_values: pd.Series,
+    y_train: pd.Series,
+    original_values: pd.Series | None,
+    original_target: pd.Series | None,
+) -> tuple[pd.Series, pd.Series]:
+    if original_values is None or original_target is None or len(original_values) == 0:
+        return train_values.reset_index(drop=True), y_train.reset_index(drop=True)
+    fit_values = pd.concat([train_values.reset_index(drop=True), original_values.reset_index(drop=True)], axis=0)
+    fit_target = pd.concat([y_train.reset_index(drop=True), original_target.reset_index(drop=True)], axis=0)
+    return fit_values, fit_target
+
+
+def _encode_target_features(
+    train_frame: pd.DataFrame,
+    y_train: pd.Series,
+    valid_frame: pd.DataFrame,
+    test_frame: pd.DataFrame,
+    *,
+    te_columns: Sequence[str],
+    inner_folds: int,
+    random_state: int,
+    smoothing_alpha: float,
+    original_frame: pd.DataFrame | None = None,
+    original_target: pd.Series | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    train_encoded = pd.DataFrame(index=train_frame.index)
+    valid_encoded = pd.DataFrame(index=valid_frame.index)
+    test_encoded = pd.DataFrame(index=test_frame.index)
+
+    inner_splitter = StratifiedKFold(
+        n_splits=int(inner_folds),
+        shuffle=True,
+        random_state=int(random_state),
+    )
+
+    for column in te_columns:
+        oof_mean = np.full(len(train_frame), float(y_train.mean()), dtype="float64")
+        oof_count = np.zeros(len(train_frame), dtype="float64")
+
+        original_values = None
+        if original_frame is not None and column in original_frame.columns:
+            original_values = original_frame[column].astype(str)
+
+        for fit_idx, hold_idx in inner_splitter.split(np.zeros(len(train_frame)), y_train.to_numpy(dtype="int8")):
+            fit_values, fit_target = _concat_fit_inputs(
+                train_frame.iloc[fit_idx][column].astype(str),
+                y_train.iloc[fit_idx],
+                original_values,
+                original_target,
+            )
+            smooth_map, count_map, prior = _smoothed_mean_map(
+                fit_values,
+                fit_target,
+                smoothing_alpha=smoothing_alpha,
+            )
+            hold_values = train_frame.iloc[hold_idx][column].astype(str)
+            oof_mean[hold_idx] = hold_values.map(smooth_map).fillna(prior).to_numpy(dtype="float64")
+            oof_count[hold_idx] = hold_values.map(count_map).fillna(0.0).to_numpy(dtype="float64")
+
+        full_fit_values, full_fit_target = _concat_fit_inputs(
+            train_frame[column].astype(str),
+            y_train,
+            original_values,
+            original_target,
+        )
+        full_smooth_map, full_count_map, full_prior = _smoothed_mean_map(
+            full_fit_values,
+            full_fit_target,
+            smoothing_alpha=smoothing_alpha,
+        )
+
+        mean_name = f"TE_{column}"
+        count_name = f"TE_COUNT_{column}"
+
+        train_encoded[mean_name] = oof_mean.astype("float32")
+        train_encoded[count_name] = oof_count.astype("float32")
+        valid_encoded[mean_name] = (
+            valid_frame[column].astype(str).map(full_smooth_map).fillna(full_prior).astype("float32")
+        )
+        valid_encoded[count_name] = (
+            valid_frame[column].astype(str).map(full_count_map).fillna(0.0).astype("float32")
+        )
+        test_encoded[mean_name] = (
+            test_frame[column].astype(str).map(full_smooth_map).fillna(full_prior).astype("float32")
+        )
+        test_encoded[count_name] = (
+            test_frame[column].astype(str).map(full_count_map).fillna(0.0).astype("float32")
+        )
+
+    return train_encoded, valid_encoded, test_encoded
+
+
+def _compute_numeric_fill_values(
+    source_frame: pd.DataFrame,
+    *,
+    numeric_columns: Sequence[str],
+) -> pd.Series:
+    if not numeric_columns:
+        return pd.Series(dtype="float32")
+    numeric_frame = source_frame.loc[:, list(numeric_columns)].apply(pd.to_numeric, errors="coerce")
+    return numeric_frame.median(numeric_only=True).astype("float32")
+
+
+def _finalize_model_matrix(
+    source_frame: pd.DataFrame,
+    encoded_frame: pd.DataFrame,
+    *,
+    numeric_columns: Sequence[str],
+    numeric_fill_values: pd.Series,
+) -> pd.DataFrame:
+    numeric_frame = source_frame.loc[:, list(numeric_columns)].apply(pd.to_numeric, errors="coerce")
+    if not numeric_frame.empty:
+        numeric_frame = numeric_frame.fillna(numeric_fill_values).astype("float32")
+    return pd.concat([numeric_frame.reset_index(drop=True), encoded_frame.reset_index(drop=True)], axis=1)
+
+
+def _train_fold_model(
+    x_train: pd.DataFrame,
+    y_train: pd.Series,
+    x_valid: pd.DataFrame,
+    y_valid: pd.Series,
+    *,
+    params: NgramXgbParams,
+    verbose_eval: int | bool,
+) -> xgb.XGBClassifier:
+    model = xgb.XGBClassifier(**params.to_xgb_kwargs())
+    model.fit(
+        x_train,
+        y_train,
+        eval_set=[(x_valid, y_valid)],
+        verbose=verbose_eval,
+    )
+    return model
+
+
+def train_ngram_xgb_cv(
+    *,
+    train_csv_path: str | Path,
+    test_csv_path: str | Path,
+    metrics_path: str | Path,
+    oof_path: str | Path,
+    test_pred_path: str | Path | None = None,
+    original_csv_path: str | Path | None = None,
+    params: NgramXgbParams | None = None,
+    folds: int = 2,
+    inner_folds: int = 3,
+    random_state: int = 42,
+    smoothing_alpha: float = 20.0,
+    include_trigrams: bool = False,
+    ngram_base_columns: Sequence[str] | None = None,
+    verbose_eval: int | bool = False,
+) -> dict[str, Any]:
+    """Train the minimal ngram+TE XGBoost line with outer CV."""
+    params = params or NgramXgbParams(random_state=random_state)
+    train_df = load_csv(train_csv_path)
+    test_df = load_csv(test_csv_path)
+    train_df = _sanitize_total_charges(train_df)
+    test_df = _sanitize_total_charges(test_df, fallback_median=float(train_df["TotalCharges"].median()))
+    y = encode_target(train_df[TARGET_COLUMN]).astype("int8")
+
+    original_df: pd.DataFrame | None = None
+    original_target: pd.Series | None = None
+    if original_csv_path:
+        original_raw = load_csv(original_csv_path)
+        original_df = _prepare_original_frame(original_raw, fallback_median=float(train_df["TotalCharges"].median()))
+        if TARGET_COLUMN not in original_df.columns:
+            raise ValueError(f"Original dataset at {original_csv_path} must contain '{TARGET_COLUMN}'.")
+        original_df, original_overlap_rows_removed = _drop_exact_original_overlaps(
+            original_df,
+            train_df=train_df,
+            test_df=test_df,
+        )
+        original_target = original_df[TARGET_COLUMN].astype("int8")
+    else:
+        original_overlap_rows_removed = 0
+
+    numeric_columns, categorical_columns, ngram_specs = _resolve_te_columns(
+        train_df,
+        ngram_base_columns=ngram_base_columns,
+        include_trigrams=include_trigrams,
+    )
+
+    train_source = train_df.drop(columns=[TARGET_COLUMN]).copy()
+    test_source = test_df.copy()
+    original_source = None
+    if original_df is not None:
+        original_source = original_df.drop(columns=[TARGET_COLUMN], errors="ignore").copy()
+
+    frames_to_augment = [train_source, test_source]
+    if original_source is not None:
+        frames_to_augment.append(original_source)
+    frames_to_augment = [_normalize_categorical_string(frame, categorical_columns) for frame in frames_to_augment]
+    frames_to_augment = [_append_ngram_columns(frame, ngram_specs) for frame in frames_to_augment]
+    train_source, test_source, *rest = frames_to_augment
+    if rest:
+        original_source = rest[0]
+
+    te_columns = list(categorical_columns) + [name for name, _ in ngram_specs]
+
+    splitter = StratifiedKFold(n_splits=int(folds), shuffle=True, random_state=int(random_state))
+    oof_pred = np.zeros(len(train_df), dtype="float64")
+    fold_aucs: list[float] = []
+    fold_best_iterations: list[int] = []
+    test_pred = np.zeros(len(test_df), dtype="float64")
+
+    for fold_idx, (fit_idx, valid_idx) in enumerate(splitter.split(np.zeros(len(train_df)), y.to_numpy(dtype="int8")), start=1):
+        fit_source = train_source.iloc[fit_idx].reset_index(drop=True)
+        valid_source = train_source.iloc[valid_idx].reset_index(drop=True)
+        y_fit = y.iloc[fit_idx].reset_index(drop=True)
+        y_valid = y.iloc[valid_idx].reset_index(drop=True)
+        numeric_fill_values = _compute_numeric_fill_values(fit_source, numeric_columns=numeric_columns)
+
+        fit_encoded, valid_encoded, test_encoded = _encode_target_features(
+            fit_source,
+            y_fit,
+            valid_source,
+            test_source.reset_index(drop=True),
+            te_columns=te_columns,
+            inner_folds=inner_folds,
+            random_state=int(random_state) + fold_idx,
+            smoothing_alpha=smoothing_alpha,
+            original_frame=original_source,
+            original_target=original_target,
+        )
+
+        x_fit = _finalize_model_matrix(
+            fit_source,
+            fit_encoded,
+            numeric_columns=numeric_columns,
+            numeric_fill_values=numeric_fill_values,
+        )
+        x_valid = _finalize_model_matrix(
+            valid_source,
+            valid_encoded,
+            numeric_columns=numeric_columns,
+            numeric_fill_values=numeric_fill_values,
+        )
+        x_test = _finalize_model_matrix(
+            test_source.reset_index(drop=True),
+            test_encoded,
+            numeric_columns=numeric_columns,
+            numeric_fill_values=numeric_fill_values,
+        )
+
+        model = _train_fold_model(
+            x_fit,
+            y_fit,
+            x_valid,
+            y_valid,
+            params=params,
+            verbose_eval=verbose_eval,
+        )
+        valid_pred = _clip_probability(model.predict_proba(x_valid)[:, 1])
+        test_fold_pred = _clip_probability(model.predict_proba(x_test)[:, 1])
+
+        oof_pred[valid_idx] = valid_pred
+        test_pred += test_fold_pred / float(folds)
+        fold_auc = float(binary_auc(y_valid, valid_pred))
+        fold_aucs.append(fold_auc)
+        best_iter = getattr(model, "best_iteration", None)
+        fold_best_iterations.append(int(best_iter) if best_iter is not None else int(params.n_estimators))
+
+    oof_auc = float(binary_auc(y, oof_pred))
+    metrics = {
+        "experiment_name": "ngram_te_xgb",
+        "model_family": "xgboost",
+        "train_csv_path": str(train_csv_path),
+        "test_csv_path": str(test_csv_path),
+        "original_csv_path": str(original_csv_path) if original_csv_path else None,
+        "used_original": bool(original_source is not None),
+        "train_rows": int(len(train_df)),
+        "test_rows": int(len(test_df)),
+        "original_rows": int(len(original_source)) if original_source is not None else 0,
+        "original_overlap_rows_removed": int(original_overlap_rows_removed),
+        "folds": int(folds),
+        "inner_folds": int(inner_folds),
+        "random_state": int(random_state),
+        "smoothing_alpha": float(smoothing_alpha),
+        "include_trigrams": bool(include_trigrams),
+        "numeric_columns": list(numeric_columns),
+        "categorical_columns": list(categorical_columns),
+        "ngram_base_columns": [column for column in (ngram_base_columns or DEFAULT_NGRAM_BASE_COLUMNS) if column in categorical_columns],
+        "ngram_columns": [name for name, _ in ngram_specs],
+        "te_columns": list(te_columns),
+        "oof_auc": oof_auc,
+        "cv_mean_auc": float(np.mean(fold_aucs)),
+        "cv_std_auc": float(np.std(fold_aucs, ddof=0)),
+        "fold_aucs": [float(value) for value in fold_aucs],
+        "fold_best_iterations": [int(value) for value in fold_best_iterations],
+        "params": params.to_xgb_kwargs(),
+        "oof_path": str(oof_path),
+        "metrics_path": str(metrics_path),
+    }
+    if test_pred_path:
+        metrics["test_pred_path"] = str(test_pred_path)
+
+    oof_frame = pd.DataFrame(
+        {
+            ID_COLUMN: train_df[ID_COLUMN].astype("int64"),
+            "target": y.astype("int8"),
+            "oof_pred": _clip_probability(oof_pred),
+        }
+    )
+    oof_out = ensure_parent_dir(oof_path)
+    oof_frame.to_csv(oof_out, index=False)
+
+    if test_pred_path:
+        test_out = ensure_parent_dir(test_pred_path)
+        pd.DataFrame(
+            {
+                ID_COLUMN: test_df[ID_COLUMN].astype("int64"),
+                TARGET_COLUMN: _clip_probability(test_pred),
+            }
+        ).to_csv(test_out, index=False)
+
+    write_json(metrics_path, metrics)
+    return metrics

--- a/src/churn_baseline/noise_audit.py
+++ b/src/churn_baseline/noise_audit.py
@@ -1,0 +1,605 @@
+"""Data-centric audit for label noise, near-duplicates, and hard examples."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+
+from .artifacts import ensure_parent_dir, write_json
+from .config import ID_COLUMN, TARGET_COLUMN
+from .data import encode_target, load_csv
+from .diagnostics import (
+    DEFAULT_REFERENCE_OOF_SPECS,
+    OOF_TARGET_COLUMN,
+    build_family_frame,
+    load_merged_oof_matrix,
+    load_reference_prediction_frame,
+    parse_oof_input_spec,
+    utc_now_iso,
+)
+from .evaluation import binary_auc
+
+
+DOMINANT_MACROFAMILY = "Electronic check__Month-to-month__Fiber optic"
+DEFAULT_V3_OOF_SPEC = "artifacts/reports/validation_protocol_v3_chain_oof.csv#candidate_pred"
+
+
+def _normalize_text_series(series: pd.Series) -> pd.Series:
+    return (
+        series.fillna("__missing__")
+        .astype(str)
+        .str.strip()
+        .str.lower()
+        .str.replace(r"\s+", " ", regex=True)
+    )
+
+
+def _normalize_numeric_series(series: pd.Series, *, decimals: int = 6) -> pd.Series:
+    numeric = pd.to_numeric(series, errors="coerce")
+    rounded = numeric.round(decimals)
+    return rounded.fillna(-999999.0)
+
+
+def _hash_signature_frame(frame: pd.DataFrame) -> pd.Series:
+    hashed = pd.util.hash_pandas_object(frame, index=False).astype("uint64").astype(str)
+    return pd.Series(hashed.to_numpy(), index=frame.index, dtype="string")
+
+
+def _build_exact_signature_frame(train_df: pd.DataFrame) -> pd.DataFrame:
+    feature_cols = [col for col in train_df.columns if col not in {ID_COLUMN, TARGET_COLUMN}]
+    normalized: dict[str, pd.Series] = {}
+    for column in feature_cols:
+        series = train_df[column]
+        if pd.api.types.is_numeric_dtype(series):
+            normalized[column] = _normalize_numeric_series(series)
+        else:
+            normalized[column] = _normalize_text_series(series)
+    return pd.DataFrame(normalized, index=train_df.index)
+
+
+def _build_coarse_signature_frame(train_df: pd.DataFrame, family_frame: pd.DataFrame) -> pd.DataFrame:
+    coarse = pd.DataFrame(index=train_df.index)
+    category_candidates = (
+        "gender",
+        "SeniorCitizen",
+        "Partner",
+        "Dependents",
+        "PhoneService",
+        "MultipleLines",
+        "InternetService",
+        "OnlineSecurity",
+        "OnlineBackup",
+        "DeviceProtection",
+        "TechSupport",
+        "StreamingTV",
+        "StreamingMovies",
+        "Contract",
+        "PaperlessBilling",
+        "PaymentMethod",
+    )
+    for column in category_candidates:
+        if column in train_df.columns:
+            coarse[column] = _normalize_text_series(train_df[column])
+
+    if "tenure" in train_df.columns:
+        tenure = pd.to_numeric(train_df["tenure"], errors="coerce").fillna(-1).astype("int64")
+        coarse["tenure_exact"] = tenure.astype(str)
+        coarse["tenure_bucket"] = family_frame["tenure_bin"].astype(str).values
+
+    if "MonthlyCharges" in train_df.columns:
+        monthly = pd.to_numeric(train_df["MonthlyCharges"], errors="coerce").fillna(-999999.0)
+        coarse["monthly_charge_bucket"] = (np.round(monthly / 1.0) * 1.0).round(2)
+
+    if "TotalCharges" in train_df.columns:
+        total = pd.to_numeric(train_df["TotalCharges"], errors="coerce").fillna(-999999.0)
+        coarse["total_charge_bucket"] = (np.round(total / 10.0) * 10.0).round(2)
+    return coarse
+
+
+def _summarize_duplicate_groups(
+    row_frame: pd.DataFrame,
+    *,
+    signature_kind: str,
+    signature_column: str,
+) -> pd.DataFrame:
+    grouped = row_frame.groupby(signature_column, dropna=False)
+    rows: list[dict[str, Any]] = []
+    for signature_value, part in grouped:
+        if len(part) < 2:
+            continue
+        labels = sorted(part[OOF_TARGET_COLUMN].astype(int).unique().tolist())
+        inconsistent = len(labels) > 1
+        sample_ids = part[ID_COLUMN].head(5).astype(int).tolist()
+        rows.append(
+            {
+                "signature_kind": signature_kind,
+                "signature": str(signature_value),
+                "group_size": int(len(part)),
+                "label_unique_count": int(len(labels)),
+                "labels": labels,
+                "positive_rate": float(part[OOF_TARGET_COLUMN].mean()),
+                "inconsistent_labels": bool(inconsistent),
+                "segment3_mode": str(part["segment3"].mode(dropna=False).iloc[0]),
+                "segment5_mode": str(part["segment5"].mode(dropna=False).iloc[0]),
+                "sample_ids": sample_ids,
+            }
+        )
+    if not rows:
+        return pd.DataFrame(
+            columns=[
+                "signature_kind",
+                "signature",
+                "group_size",
+                "label_unique_count",
+                "labels",
+                "positive_rate",
+                "inconsistent_labels",
+                "segment3_mode",
+                "segment5_mode",
+                "sample_ids",
+            ]
+        )
+    return pd.DataFrame(rows).sort_values(
+        by=["inconsistent_labels", "group_size"],
+        ascending=[False, False],
+    ).reset_index(drop=True)
+
+
+def _merge_duplicate_flags(
+    analysis: pd.DataFrame,
+    groups: pd.DataFrame,
+    *,
+    signature_kind: str,
+    signature_column: str,
+) -> pd.DataFrame:
+    if groups.empty:
+        analysis[f"{signature_kind}_group_size"] = 1
+        analysis[f"{signature_kind}_inconsistent"] = False
+        return analysis
+
+    lookup = groups[[ "signature", "group_size", "inconsistent_labels"]].rename(
+        columns={
+            "signature": signature_column,
+            "group_size": f"{signature_kind}_group_size",
+            "inconsistent_labels": f"{signature_kind}_inconsistent",
+        }
+    )
+    out = analysis.merge(lookup, how="left", on=signature_column, validate="many_to_one")
+    out[f"{signature_kind}_group_size"] = out[f"{signature_kind}_group_size"].fillna(1).astype(int)
+    out[f"{signature_kind}_inconsistent"] = (
+        out[f"{signature_kind}_inconsistent"].astype("boolean").fillna(False).astype(bool)
+    )
+    return out
+
+
+def _load_teacher_components(
+    *,
+    oof_specs: Sequence[str] | None,
+) -> tuple[pd.DataFrame | None, dict[str, Any]]:
+    specs_raw = list(oof_specs or DEFAULT_REFERENCE_OOF_SPECS)
+    specs = [parse_oof_input_spec(raw) for raw in specs_raw]
+    merged, model_columns = load_merged_oof_matrix(specs, id_column=ID_COLUMN, target_column=OOF_TARGET_COLUMN)
+    merged = merged.rename(columns={column: column.replace("pred_", "teacher_") for column in model_columns})
+    teacher_cols = [column for column in merged.columns if column.startswith("teacher_")]
+    if not teacher_cols:
+        raise ValueError("Teacher OOF specs produced zero usable prediction columns.")
+    info = {
+        "available": True,
+        "oof_specs": specs_raw,
+        "teacher_columns": teacher_cols,
+    }
+    return merged[[ID_COLUMN, OOF_TARGET_COLUMN, *teacher_cols]], info
+
+
+def _build_primary_reason(analysis: pd.DataFrame) -> pd.Series:
+    reasons = np.full(len(analysis), "", dtype=object)
+    near_mask = analysis["near_duplicate_conflict"].to_numpy(dtype=bool)
+    noise_mask = analysis["label_noise_candidate"].to_numpy(dtype=bool)
+    hard_mask = analysis["hard_example_stable"].to_numpy(dtype=bool)
+    reasons[hard_mask] = "hard_example_stable"
+    reasons[noise_mask] = "label_noise_candidate"
+    reasons[near_mask] = "near_duplicate_conflict"
+    return pd.Series(reasons, index=analysis.index, dtype="string")
+
+
+def _top_family_table(
+    analysis: pd.DataFrame,
+    *,
+    family_column: str,
+    mask_column: str,
+    top_n: int,
+) -> list[dict[str, Any]]:
+    work = analysis.groupby(family_column, dropna=False).agg(
+        rows=(ID_COLUMN, "size"),
+        suspicious_rows=(mask_column, "sum"),
+        mean_logloss=("logloss", "mean"),
+        mean_abs_error=("abs_error", "mean"),
+    )
+    work["suspicious_rate"] = work["suspicious_rows"] / work["rows"].clip(lower=1)
+    work = work.sort_values(by=["suspicious_rows", "suspicious_rate"], ascending=[False, False]).head(int(top_n))
+    return [
+        {
+            "family_value": str(idx),
+            "rows": int(row["rows"]),
+            "suspicious_rows": int(row["suspicious_rows"]),
+            "suspicious_rate": float(row["suspicious_rate"]),
+            "mean_logloss": float(row["mean_logloss"]),
+            "mean_abs_error": float(row["mean_abs_error"]),
+        }
+        for idx, row in work.iterrows()
+    ]
+
+
+def _fingerprint(paths: Sequence[str]) -> str:
+    digest = hashlib.sha256()
+    for path in paths:
+        digest.update(str(path).encode("utf-8"))
+    return digest.hexdigest()[:12]
+
+
+def run_label_noise_audit(
+    *,
+    train_csv_path: str | Path,
+    v3_oof_spec: str = DEFAULT_V3_OOF_SPEC,
+    teacher_oof_specs: Sequence[str] | None = None,
+    high_confidence_upper: float = 0.90,
+    high_confidence_lower: float = 0.10,
+    hard_loss_quantile: float = 0.995,
+    low_disagreement_quantile: float = 0.35,
+    high_disagreement_quantile: float = 0.75,
+    max_near_duplicate_group_size: int = 5,
+    top_n_families: int = 15,
+    out_json_path: str | Path | None = None,
+    out_rows_csv_path: str | Path | None = None,
+    out_duplicate_csv_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Run a diagnostic-only audit for label noise and near-duplicates."""
+    if not (0.5 < high_confidence_upper < 1.0):
+        raise ValueError("high_confidence_upper must be in (0.5, 1.0)")
+    if not (0.0 < high_confidence_lower < 0.5):
+        raise ValueError("high_confidence_lower must be in (0.0, 0.5)")
+    if high_confidence_lower >= high_confidence_upper:
+        raise ValueError("high_confidence_lower must be less than high_confidence_upper")
+    if not (0.0 < hard_loss_quantile < 1.0):
+        raise ValueError("hard_loss_quantile must be in (0, 1)")
+    if not (0.0 < low_disagreement_quantile < 1.0):
+        raise ValueError("low_disagreement_quantile must be in (0, 1)")
+    if not (0.0 < high_disagreement_quantile < 1.0):
+        raise ValueError("high_disagreement_quantile must be in (0, 1)")
+    if int(max_near_duplicate_group_size) < 2:
+        raise ValueError("max_near_duplicate_group_size must be >= 2")
+
+    train_df = load_csv(train_csv_path)
+    family_frame = build_family_frame(train_df)
+    reference_frame, reference_source = load_reference_prediction_frame(
+        reference_oof_spec=v3_oof_spec,
+        id_column=ID_COLUMN,
+        target_column=OOF_TARGET_COLUMN,
+    )
+
+    analysis = train_df[[ID_COLUMN, TARGET_COLUMN]].copy()
+    analysis = analysis.merge(
+        reference_frame[[ID_COLUMN, OOF_TARGET_COLUMN, "reference_pred"]],
+        how="inner",
+        on=ID_COLUMN,
+        validate="one_to_one",
+    )
+    analysis = analysis.merge(
+        family_frame[[ID_COLUMN, "segment3", "segment5", "tenure_bin"]],
+        how="inner",
+        on=ID_COLUMN,
+        validate="one_to_one",
+    )
+    if len(analysis) != len(train_df):
+        raise ValueError("v3 OOF coverage does not match train.csv rows.")
+
+    y_true = encode_target(analysis[TARGET_COLUMN]).astype("int8")
+    oof_target = analysis[OOF_TARGET_COLUMN].astype("int8")
+    if not np.array_equal(y_true.to_numpy(), oof_target.to_numpy()):
+        raise ValueError("v3 OOF target does not align with train.csv labels.")
+
+    analysis = analysis.drop(columns=[TARGET_COLUMN, OOF_TARGET_COLUMN]).rename(columns={"reference_pred": "v3_pred"})
+    analysis[OOF_TARGET_COLUMN] = y_true.values
+    pred = analysis["v3_pred"].astype("float64").clip(1e-6, 1.0 - 1e-6)
+    analysis["abs_error"] = np.abs(analysis[OOF_TARGET_COLUMN].astype("float64") - pred)
+    analysis["logloss"] = -(
+        analysis[OOF_TARGET_COLUMN].astype("float64") * np.log(pred)
+        + (1.0 - analysis[OOF_TARGET_COLUMN].astype("float64")) * np.log(1.0 - pred)
+    )
+    analysis["prediction_margin"] = np.abs(pred - 0.5)
+    analysis["high_confidence_wrong"] = (
+        ((analysis[OOF_TARGET_COLUMN] == 0) & pred.ge(float(high_confidence_upper)))
+        | ((analysis[OOF_TARGET_COLUMN] == 1) & pred.le(float(high_confidence_lower)))
+    )
+
+    teacher_info: dict[str, Any] = {"available": False}
+    try:
+        teacher_frame, teacher_info = _load_teacher_components(oof_specs=teacher_oof_specs)
+    except Exception as exc:  # pragma: no cover - diagnostic fallback
+        teacher_frame = None
+        teacher_info = {"available": False, "error": str(exc)}
+
+    if teacher_frame is not None:
+        teacher_feature_cols = [column for column in teacher_frame.columns if column.startswith("teacher_")]
+        teacher_frame = teacher_frame.rename(columns={OOF_TARGET_COLUMN: "teacher_target"}).copy()
+        analysis = analysis.merge(teacher_frame, how="left", on=ID_COLUMN, validate="one_to_one")
+        if len(analysis) != len(train_df):
+            raise ValueError("Teacher OOF merge changed row coverage unexpectedly.")
+        if analysis["teacher_target"].isna().any():
+            missing = int(analysis["teacher_target"].isna().sum())
+            raise ValueError(f"Teacher OOF coverage is incomplete: {missing} rows missing.")
+        if not np.array_equal(
+            analysis["teacher_target"].astype("int8").to_numpy(),
+            analysis[OOF_TARGET_COLUMN].astype("int8").to_numpy(),
+        ):
+            raise ValueError("Teacher OOF target does not align with train.csv labels.")
+        analysis = analysis.drop(columns=["teacher_target"])
+        teacher_matrix = analysis[teacher_feature_cols].to_numpy(dtype="float64")
+        analysis["teacher_mean"] = teacher_matrix.mean(axis=1)
+        analysis["teacher_std"] = teacher_matrix.std(axis=1)
+        analysis["teacher_range"] = teacher_matrix.max(axis=1) - teacher_matrix.min(axis=1)
+        analysis["teacher_unanimous_side"] = (
+            np.all(teacher_matrix >= 0.5, axis=1) | np.all(teacher_matrix < 0.5, axis=1)
+        )
+        low_std_threshold = float(analysis["teacher_std"].quantile(float(low_disagreement_quantile)))
+        high_std_threshold = float(analysis["teacher_std"].quantile(float(high_disagreement_quantile)))
+    else:
+        analysis["teacher_mean"] = np.nan
+        analysis["teacher_std"] = np.nan
+        analysis["teacher_range"] = np.nan
+        analysis["teacher_unanimous_side"] = False
+        low_std_threshold = float("nan")
+        high_std_threshold = float("nan")
+
+    exact_signature_frame = _build_exact_signature_frame(train_df)
+    coarse_signature_frame = _build_coarse_signature_frame(train_df, family_frame)
+    analysis["exact_signature"] = _hash_signature_frame(exact_signature_frame)
+    analysis["coarse_signature"] = _hash_signature_frame(coarse_signature_frame)
+
+    exact_groups = _summarize_duplicate_groups(analysis, signature_kind="exact", signature_column="exact_signature")
+    coarse_groups = _summarize_duplicate_groups(analysis, signature_kind="coarse", signature_column="coarse_signature")
+
+    analysis = _merge_duplicate_flags(
+        analysis,
+        exact_groups,
+        signature_kind="exact",
+        signature_column="exact_signature",
+    )
+    analysis = _merge_duplicate_flags(
+        analysis,
+        coarse_groups,
+        signature_kind="coarse",
+        signature_column="coarse_signature",
+    )
+    analysis["near_duplicate_conflict"] = analysis["exact_inconsistent"] | (
+        analysis["coarse_inconsistent"] & analysis["coarse_group_size"].le(int(max_near_duplicate_group_size))
+    )
+
+    if teacher_frame is not None:
+        analysis["label_noise_candidate"] = (
+            analysis["high_confidence_wrong"]
+            & analysis["teacher_unanimous_side"]
+            & analysis["teacher_std"].le(low_std_threshold)
+        )
+        instability_proxy = analysis["teacher_std"].ge(high_std_threshold) | analysis["prediction_margin"].le(0.15)
+    else:
+        analysis["label_noise_candidate"] = analysis["high_confidence_wrong"]
+        instability_proxy = analysis["prediction_margin"].le(0.15)
+
+    hard_loss_threshold = float(analysis["logloss"].quantile(float(hard_loss_quantile)))
+    analysis["hard_example_stable"] = (
+        analysis["logloss"].ge(hard_loss_threshold)
+        & ~analysis["label_noise_candidate"]
+        & ~analysis["near_duplicate_conflict"]
+        & instability_proxy
+    )
+
+    analysis["suspicious_any"] = (
+        analysis["label_noise_candidate"]
+        | analysis["near_duplicate_conflict"]
+        | analysis["hard_example_stable"]
+    )
+    analysis["primary_reason"] = _build_primary_reason(analysis)
+
+    suspicious_rows = analysis.loc[analysis["suspicious_any"]].copy()
+    suspicious_rows = suspicious_rows.sort_values(
+        by=["primary_reason", "logloss", "abs_error"],
+        ascending=[True, False, False],
+    ).reset_index(drop=True)
+
+    duplicate_group_frames = [frame for frame in (exact_groups, coarse_groups) if not frame.empty]
+    if duplicate_group_frames:
+        duplicate_groups = pd.concat(duplicate_group_frames, axis=0, ignore_index=True)
+        duplicate_groups["eligible_near_duplicate_conflict"] = (
+            duplicate_groups["signature_kind"].eq("exact")
+            | (
+                duplicate_groups["signature_kind"].eq("coarse")
+                & duplicate_groups["group_size"].le(int(max_near_duplicate_group_size))
+            )
+        )
+        duplicate_groups = duplicate_groups.sort_values(
+            by=["eligible_near_duplicate_conflict", "inconsistent_labels", "group_size"],
+            ascending=[False, False, False],
+        ).reset_index(drop=True)
+    else:
+        duplicate_groups = pd.DataFrame(
+            columns=[
+                "signature_kind",
+                "signature",
+                "group_size",
+                "label_unique_count",
+                "labels",
+                "positive_rate",
+                "inconsistent_labels",
+                "segment3_mode",
+                "segment5_mode",
+                "sample_ids",
+                "eligible_near_duplicate_conflict",
+            ]
+        )
+
+    dominant_mask = analysis["segment3"].astype(str).eq(DOMINANT_MACROFAMILY)
+    suspicious_dom = suspicious_rows["segment3"].astype(str).eq(DOMINANT_MACROFAMILY)
+    duplicate_conflict_rows = int(analysis["near_duplicate_conflict"].sum())
+    label_noise_rows = int(analysis["label_noise_candidate"].sum())
+    hard_rows = int(analysis["hard_example_stable"].sum())
+    overall_suspicious_rate = float(analysis["suspicious_any"].mean())
+    dominant_suspicious_rate = float(suspicious_dom.sum() / dominant_mask.sum()) if int(dominant_mask.sum()) > 0 else 0.0
+
+    summary: dict[str, Any] = {
+        "generated_at_utc": utc_now_iso(),
+        "train_csv_path": str(train_csv_path),
+        "v3_oof_spec": str(v3_oof_spec),
+        "teacher_component_source_fingerprint": _fingerprint(list(teacher_info.get("oof_specs", []))) if teacher_info.get("available") else None,
+        "reference_source": reference_source,
+        "teacher_components": teacher_info,
+        "rows": int(len(analysis)),
+        "global_v3_auc": float(binary_auc(analysis[OOF_TARGET_COLUMN], analysis["v3_pred"])),
+        "thresholds": {
+            "high_confidence_upper": float(high_confidence_upper),
+            "high_confidence_lower": float(high_confidence_lower),
+            "hard_loss_quantile": float(hard_loss_quantile),
+            "hard_loss_threshold": hard_loss_threshold,
+            "low_disagreement_quantile": float(low_disagreement_quantile),
+            "low_teacher_std_threshold": low_std_threshold if np.isfinite(low_std_threshold) else None,
+            "high_disagreement_quantile": float(high_disagreement_quantile),
+            "high_teacher_std_threshold": high_std_threshold if np.isfinite(high_std_threshold) else None,
+            "max_near_duplicate_group_size": int(max_near_duplicate_group_size),
+        },
+        "suspicion_counts": {
+            "suspicious_any": int(analysis["suspicious_any"].sum()),
+            "label_noise_candidate": label_noise_rows,
+            "near_duplicate_conflict": duplicate_conflict_rows,
+            "hard_example_stable": hard_rows,
+            "high_confidence_wrong": int(analysis["high_confidence_wrong"].sum()),
+        },
+        "suspicion_rates": {
+            "suspicious_any": overall_suspicious_rate,
+            "label_noise_candidate": float(analysis["label_noise_candidate"].mean()),
+            "near_duplicate_conflict": float(analysis["near_duplicate_conflict"].mean()),
+            "hard_example_stable": float(analysis["hard_example_stable"].mean()),
+        },
+        "dominant_macrofamily": {
+            "family_value": DOMINANT_MACROFAMILY,
+            "rows": int(dominant_mask.sum()),
+            "suspicious_rows": int(suspicious_dom.sum()),
+            "suspicious_rate": dominant_suspicious_rate,
+            "label_noise_rows": int(
+                analysis.loc[dominant_mask, "label_noise_candidate"].sum()
+            ),
+            "near_duplicate_conflict_rows": int(
+                analysis.loc[dominant_mask, "near_duplicate_conflict"].sum()
+            ),
+            "hard_example_rows": int(
+                analysis.loc[dominant_mask, "hard_example_stable"].sum()
+            ),
+        },
+        "top_segment3_suspicious": _top_family_table(
+            analysis,
+            family_column="segment3",
+            mask_column="suspicious_any",
+            top_n=top_n_families,
+        ),
+        "top_segment5_suspicious": _top_family_table(
+            analysis,
+            family_column="segment5",
+            mask_column="suspicious_any",
+            top_n=top_n_families,
+        ),
+        "top_segment5_label_noise": _top_family_table(
+            analysis,
+            family_column="segment5",
+            mask_column="label_noise_candidate",
+            top_n=top_n_families,
+        ),
+        "top_segment5_duplicate_conflicts": _top_family_table(
+            analysis,
+            family_column="segment5",
+            mask_column="near_duplicate_conflict",
+            top_n=top_n_families,
+        ),
+        "duplicate_groups": {
+            "exact_groups_with_size_gt_1": int(len(exact_groups)),
+            "exact_groups_with_label_conflict": int(exact_groups["inconsistent_labels"].sum()) if not exact_groups.empty else 0,
+            "coarse_groups_with_size_gt_1": int(len(coarse_groups)),
+            "coarse_groups_with_label_conflict": int(coarse_groups["inconsistent_labels"].sum()) if not coarse_groups.empty else 0,
+            "eligible_conflict_groups": int(duplicate_groups["eligible_near_duplicate_conflict"].sum()) if not duplicate_groups.empty else 0,
+        },
+        "top_duplicate_conflict_groups": duplicate_groups.loc[
+            duplicate_groups["eligible_near_duplicate_conflict"] & duplicate_groups["inconsistent_labels"]
+        ].head(int(top_n_families)).to_dict(orient="records") if not duplicate_groups.empty else [],
+    }
+
+    if duplicate_conflict_rows >= max(label_noise_rows * 3, 1):
+        driver_text = "near-duplicates/cohortes casi repetidas"
+        next_action = (
+            "Auditar manualmente y con reglas mas finas los grupos `coarse` pequenos e inconsistentes "
+            "antes de probar reweight o exclusion."
+        )
+    else:
+        driver_text = "label noise de alta confianza"
+        next_action = (
+            "Inspeccionar primero los casos de alta confianza erronea con bajo desacuerdo del teacher "
+            "antes de probar filtrado o reweight."
+        )
+
+    if dominant_suspicious_rate >= overall_suspicious_rate * 1.5:
+        concentration_text = (
+            "La sospecha se concentra de forma material en la macrofamilia dominante "
+            "`Electronic check / Month-to-month / Fiber optic`."
+        )
+    else:
+        concentration_text = (
+            "La sospecha no se concentra de forma desproporcionada en la macrofamilia dominante; "
+            "conviene revisar tambien familias secundarias del top segment3."
+        )
+
+    summary["operational_conclusion"] = {
+        "headline": f"La senal dominante del audit apunta mas a {driver_text} que a la otra clase principal.",
+        "family_concentration": concentration_text,
+        "recommended_next_action": next_action,
+        "do_not_do_yet": (
+            "No filtrar globalmente filas ni reentrenar con drops masivos hasta separar near-duplicate real de "
+            "cohorte legitima repetida."
+        ),
+    }
+
+    suspicious_output_columns = [
+        ID_COLUMN,
+        OOF_TARGET_COLUMN,
+        "v3_pred",
+        "abs_error",
+        "logloss",
+        "prediction_margin",
+        "segment3",
+        "segment5",
+        "tenure_bin",
+        "high_confidence_wrong",
+        "label_noise_candidate",
+        "near_duplicate_conflict",
+        "hard_example_stable",
+        "primary_reason",
+        "exact_group_size",
+        "exact_inconsistent",
+        "coarse_group_size",
+        "coarse_inconsistent",
+        "teacher_mean",
+        "teacher_std",
+        "teacher_range",
+        "teacher_unanimous_side",
+    ]
+    suspicious_export = suspicious_rows[suspicious_output_columns].copy()
+
+    if out_rows_csv_path is not None:
+        out_rows = ensure_parent_dir(out_rows_csv_path)
+        suspicious_export.to_csv(out_rows, index=False)
+    if out_duplicate_csv_path is not None:
+        out_dup = ensure_parent_dir(out_duplicate_csv_path)
+        duplicate_groups.to_csv(out_dup, index=False)
+    if out_json_path is not None:
+        write_json(out_json_path, summary)
+    return summary

--- a/src/churn_baseline/noise_mitigation.py
+++ b/src/churn_baseline/noise_mitigation.py
@@ -1,0 +1,330 @@
+"""Minimal mitigation harness for near-duplicate minority rows."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import StratifiedKFold
+
+from .config import CatBoostHyperParams, ID_COLUMN
+from .data import infer_categorical_columns, load_csv
+from .diagnostics import OOF_TARGET_COLUMN, build_family_frame, utc_now_iso
+from .evaluation import binary_auc
+from .feature_engineering import normalize_feature_blocks
+from .modeling import best_iteration_or_default, fit_with_validation, predict_proba
+from .noise_audit import DOMINANT_MACROFAMILY
+from .pipeline import _build_stratify_labels, _prepare_train_matrix, _transform_pair_with_stateful_blocks
+
+
+MITIGATION_DOWNWEIGHT = "downweight"
+MITIGATION_DROP = "drop"
+SUPPORTED_MITIGATION_MODES = (MITIGATION_DOWNWEIGHT, MITIGATION_DROP)
+
+
+def _normalize_text_series(series: pd.Series) -> pd.Series:
+    return (
+        series.fillna("__missing__")
+        .astype(str)
+        .str.strip()
+        .str.lower()
+        .str.replace(r"\s+", " ", regex=True)
+    )
+
+
+def _hash_signature_frame(frame: pd.DataFrame) -> pd.Series:
+    hashed = pd.util.hash_pandas_object(frame, index=False).astype("uint64").astype(str)
+    return pd.Series(hashed.to_numpy(), index=frame.index, dtype="string")
+
+
+def _build_mitigation_signature_frame(train_df: pd.DataFrame, family_frame: pd.DataFrame) -> pd.DataFrame:
+    work = pd.DataFrame(index=train_df.index)
+    category_candidates = (
+        "gender",
+        "SeniorCitizen",
+        "Partner",
+        "Dependents",
+        "PhoneService",
+        "MultipleLines",
+        "InternetService",
+        "OnlineSecurity",
+        "OnlineBackup",
+        "DeviceProtection",
+        "TechSupport",
+        "StreamingTV",
+        "StreamingMovies",
+        "Contract",
+        "PaperlessBilling",
+        "PaymentMethod",
+    )
+    for column in category_candidates:
+        if column in train_df.columns:
+            work[column] = _normalize_text_series(train_df[column])
+
+    if "tenure" in train_df.columns:
+        work["tenure_exact"] = pd.to_numeric(train_df["tenure"], errors="coerce").fillna(-1).astype("int64").astype(str)
+    if "MonthlyCharges" in train_df.columns:
+        monthly = pd.to_numeric(train_df["MonthlyCharges"], errors="coerce").fillna(-999999.0)
+        work["monthly_charge_bucket"] = (np.round(monthly / 1.0) * 1.0).round(2)
+    if "TotalCharges" in train_df.columns:
+        total = pd.to_numeric(train_df["TotalCharges"], errors="coerce").fillna(-999999.0)
+        work["total_charge_bucket"] = (np.round(total / 10.0) * 10.0).round(2)
+
+    work["segment3"] = family_frame["segment3"].astype(str).values
+    work["segment5"] = family_frame["segment5"].astype(str).values
+    return work
+
+
+def derive_fold_local_suspects(
+    train_fold_df: pd.DataFrame,
+    y_train_fold: pd.Series,
+    *,
+    dominant_only: bool,
+    dominant_family_value: str,
+    min_group_size: int,
+    max_group_size: int,
+    majority_share_min: float,
+) -> tuple[pd.Series, dict[str, Any]]:
+    """Flag minority-label rows inside small mixed coarse duplicate groups.
+
+    Returns:
+        suspects:
+            Boolean Series indexed like ``train_fold_df`` where ``True`` marks
+            minority-label rows selected by the local mitigation rule.
+        metadata:
+            Summary dict with group counts, flagged row counts, rule params, and
+            a ``top_groups`` preview for traceability.
+    """
+    if int(min_group_size) < 2:
+        raise ValueError("min_group_size must be >= 2")
+    if int(max_group_size) < int(min_group_size):
+        raise ValueError("max_group_size must be >= min_group_size")
+    if not (0.5 < float(majority_share_min) <= 1.0):
+        raise ValueError("majority_share_min must be in (0.5, 1.0]")
+
+    family_frame = build_family_frame(train_fold_df)
+    signature_frame = _build_mitigation_signature_frame(train_fold_df, family_frame)
+    signature = _hash_signature_frame(signature_frame)
+
+    work = pd.DataFrame(
+        {
+            ID_COLUMN: train_fold_df[ID_COLUMN].values,
+            OOF_TARGET_COLUMN: y_train_fold.astype("int8").values,
+            "segment3": family_frame["segment3"].astype(str).values,
+            "segment5": family_frame["segment5"].astype(str).values,
+            "signature": signature.values,
+        },
+        index=train_fold_df.index,
+    )
+    suspects = pd.Series(False, index=work.index, dtype=bool, name="suspect_row")
+    group_rows: list[dict[str, Any]] = []
+    examined_groups = 0
+    eligible_groups = 0
+    flagged_groups = 0
+    filtered_out_by_macro = 0
+    for signature_value, part in work.groupby("signature", dropna=False):
+        examined_groups += 1
+        if dominant_only and str(part["segment3"].iloc[0]) != str(dominant_family_value):
+            filtered_out_by_macro += 1
+            continue
+        size = int(len(part))
+        if size < int(min_group_size) or size > int(max_group_size):
+            continue
+        label_counts = part[OOF_TARGET_COLUMN].value_counts(dropna=False).sort_values(ascending=False)
+        if len(label_counts) < 2:
+            continue
+        majority_label = int(label_counts.index[0])
+        majority_share = float(label_counts.iloc[0] / size)
+        if majority_share < float(majority_share_min):
+            continue
+        eligible_groups += 1
+        minority_mask = part[OOF_TARGET_COLUMN].astype(int).ne(majority_label)
+        if not minority_mask.any():
+            continue
+        suspects.loc[part.index[minority_mask]] = True
+        flagged_groups += 1
+        group_rows.append(
+            {
+                "signature": str(signature_value),
+                "group_size": size,
+                "majority_label": majority_label,
+                "majority_share": majority_share,
+                "minority_rows": int(minority_mask.sum()),
+                "segment3_mode": str(part["segment3"].mode(dropna=False).iloc[0]),
+                "segment5_mode": str(part["segment5"].mode(dropna=False).iloc[0]),
+            }
+        )
+
+    metadata = {
+        "examined_groups": int(examined_groups),
+        "eligible_groups": int(eligible_groups),
+        "flagged_groups": int(flagged_groups),
+        "flagged_rows": int(suspects.sum()),
+        "dominant_only": bool(dominant_only),
+        "dominant_family_value": str(dominant_family_value),
+        "filtered_out_by_macro": int(filtered_out_by_macro),
+        "min_group_size": int(min_group_size),
+        "max_group_size": int(max_group_size),
+        "majority_share_min": float(majority_share_min),
+        "top_groups": group_rows[:10],
+    }
+    return suspects, metadata
+
+
+def run_noise_mitigation_smoke(
+    *,
+    train_csv_path: str,
+    params: CatBoostHyperParams,
+    feature_blocks: Sequence[str],
+    folds: int,
+    seed: int,
+    early_stopping_rounds: int,
+    verbose: int,
+    stratify_mode: str,
+    mitigation_mode: str,
+    suspect_weight: float,
+    dominant_only: bool,
+    dominant_family_value: str = DOMINANT_MACROFAMILY,
+    min_group_size: int = 3,
+    max_group_size: int = 5,
+    majority_share_min: float = 0.75,
+) -> dict[str, Any]:
+    """Run a smoke CatBoost CV with fold-local near-duplicate mitigation.
+
+    Returns a metrics dict with scalar CV summaries, ``fold_metrics`` per fold,
+    mitigation rule params, and an ``oof_pred`` Series used by the CLI to build
+    direct-vs-v3 analysis artifacts.
+    """
+    mode = str(mitigation_mode).strip().lower()
+    if mode not in SUPPORTED_MITIGATION_MODES:
+        raise ValueError(f"Unsupported mitigation_mode '{mitigation_mode}'. Supported: {SUPPORTED_MITIGATION_MODES}")
+    if not (0.0 < float(suspect_weight) <= 1.0):
+        raise ValueError("suspect_weight must be in (0, 1]")
+
+    train_df = load_csv(train_csv_path)
+    normalized_blocks, _, stateful_blocks, x, y = _prepare_train_matrix(train_df, feature_blocks)
+    aligned_train_df = train_df.loc[x.index].copy()
+    splitter = StratifiedKFold(n_splits=int(folds), shuffle=True, random_state=int(seed))
+    stratify_labels = _build_stratify_labels(x, y, stratify_mode=stratify_mode, min_count=int(folds))
+
+    oof_pred = pd.Series(index=x.index, dtype="float64", name="oof_pred")
+    fold_rows: list[dict[str, Any]] = []
+
+    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x, stratify_labels), start=1):
+        raw_train_fold = aligned_train_df.iloc[train_idx].copy()
+        x_train = x.iloc[train_idx]
+        y_train = y.iloc[train_idx]
+        x_valid = x.iloc[valid_idx]
+        y_valid = y.iloc[valid_idx]
+
+        suspect_rows, suspect_meta = derive_fold_local_suspects(
+            raw_train_fold,
+            y_train,
+            dominant_only=dominant_only,
+            dominant_family_value=dominant_family_value,
+            min_group_size=min_group_size,
+            max_group_size=max_group_size,
+            majority_share_min=majority_share_min,
+        )
+
+        if mode == MITIGATION_DROP:
+            keep_mask = ~suspect_rows
+            x_train_fit = x_train.loc[keep_mask]
+            y_train_fit = y_train.loc[keep_mask]
+            sample_weight_train = None
+        else:
+            keep_mask = pd.Series(True, index=x_train.index, dtype=bool)
+            x_train_fit = x_train
+            y_train_fit = y_train
+            sample_weight_train = pd.Series(1.0, index=x_train.index, dtype="float64")
+            sample_weight_train.loc[suspect_rows] = float(suspect_weight)
+
+        x_train_fit, x_valid_fit = _transform_pair_with_stateful_blocks(x_train_fit, x_valid, stateful_blocks)
+        cat_columns = infer_categorical_columns(x_train_fit)
+
+        fold_params = CatBoostHyperParams(
+            iterations=params.iterations,
+            learning_rate=params.learning_rate,
+            depth=params.depth,
+            l2_leaf_reg=params.l2_leaf_reg,
+            random_seed=seed,
+            loss_function=params.loss_function,
+            eval_metric=params.eval_metric,
+            monotone_constraints=params.monotone_constraints,
+        )
+
+        model = fit_with_validation(
+            x_train=x_train_fit,
+            y_train=y_train_fit,
+            x_valid=x_valid_fit,
+            y_valid=y_valid,
+            cat_columns=cat_columns,
+            params=fold_params,
+            early_stopping_rounds=early_stopping_rounds,
+            verbose=verbose,
+            sample_weight_train=None if sample_weight_train is None else sample_weight_train.loc[x_train_fit.index],
+        )
+
+        fold_pred = predict_proba(model, x_valid_fit)
+        oof_pred.iloc[valid_idx] = fold_pred.values
+        fold_rows.append(
+            {
+                "fold": int(fold_number),
+                "valid_rows": int(len(valid_idx)),
+                "auc": float(binary_auc(y_valid, fold_pred)),
+                "best_iteration": int(model.get_best_iteration()),
+                "final_iterations": int(best_iteration_or_default(model, params.iterations)),
+                "train_rows_before": int(len(train_idx)),
+                "train_rows_after": int(len(x_train_fit)),
+                "suspect_rows": int(suspect_rows.sum()),
+                "mode": mode,
+                "suspect_meta": suspect_meta,
+            }
+        )
+
+    if oof_pred.isna().any():
+        raise RuntimeError("Noise mitigation OOF predictions contain missing values.")
+
+    fold_aucs = [row["auc"] for row in fold_rows]
+    flagged_rows = sum(int(row["suspect_rows"]) for row in fold_rows)
+    unique_flagged_rows = None
+    if fold_rows:
+        per_fold_indices = []
+        for train_idx, _ in splitter.split(x, stratify_labels):
+            raw_train_fold = aligned_train_df.iloc[train_idx].copy()
+            y_train = y.iloc[train_idx]
+            suspect_rows, _ = derive_fold_local_suspects(
+                raw_train_fold,
+                y_train,
+                dominant_only=dominant_only,
+                dominant_family_value=dominant_family_value,
+                min_group_size=min_group_size,
+                max_group_size=max_group_size,
+                majority_share_min=majority_share_min,
+            )
+            per_fold_indices.extend(raw_train_fold.loc[suspect_rows, ID_COLUMN].astype(int).tolist())
+        unique_flagged_rows = int(len(set(per_fold_indices)))
+
+    return {
+        "generated_at_utc": utc_now_iso(),
+        "train_csv_path": str(train_csv_path),
+        "feature_blocks": list(normalize_feature_blocks(feature_blocks)),
+        "mitigation_mode": mode,
+        "suspect_weight": float(suspect_weight),
+        "dominant_only": bool(dominant_only),
+        "dominant_family_value": str(dominant_family_value),
+        "min_group_size": int(min_group_size),
+        "max_group_size": int(max_group_size),
+        "majority_share_min": float(majority_share_min),
+        "rows": int(len(train_df)),
+        "folds": int(folds),
+        "seed": int(seed),
+        "cv_mean_auc": float(np.mean(fold_aucs)),
+        "cv_std_auc": float(np.std(fold_aucs)),
+        "oof_auc": float(binary_auc(y, oof_pred)),
+        "oof_pred": oof_pred,
+        "flagged_rows_total_across_folds": int(flagged_rows),
+        "flagged_unique_row_ids": unique_flagged_rows,
+        "fold_metrics": fold_rows,
+    }

--- a/src/churn_baseline/pipeline.py
+++ b/src/churn_baseline/pipeline.py
@@ -16,7 +16,13 @@ from .data import (
     prepare_train_features,
 )
 from .evaluation import binary_auc
-from .feature_engineering import normalize_feature_blocks
+from .feature_engineering import (
+    BLOCK_G,
+    apply_coverage_backoff_features,
+    fit_coverage_backoff_state,
+    normalize_feature_blocks,
+    partition_feature_blocks,
+)
 from .modeling import (
     best_iteration_or_default,
     fit_full_train,
@@ -25,6 +31,126 @@ from .modeling import (
     predict_proba,
     save_model,
 )
+
+STRATIFY_TARGET = "target"
+STRATIFY_COMPOSITE = "composite"
+SUPPORTED_STRATIFY_MODES = (STRATIFY_TARGET, STRATIFY_COMPOSITE)
+
+
+def normalize_stratify_mode(stratify_mode: str | None) -> str:
+    """Validate supported CV/holdout stratification modes."""
+    normalized = str(stratify_mode or STRATIFY_TARGET).strip().lower()
+    if normalized not in SUPPORTED_STRATIFY_MODES:
+        raise ValueError(
+            f"Unsupported stratify_mode '{stratify_mode}'. Supported: {SUPPORTED_STRATIFY_MODES}"
+        )
+    return normalized
+
+
+def _build_composite_stratify_labels(
+    x: pd.DataFrame,
+    y: pd.Series,
+    *,
+    min_count: int,
+) -> pd.Series:
+    required = ("PaymentMethod", "Contract", "InternetService")
+    if any(column not in x.columns for column in required):
+        return y.astype(str).reset_index(drop=True)
+
+    y_label = y.astype(str)
+    contract = x["Contract"].astype(str)
+    payment_contract = x["PaymentMethod"].astype(str) + "__" + contract
+    segment3 = payment_contract + "__" + x["InternetService"].astype(str)
+
+    contract_joint = y_label + "__" + contract
+    payment_contract_joint = y_label + "__" + payment_contract
+    segment3_joint = y_label + "__" + segment3
+
+    contract_counts = contract_joint.value_counts(dropna=False)
+    payment_contract_counts = payment_contract_joint.value_counts(dropna=False)
+    segment3_counts = segment3_joint.value_counts(dropna=False)
+
+    labels = np.where(
+        segment3_joint.map(segment3_counts).ge(min_count),
+        segment3_joint,
+        np.where(
+            payment_contract_joint.map(payment_contract_counts).ge(min_count),
+            payment_contract_joint,
+            np.where(
+                contract_joint.map(contract_counts).ge(min_count),
+                contract_joint,
+                y_label,
+            ),
+        ),
+    )
+    return pd.Series(labels, index=x.index, dtype="object")
+
+
+def _build_stratify_labels(
+    x: pd.DataFrame,
+    y: pd.Series,
+    *,
+    stratify_mode: str,
+    min_count: int,
+) -> pd.Series:
+    normalized_mode = normalize_stratify_mode(stratify_mode)
+    if normalized_mode == STRATIFY_TARGET:
+        return y.astype(str).reset_index(drop=True)
+    return _build_composite_stratify_labels(x, y, min_count=max(int(min_count), 2))
+
+
+def _transform_pair_with_stateful_blocks(
+    x_fit: pd.DataFrame,
+    x_apply: pd.DataFrame,
+    stateful_blocks: Sequence[str],
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    fit_out = x_fit.copy()
+    apply_out = x_apply.copy()
+    normalized_stateful = tuple(stateful_blocks)
+    if BLOCK_G in normalized_stateful:
+        coverage_state = fit_coverage_backoff_state(fit_out)
+        fit_out = apply_coverage_backoff_features(fit_out, coverage_state)
+        apply_out = apply_coverage_backoff_features(apply_out, coverage_state)
+    return fit_out, apply_out
+
+
+def _transform_single_with_stateful_blocks(
+    x_fit: pd.DataFrame,
+    stateful_blocks: Sequence[str],
+) -> pd.DataFrame:
+    fit_out, _ = _transform_pair_with_stateful_blocks(x_fit, x_fit, stateful_blocks)
+    return fit_out
+
+
+def _prepare_train_matrix(
+    train_df: pd.DataFrame,
+    feature_blocks: Sequence[str] | None,
+) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...], pd.DataFrame, pd.Series]:
+    normalized_blocks = normalize_feature_blocks(feature_blocks)
+    stateless_blocks, stateful_blocks = partition_feature_blocks(normalized_blocks)
+    x, y = prepare_train_features(train_df, drop_id=True, feature_blocks=stateless_blocks)
+    return normalized_blocks, stateless_blocks, stateful_blocks, x, y
+
+
+def _prepare_test_matrix(
+    test_df: pd.DataFrame,
+    *,
+    stateless_blocks: Sequence[str],
+    stateful_blocks: Sequence[str],
+    train_csv_path: str | Path | None,
+) -> pd.DataFrame:
+    x_test = prepare_test_features(test_df, drop_id=True, feature_blocks=stateless_blocks)
+    if not stateful_blocks:
+        return x_test
+    if train_csv_path is None:
+        raise ValueError(
+            "Stateful feature blocks require train_csv_path at inference time. "
+            "Provide train_csv_path when using block G."
+        )
+    train_df = load_csv(train_csv_path)
+    _, _, _, x_train_base, _ = _prepare_train_matrix(train_df, stateless_blocks)
+    _, x_test_stateful = _transform_pair_with_stateful_blocks(x_train_base, x_test, stateful_blocks)
+    return x_test_stateful
 
 
 def train_baseline(
@@ -37,20 +163,28 @@ def train_baseline(
     early_stopping_rounds: int,
     verbose: int,
     feature_blocks: Sequence[str] | None = None,
+    stratify_mode: str = STRATIFY_TARGET,
 ) -> Dict[str, Any]:
     """Train holdout+full baseline and save model + metrics."""
     train_df = load_csv(train_csv_path)
-    normalized_blocks = normalize_feature_blocks(feature_blocks)
-    x, y = prepare_train_features(train_df, drop_id=True, feature_blocks=normalized_blocks)
-    cat_columns = infer_categorical_columns(x)
+    normalized_blocks, _, stateful_blocks, x, y = _prepare_train_matrix(train_df, feature_blocks)
+    normalized_stratify_mode = normalize_stratify_mode(stratify_mode)
+    stratify_labels = _build_stratify_labels(
+        x,
+        y,
+        stratify_mode=normalized_stratify_mode,
+        min_count=max(int(np.ceil(1.0 / min(valid_size, 1.0 - valid_size))), 2),
+    )
 
     x_train, x_valid, y_train, y_valid = train_test_split(
         x,
         y,
         test_size=valid_size,
         random_state=random_state,
-        stratify=y,
+        stratify=stratify_labels,
     )
+    x_train, x_valid = _transform_pair_with_stateful_blocks(x_train, x_valid, stateful_blocks)
+    cat_columns = infer_categorical_columns(x_train)
 
     holdout_model = fit_with_validation(
         x_train=x_train,
@@ -77,10 +211,12 @@ def train_baseline(
         eval_metric=params.eval_metric,
     )
 
+    x_full = _transform_single_with_stateful_blocks(x, stateful_blocks)
+    full_cat_columns = infer_categorical_columns(x_full)
     full_model = fit_full_train(
-        x_train=x,
+        x_train=x_full,
         y_train=y,
-        cat_columns=cat_columns,
+        cat_columns=full_cat_columns,
         params=full_params,
         verbose=verbose,
     )
@@ -88,9 +224,10 @@ def train_baseline(
 
     metrics: Dict[str, Any] = {
         "train_rows": int(len(train_df)),
-        "feature_count": int(x.shape[1]),
+        "feature_count": int(x_full.shape[1]),
         "feature_blocks": list(normalized_blocks),
-        "categorical_columns": cat_columns,
+        "categorical_columns": full_cat_columns,
+        "stratify_mode": normalized_stratify_mode,
         "holdout_auc": holdout_auc,
         "holdout_best_iteration": int(holdout_model.get_best_iteration()),
         "final_iterations": int(final_iterations),
@@ -107,24 +244,33 @@ def train_baseline(
 def _run_cv_for_seed(
     x: pd.DataFrame,
     y: pd.Series,
-    cat_columns: list[str],
     params: CatBoostHyperParams,
     folds: int,
     seed: int,
     early_stopping_rounds: int,
     verbose: int,
+    stateful_blocks: Sequence[str],
+    stratify_mode: str,
 ) -> Dict[str, Any]:
     """Run Stratified K-Fold CV for a single random seed and return OOF stats."""
     splitter = StratifiedKFold(n_splits=folds, shuffle=True, random_state=seed)
+    stratify_labels = _build_stratify_labels(
+        x,
+        y,
+        stratify_mode=stratify_mode,
+        min_count=folds,
+    )
     oof_pred = pd.Series(index=x.index, dtype="float64", name=f"oof_seed_{seed}")
     fold_rows = []
     fold_iterations = []
 
-    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x, y), start=1):
+    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x, stratify_labels), start=1):
         x_train = x.iloc[train_idx]
         y_train = y.iloc[train_idx]
         x_valid = x.iloc[valid_idx]
         y_valid = y.iloc[valid_idx]
+        x_train, x_valid = _transform_pair_with_stateful_blocks(x_train, x_valid, stateful_blocks)
+        cat_columns = infer_categorical_columns(x_train)
 
         fold_params = CatBoostHyperParams(
             iterations=params.iterations,
@@ -193,25 +339,26 @@ def train_baseline_cv(
     early_stopping_rounds: int,
     verbose: int,
     feature_blocks: Sequence[str] | None = None,
+    stratify_mode: str = STRATIFY_TARGET,
 ) -> Dict[str, Any]:
     """Train baseline with Stratified K-Fold CV, generate OOF and fit final model."""
     if folds < 2:
         raise ValueError("folds must be >= 2")
 
     train_df = load_csv(train_csv_path)
-    normalized_blocks = normalize_feature_blocks(feature_blocks)
-    x, y = prepare_train_features(train_df, drop_id=True, feature_blocks=normalized_blocks)
-    cat_columns = infer_categorical_columns(x)
+    normalized_blocks, _, stateful_blocks, x, y = _prepare_train_matrix(train_df, feature_blocks)
+    normalized_stratify_mode = normalize_stratify_mode(stratify_mode)
 
     seed_run = _run_cv_for_seed(
         x=x,
         y=y,
-        cat_columns=cat_columns,
         params=params,
         folds=folds,
         seed=random_state,
         early_stopping_rounds=early_stopping_rounds,
         verbose=verbose,
+        stateful_blocks=stateful_blocks,
+        stratify_mode=normalized_stratify_mode,
     )
     oof_pred = seed_run["oof_pred"]
     fold_rows = seed_run["fold_metrics"]
@@ -231,10 +378,12 @@ def train_baseline_cv(
         eval_metric=params.eval_metric,
     )
 
+    x_full = _transform_single_with_stateful_blocks(x, stateful_blocks)
+    full_cat_columns = infer_categorical_columns(x_full)
     full_model = fit_full_train(
-        x_train=x,
+        x_train=x_full,
         y_train=y,
-        cat_columns=cat_columns,
+        cat_columns=full_cat_columns,
         params=full_params,
         verbose=verbose,
     )
@@ -253,9 +402,10 @@ def train_baseline_cv(
 
     metrics: Dict[str, Any] = {
         "train_rows": int(len(train_df)),
-        "feature_count": int(x.shape[1]),
+        "feature_count": int(x_full.shape[1]),
         "feature_blocks": list(normalized_blocks),
-        "categorical_columns": cat_columns,
+        "categorical_columns": full_cat_columns,
+        "stratify_mode": normalized_stratify_mode,
         "cv_folds": int(folds),
         "cv_fold_metrics": fold_rows,
         "cv_mean_auc": cv_mean_auc,
@@ -285,6 +435,7 @@ def train_baseline_cv_multiseed(
     early_stopping_rounds: int,
     verbose: int,
     feature_blocks: Sequence[str] | None = None,
+    stratify_mode: str = STRATIFY_TARGET,
 ) -> Dict[str, Any]:
     """Train CV baseline across multiple seeds and average OOF predictions."""
     if folds < 2:
@@ -297,12 +448,13 @@ def train_baseline_cv_multiseed(
         raise ValueError("seeds contain duplicates")
 
     train_df = load_csv(train_csv_path)
-    normalized_blocks = normalize_feature_blocks(feature_blocks)
-    x, y = prepare_train_features(train_df, drop_id=True, feature_blocks=normalized_blocks)
-    cat_columns = infer_categorical_columns(x)
+    normalized_blocks, _, stateful_blocks, x, y = _prepare_train_matrix(train_df, feature_blocks)
+    normalized_stratify_mode = normalize_stratify_mode(stratify_mode)
 
     models_out_dir = Path(models_dir)
     models_out_dir.mkdir(parents=True, exist_ok=True)
+    x_full_train = _transform_single_with_stateful_blocks(x, stateful_blocks)
+    full_cat_columns = infer_categorical_columns(x_full_train)
 
     per_seed_metrics = []
     per_seed_oof = []
@@ -312,12 +464,13 @@ def train_baseline_cv_multiseed(
         seed_run = _run_cv_for_seed(
             x=x,
             y=y,
-            cat_columns=cat_columns,
             params=params,
             folds=folds,
             seed=seed,
             early_stopping_rounds=early_stopping_rounds,
             verbose=verbose,
+            stateful_blocks=stateful_blocks,
+            stratify_mode=normalized_stratify_mode,
         )
         per_seed_oof.append(seed_run["oof_pred"].values)
 
@@ -333,9 +486,9 @@ def train_baseline_cv_multiseed(
 
         model_path = models_out_dir / f"catboost_seed_{seed}.cbm"
         full_model = fit_full_train(
-            x_train=x,
+            x_train=x_full_train,
             y_train=y,
-            cat_columns=cat_columns,
+            cat_columns=full_cat_columns,
             params=full_params,
             verbose=verbose,
         )
@@ -378,9 +531,10 @@ def train_baseline_cv_multiseed(
     seed_oof_aucs = [item["oof_auc"] for item in per_seed_metrics]
     metrics: Dict[str, Any] = {
         "train_rows": int(len(train_df)),
-        "feature_count": int(x.shape[1]),
+        "feature_count": int(x_full_train.shape[1]),
         "feature_blocks": list(normalized_blocks),
-        "categorical_columns": cat_columns,
+        "categorical_columns": full_cat_columns,
+        "stratify_mode": normalized_stratify_mode,
         "cv_folds": int(folds),
         "seeds": normalized_seeds,
         "per_seed_metrics": per_seed_metrics,
@@ -405,6 +559,7 @@ def make_submission(
     test_csv_path: str | Path,
     output_csv_path: str | Path,
     feature_blocks: Sequence[str] | None = None,
+    train_csv_path: str | Path | None = None,
 ) -> Dict[str, Any]:
     """Generate submission CSV using a trained model."""
     test_df = load_csv(test_csv_path)
@@ -413,7 +568,13 @@ def make_submission(
 
     ids = test_df[ID_COLUMN].copy()
     normalized_blocks = normalize_feature_blocks(feature_blocks)
-    x_test = prepare_test_features(test_df, drop_id=True, feature_blocks=normalized_blocks)
+    stateless_blocks, stateful_blocks = partition_feature_blocks(normalized_blocks)
+    x_test = _prepare_test_matrix(
+        test_df,
+        stateless_blocks=stateless_blocks,
+        stateful_blocks=stateful_blocks,
+        train_csv_path=train_csv_path,
+    )
     model = load_model(model_path)
     predictions = predict_proba(model, x_test)
 
@@ -436,6 +597,7 @@ def make_submission_ensemble(
     test_csv_path: str | Path,
     output_csv_path: str | Path,
     feature_blocks: Sequence[str] | None = None,
+    train_csv_path: str | Path | None = None,
 ) -> Dict[str, Any]:
     """Generate submission CSV by averaging predictions from multiple models."""
     if not model_paths:
@@ -447,7 +609,13 @@ def make_submission_ensemble(
 
     ids = test_df[ID_COLUMN].copy()
     normalized_blocks = normalize_feature_blocks(feature_blocks)
-    x_test = prepare_test_features(test_df, drop_id=True, feature_blocks=normalized_blocks)
+    stateless_blocks, stateful_blocks = partition_feature_blocks(normalized_blocks)
+    x_test = _prepare_test_matrix(
+        test_df,
+        stateless_blocks=stateless_blocks,
+        stateful_blocks=stateful_blocks,
+        train_csv_path=train_csv_path,
+    )
 
     predictions_matrix = []
     for model_path in model_paths:

--- a/src/churn_baseline/pipeline.py
+++ b/src/churn_baseline/pipeline.py
@@ -18,8 +18,11 @@ from .data import (
 from .evaluation import binary_auc
 from .feature_engineering import (
     BLOCK_G,
+    BLOCK_T,
     apply_coverage_backoff_features,
+    apply_ec_surface_fit_features,
     ensure_monotonic_features,
+    fit_ec_surface_state,
     fit_coverage_backoff_state,
     normalize_feature_blocks,
     partition_feature_blocks,
@@ -112,6 +115,10 @@ def _transform_pair_with_stateful_blocks(
         coverage_state = fit_coverage_backoff_state(fit_out)
         fit_out = apply_coverage_backoff_features(fit_out, coverage_state)
         apply_out = apply_coverage_backoff_features(apply_out, coverage_state)
+    if BLOCK_T in normalized_stateful:
+        surface_state = fit_ec_surface_state(fit_out)
+        fit_out = apply_ec_surface_fit_features(fit_out, surface_state)
+        apply_out = apply_ec_surface_fit_features(apply_out, surface_state)
     return fit_out, apply_out
 
 
@@ -153,7 +160,7 @@ def _prepare_test_matrix(
     if train_csv_path is None:
         raise ValueError(
             "Stateful feature blocks require train_csv_path at inference time. "
-            "Provide train_csv_path when using block G."
+            "Provide train_csv_path when using blocks like G or T."
         )
     train_df = load_csv(train_csv_path)
     _, _, _, x_train_base, _ = _prepare_train_matrix(

--- a/src/churn_baseline/pipeline.py
+++ b/src/churn_baseline/pipeline.py
@@ -19,6 +19,7 @@ from .evaluation import binary_auc
 from .feature_engineering import (
     BLOCK_G,
     apply_coverage_backoff_features,
+    ensure_monotonic_features,
     fit_coverage_backoff_state,
     normalize_feature_blocks,
     partition_feature_blocks,
@@ -125,10 +126,14 @@ def _transform_single_with_stateful_blocks(
 def _prepare_train_matrix(
     train_df: pd.DataFrame,
     feature_blocks: Sequence[str] | None,
+    *,
+    include_monotonic_features: bool = False,
 ) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...], pd.DataFrame, pd.Series]:
     normalized_blocks = normalize_feature_blocks(feature_blocks)
     stateless_blocks, stateful_blocks = partition_feature_blocks(normalized_blocks)
     x, y = prepare_train_features(train_df, drop_id=True, feature_blocks=stateless_blocks)
+    if include_monotonic_features:
+        x = ensure_monotonic_features(x)
     return normalized_blocks, stateless_blocks, stateful_blocks, x, y
 
 
@@ -138,8 +143,11 @@ def _prepare_test_matrix(
     stateless_blocks: Sequence[str],
     stateful_blocks: Sequence[str],
     train_csv_path: str | Path | None,
+    include_monotonic_features: bool = False,
 ) -> pd.DataFrame:
     x_test = prepare_test_features(test_df, drop_id=True, feature_blocks=stateless_blocks)
+    if include_monotonic_features:
+        x_test = ensure_monotonic_features(x_test)
     if not stateful_blocks:
         return x_test
     if train_csv_path is None:
@@ -148,7 +156,11 @@ def _prepare_test_matrix(
             "Provide train_csv_path when using block G."
         )
     train_df = load_csv(train_csv_path)
-    _, _, _, x_train_base, _ = _prepare_train_matrix(train_df, stateless_blocks)
+    _, _, _, x_train_base, _ = _prepare_train_matrix(
+        train_df,
+        stateless_blocks,
+        include_monotonic_features=include_monotonic_features,
+    )
     _, x_test_stateful = _transform_pair_with_stateful_blocks(x_train_base, x_test, stateful_blocks)
     return x_test_stateful
 
@@ -164,10 +176,15 @@ def train_baseline(
     verbose: int,
     feature_blocks: Sequence[str] | None = None,
     stratify_mode: str = STRATIFY_TARGET,
+    include_monotonic_features: bool = False,
 ) -> Dict[str, Any]:
     """Train holdout+full baseline and save model + metrics."""
     train_df = load_csv(train_csv_path)
-    normalized_blocks, _, stateful_blocks, x, y = _prepare_train_matrix(train_df, feature_blocks)
+    normalized_blocks, _, stateful_blocks, x, y = _prepare_train_matrix(
+        train_df,
+        feature_blocks,
+        include_monotonic_features=include_monotonic_features,
+    )
     normalized_stratify_mode = normalize_stratify_mode(stratify_mode)
     stratify_labels = _build_stratify_labels(
         x,
@@ -209,6 +226,7 @@ def train_baseline(
         random_seed=params.random_seed,
         loss_function=params.loss_function,
         eval_metric=params.eval_metric,
+        monotone_constraints=params.monotone_constraints,
     )
 
     x_full = _transform_single_with_stateful_blocks(x, stateful_blocks)
@@ -226,6 +244,7 @@ def train_baseline(
         "train_rows": int(len(train_df)),
         "feature_count": int(x_full.shape[1]),
         "feature_blocks": list(normalized_blocks),
+        "include_monotonic_features": bool(include_monotonic_features),
         "categorical_columns": full_cat_columns,
         "stratify_mode": normalized_stratify_mode,
         "holdout_auc": holdout_auc,
@@ -280,6 +299,7 @@ def _run_cv_for_seed(
             random_seed=seed,
             loss_function=params.loss_function,
             eval_metric=params.eval_metric,
+            monotone_constraints=params.monotone_constraints,
         )
 
         fold_model = fit_with_validation(
@@ -340,13 +360,18 @@ def train_baseline_cv(
     verbose: int,
     feature_blocks: Sequence[str] | None = None,
     stratify_mode: str = STRATIFY_TARGET,
+    include_monotonic_features: bool = False,
 ) -> Dict[str, Any]:
     """Train baseline with Stratified K-Fold CV, generate OOF and fit final model."""
     if folds < 2:
         raise ValueError("folds must be >= 2")
 
     train_df = load_csv(train_csv_path)
-    normalized_blocks, _, stateful_blocks, x, y = _prepare_train_matrix(train_df, feature_blocks)
+    normalized_blocks, _, stateful_blocks, x, y = _prepare_train_matrix(
+        train_df,
+        feature_blocks,
+        include_monotonic_features=include_monotonic_features,
+    )
     normalized_stratify_mode = normalize_stratify_mode(stratify_mode)
 
     seed_run = _run_cv_for_seed(
@@ -376,6 +401,7 @@ def train_baseline_cv(
         random_seed=params.random_seed,
         loss_function=params.loss_function,
         eval_metric=params.eval_metric,
+        monotone_constraints=params.monotone_constraints,
     )
 
     x_full = _transform_single_with_stateful_blocks(x, stateful_blocks)
@@ -404,6 +430,7 @@ def train_baseline_cv(
         "train_rows": int(len(train_df)),
         "feature_count": int(x_full.shape[1]),
         "feature_blocks": list(normalized_blocks),
+        "include_monotonic_features": bool(include_monotonic_features),
         "categorical_columns": full_cat_columns,
         "stratify_mode": normalized_stratify_mode,
         "cv_folds": int(folds),
@@ -436,6 +463,7 @@ def train_baseline_cv_multiseed(
     verbose: int,
     feature_blocks: Sequence[str] | None = None,
     stratify_mode: str = STRATIFY_TARGET,
+    include_monotonic_features: bool = False,
 ) -> Dict[str, Any]:
     """Train CV baseline across multiple seeds and average OOF predictions."""
     if folds < 2:
@@ -448,7 +476,11 @@ def train_baseline_cv_multiseed(
         raise ValueError("seeds contain duplicates")
 
     train_df = load_csv(train_csv_path)
-    normalized_blocks, _, stateful_blocks, x, y = _prepare_train_matrix(train_df, feature_blocks)
+    normalized_blocks, _, stateful_blocks, x, y = _prepare_train_matrix(
+        train_df,
+        feature_blocks,
+        include_monotonic_features=include_monotonic_features,
+    )
     normalized_stratify_mode = normalize_stratify_mode(stratify_mode)
 
     models_out_dir = Path(models_dir)
@@ -482,6 +514,7 @@ def train_baseline_cv_multiseed(
             random_seed=seed,
             loss_function=params.loss_function,
             eval_metric=params.eval_metric,
+            monotone_constraints=params.monotone_constraints,
         )
 
         model_path = models_out_dir / f"catboost_seed_{seed}.cbm"
@@ -533,6 +566,7 @@ def train_baseline_cv_multiseed(
         "train_rows": int(len(train_df)),
         "feature_count": int(x_full_train.shape[1]),
         "feature_blocks": list(normalized_blocks),
+        "include_monotonic_features": bool(include_monotonic_features),
         "categorical_columns": full_cat_columns,
         "stratify_mode": normalized_stratify_mode,
         "cv_folds": int(folds),
@@ -560,6 +594,7 @@ def make_submission(
     output_csv_path: str | Path,
     feature_blocks: Sequence[str] | None = None,
     train_csv_path: str | Path | None = None,
+    include_monotonic_features: bool = False,
 ) -> Dict[str, Any]:
     """Generate submission CSV using a trained model."""
     test_df = load_csv(test_csv_path)
@@ -574,6 +609,7 @@ def make_submission(
         stateless_blocks=stateless_blocks,
         stateful_blocks=stateful_blocks,
         train_csv_path=train_csv_path,
+        include_monotonic_features=include_monotonic_features,
     )
     model = load_model(model_path)
     predictions = predict_proba(model, x_test)
@@ -587,6 +623,7 @@ def make_submission(
         "output_csv": str(out_path),
         "rows": int(len(submission)),
         "feature_blocks": list(normalized_blocks),
+        "include_monotonic_features": bool(include_monotonic_features),
         "prediction_min": float(submission[TARGET_COLUMN].min()),
         "prediction_max": float(submission[TARGET_COLUMN].max()),
     }
@@ -598,6 +635,7 @@ def make_submission_ensemble(
     output_csv_path: str | Path,
     feature_blocks: Sequence[str] | None = None,
     train_csv_path: str | Path | None = None,
+    include_monotonic_features: bool = False,
 ) -> Dict[str, Any]:
     """Generate submission CSV by averaging predictions from multiple models."""
     if not model_paths:
@@ -615,6 +653,7 @@ def make_submission_ensemble(
         stateless_blocks=stateless_blocks,
         stateful_blocks=stateful_blocks,
         train_csv_path=train_csv_path,
+        include_monotonic_features=include_monotonic_features,
     )
 
     predictions_matrix = []
@@ -634,6 +673,7 @@ def make_submission_ensemble(
         "rows": int(len(submission)),
         "model_count": int(len(model_paths)),
         "feature_blocks": list(normalized_blocks),
+        "include_monotonic_features": bool(include_monotonic_features),
         "prediction_min": float(submission[TARGET_COLUMN].min()),
         "prediction_max": float(submission[TARGET_COLUMN].max()),
     }

--- a/src/churn_baseline/pseudo_labeling.py
+++ b/src/churn_baseline/pseudo_labeling.py
@@ -1,0 +1,645 @@
+"""Offline family-level pseudo-labeling experiments."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from itertools import product
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import train_test_split
+
+from .artifacts import ensure_parent_dir, write_json
+from .config import CatBoostHyperParams, ID_COLUMN
+from .data import infer_categorical_columns, load_csv, prepare_train_features
+from .evaluation import binary_auc
+from .feature_engineering import (
+    BLOCK_G,
+    apply_coverage_backoff_features,
+    fit_coverage_backoff_state,
+    normalize_feature_blocks,
+    partition_feature_blocks,
+)
+from .modeling import best_iteration_or_default, fit_with_validation, predict_proba
+
+
+DEFAULT_FAMILY_KEY = "Electronic check__Month-to-month__Fiber optic__Yes__13_24"
+_MIN_CLASS_COUNT = 2
+LABEL_MODE_HARD = "hard"
+LABEL_MODE_SOFT = "soft"
+SUPPORTED_LABEL_MODES = (LABEL_MODE_HARD, LABEL_MODE_SOFT)
+
+
+def _build_tenure_bin(tenure_values: pd.Series) -> pd.Series:
+    return pd.cut(
+        pd.to_numeric(tenure_values, errors="coerce").fillna(0.0),
+        bins=[-np.inf, 6, 12, 24, 48, np.inf],
+        labels=["0_6", "7_12", "13_24", "25_48", "49_plus"],
+    ).astype(str)
+
+
+def build_segment5_family(frame: pd.DataFrame) -> pd.Series:
+    """Build segment5 family key from the raw train/test schema."""
+    required = ("PaymentMethod", "Contract", "InternetService", "PaperlessBilling", "tenure")
+    missing = [column for column in required if column not in frame.columns]
+    if missing:
+        raise ValueError(f"segment5 family requires columns: {missing}")
+
+    tenure_bin = _build_tenure_bin(frame["tenure"])
+    return (
+        frame["PaymentMethod"].astype(str)
+        + "__"
+        + frame["Contract"].astype(str)
+        + "__"
+        + frame["InternetService"].astype(str)
+        + "__"
+        + frame["PaperlessBilling"].astype(str)
+        + "__"
+        + tenure_bin.astype(str)
+    )
+
+
+def list_supported_label_modes() -> tuple[str, ...]:
+    """Return supported pseudo-label target modes."""
+    return SUPPORTED_LABEL_MODES
+
+
+def _build_split_stratify_labels(
+    y: pd.Series,
+    family_mask: pd.Series,
+    *,
+    min_count: int = _MIN_CLASS_COUNT,
+) -> pd.Series:
+    base = y.astype(str)
+    joint = base + "__" + family_mask.astype("int8").astype(str)
+    counts = joint.value_counts(dropna=False)
+    if not counts.empty and int(counts.min()) >= int(min_count):
+        return joint
+    return base
+
+
+def _resolve_component_frame(
+    train_df: pd.DataFrame,
+    reference_component_frame: pd.DataFrame | None,
+) -> pd.DataFrame | None:
+    if reference_component_frame is None:
+        return None
+    if ID_COLUMN not in reference_component_frame.columns:
+        raise ValueError(f"reference_component_frame must contain '{ID_COLUMN}'")
+    component_columns = [
+        column for column in reference_component_frame.columns if column != ID_COLUMN and str(column).startswith("pred_")
+    ]
+    if not component_columns:
+        raise ValueError("reference_component_frame must contain at least one 'pred_*' column")
+    aligned = train_df[[ID_COLUMN]].merge(
+        reference_component_frame[[ID_COLUMN, *component_columns]].copy(),
+        how="left",
+        on=ID_COLUMN,
+        validate="one_to_one",
+    )
+    if aligned[component_columns].isna().any().any():
+        missing_ids = aligned.loc[aligned[component_columns].isna().any(axis=1), ID_COLUMN].head(5).tolist()
+        raise ValueError(f"reference_component_frame missing train ids: {missing_ids}")
+    return aligned
+
+
+def _apply_stateful_views(
+    x_fit: pd.DataFrame,
+    stateful_blocks: Sequence[str],
+    apply_frames: dict[str, pd.DataFrame],
+) -> tuple[pd.DataFrame, dict[str, pd.DataFrame]]:
+    fit_out = x_fit.copy()
+    outputs = {name: frame.copy() for name, frame in apply_frames.items()}
+    if not stateful_blocks:
+        return fit_out, outputs
+
+    normalized_stateful = tuple(stateful_blocks)
+    if BLOCK_G in normalized_stateful:
+        coverage_state = fit_coverage_backoff_state(fit_out)
+        fit_out = apply_coverage_backoff_features(fit_out, coverage_state)
+        outputs = {
+            name: apply_coverage_backoff_features(frame, coverage_state) for name, frame in outputs.items()
+        }
+    unsupported = [block for block in normalized_stateful if block != BLOCK_G]
+    if unsupported:
+        raise ValueError(
+            "Unsupported stateful feature blocks for pseudo-labeling experiment: "
+            f"{unsupported}. Update _apply_stateful_views before enabling them here."
+        )
+    return fit_out, outputs
+
+
+def _safe_auc_on_mask(y_true: pd.Series, pred: pd.Series, mask: pd.Series) -> float | None:
+    if int(mask.sum()) < 2:
+        return None
+    masked_y = y_true.loc[mask]
+    if masked_y.nunique(dropna=False) < 2:
+        return None
+    return float(binary_auc(masked_y, pred.loc[mask]))
+
+
+def _teacher_std(component_frame: pd.DataFrame | None, index: pd.Index) -> pd.Series | None:
+    if component_frame is None:
+        return None
+    component_columns = [column for column in component_frame.columns if column != ID_COLUMN]
+    std = component_frame.loc[index, component_columns].astype("float64").std(axis=1, ddof=0)
+    return pd.Series(std.values, index=index, dtype="float64")
+
+
+def _teacher_agreement_mask(
+    component_frame: pd.DataFrame | None,
+    index: pd.Index,
+    pseudo_target: pd.Series,
+) -> pd.Series:
+    if component_frame is None:
+        raise ValueError("teacher agreement requires reference_component_frame")
+    component_columns = [column for column in component_frame.columns if column != ID_COLUMN]
+    teacher_matrix = component_frame.loc[index, component_columns].astype("float64")
+    agree_positive = teacher_matrix.ge(0.5).all(axis=1)
+    agree_negative = teacher_matrix.lt(0.5).all(axis=1)
+    return pd.Series(
+        np.where(pseudo_target.astype(int).eq(1), agree_positive, agree_negative),
+        index=index,
+        dtype="bool",
+    )
+
+
+def _select_pseudo_rows(
+    *,
+    y_true: pd.Series,
+    reference_pred: pd.Series,
+    component_frame: pd.DataFrame | None,
+    upper_threshold: float,
+    lower_threshold: float,
+    require_teacher_agreement: bool,
+    max_teacher_std: float | None,
+    min_selected_rows: int,
+) -> tuple[pd.Index, pd.Series, pd.Series, dict[str, Any]]:
+    if not (0.5 < upper_threshold <= 1.0):
+        raise ValueError(f"upper_threshold must be in (0.5, 1.0], got {upper_threshold}")
+    if not (0.0 <= lower_threshold < 0.5):
+        raise ValueError(f"lower_threshold must be in [0.0, 0.5), got {lower_threshold}")
+
+    positive_mask = reference_pred.ge(float(upper_threshold))
+    negative_mask = reference_pred.le(float(lower_threshold))
+    selected_mask = positive_mask | negative_mask
+    selected_index = reference_pred.index[selected_mask]
+    if len(selected_index) == 0:
+        return selected_index, pd.Series(dtype="int8"), pd.Series(dtype="float64"), {
+            "selected_reference_mean": None,
+            "selected_rows": 0,
+            "selected_positive_rows": 0,
+            "selected_negative_rows": 0,
+            "selected_accuracy": None,
+            "selected_positive_precision": None,
+            "selected_negative_precision": None,
+            "selected_mean_confidence": None,
+            "teacher_std_mean": None,
+        }
+
+    pseudo_target = pd.Series(
+        np.where(positive_mask.loc[selected_index], 1, 0),
+        index=selected_index,
+        dtype="int8",
+    )
+
+    if require_teacher_agreement:
+        agreement_mask = _teacher_agreement_mask(component_frame, selected_index, pseudo_target)
+        selected_index = agreement_mask.index[agreement_mask]
+        pseudo_target = pseudo_target.loc[selected_index]
+
+    teacher_std = _teacher_std(component_frame, selected_index)
+    if max_teacher_std is not None and teacher_std is not None:
+        std_mask = teacher_std.le(float(max_teacher_std))
+        selected_index = std_mask.index[std_mask]
+        pseudo_target = pseudo_target.loc[selected_index]
+        teacher_std = teacher_std.loc[selected_index]
+
+    if len(selected_index) < int(min_selected_rows):
+        return selected_index, pseudo_target, reference_pred.loc[selected_index].astype("float64"), {
+            "selected_reference_mean": (
+                None if len(selected_index) == 0 else float(reference_pred.loc[selected_index].astype("float64").mean())
+            ),
+            "selected_rows": int(len(selected_index)),
+            "selected_positive_rows": int(pseudo_target.sum()),
+            "selected_negative_rows": int(len(selected_index) - int(pseudo_target.sum())),
+            "selected_accuracy": None,
+            "selected_positive_precision": None,
+            "selected_negative_precision": None,
+            "selected_mean_confidence": None,
+            "teacher_std_mean": None if teacher_std is None or teacher_std.empty else float(teacher_std.mean()),
+        }
+
+    selected_truth = y_true.loc[selected_index].astype(int)
+    selected_reference = reference_pred.loc[selected_index].astype("float64")
+    selected_positive = pseudo_target.eq(1)
+    selected_negative = ~selected_positive
+    positive_precision = (
+        float((selected_truth.loc[selected_positive] == 1).mean())
+        if int(selected_positive.sum()) > 0
+        else None
+    )
+    negative_precision = (
+        float((selected_truth.loc[selected_negative] == 0).mean())
+        if int(selected_negative.sum()) > 0
+        else None
+    )
+    metrics = {
+        "selected_reference_mean": float(selected_reference.mean()),
+        "selected_rows": int(len(selected_index)),
+        "selected_positive_rows": int(selected_positive.sum()),
+        "selected_negative_rows": int(selected_negative.sum()),
+        "selected_accuracy": float((selected_truth == pseudo_target).mean()),
+        "selected_positive_precision": positive_precision,
+        "selected_negative_precision": negative_precision,
+        "selected_mean_confidence": float(np.maximum(selected_reference, 1.0 - selected_reference).mean()),
+        "teacher_std_mean": None if teacher_std is None or teacher_std.empty else float(teacher_std.mean()),
+    }
+    return selected_index, pseudo_target, selected_reference, metrics
+
+
+def _build_pseudo_training_rows(
+    *,
+    x_selected: pd.DataFrame,
+    pseudo_target: pd.Series,
+    selected_reference: pd.Series,
+    pseudo_weight: float,
+    label_mode: str,
+    scale_weight_by_confidence: bool,
+) -> tuple[pd.DataFrame, pd.Series, np.ndarray]:
+    label_mode_value = str(label_mode).strip().lower()
+    if label_mode_value not in SUPPORTED_LABEL_MODES:
+        raise ValueError(f"Unsupported label_mode '{label_mode}'. Supported: {SUPPORTED_LABEL_MODES}")
+
+    base_confidence = np.ones(len(x_selected), dtype="float64")
+    if scale_weight_by_confidence:
+        base_confidence = np.clip(2.0 * np.abs(selected_reference.to_numpy(dtype="float64") - 0.5), 0.0, 1.0)
+
+    if label_mode_value == LABEL_MODE_HARD:
+        weights = np.asarray(base_confidence, dtype="float64") * float(pseudo_weight)
+        return (
+            x_selected.copy(),
+            pseudo_target.astype("int8").copy(),
+            weights,
+        )
+
+    positive_rows = x_selected.copy()
+    positive_target = pd.Series(np.ones(len(x_selected), dtype="int8"), index=x_selected.index)
+    positive_weight = (
+        selected_reference.to_numpy(dtype="float64") * np.asarray(base_confidence, dtype="float64") * float(pseudo_weight)
+    )
+
+    negative_rows = x_selected.copy()
+    negative_rows.index = pd.Index([f"{idx}__soft_neg" for idx in x_selected.index], dtype="object")
+    negative_target = pd.Series(np.zeros(len(x_selected), dtype="int8"), index=negative_rows.index)
+    negative_weight = (
+        (1.0 - selected_reference.to_numpy(dtype="float64"))
+        * np.asarray(base_confidence, dtype="float64")
+        * float(pseudo_weight)
+    )
+
+    positive_rows.index = pd.Index([f"{idx}__soft_pos" for idx in x_selected.index], dtype="object")
+    positive_target.index = positive_rows.index
+    pseudo_x = pd.concat([positive_rows, negative_rows], axis=0)
+    pseudo_y = pd.concat([positive_target, negative_target], axis=0)
+    pseudo_weight_array = np.concatenate([positive_weight, negative_weight]).astype("float64")
+    return pseudo_x, pseudo_y, pseudo_weight_array
+
+
+def _fit_eval_classifier(
+    *,
+    x_train: pd.DataFrame,
+    y_train: pd.Series,
+    x_valid: pd.DataFrame,
+    y_valid: pd.Series,
+    x_eval: pd.DataFrame,
+    y_eval: pd.Series,
+    eval_family_mask: pd.Series,
+    params: CatBoostHyperParams,
+    early_stopping_rounds: int,
+    verbose: int,
+    sample_weight_train: Sequence[float] | pd.Series | None = None,
+) -> dict[str, Any]:
+    cat_columns = infer_categorical_columns(x_train)
+    model = fit_with_validation(
+        x_train=x_train,
+        y_train=y_train,
+        x_valid=x_valid,
+        y_valid=y_valid,
+        cat_columns=cat_columns,
+        params=params,
+        early_stopping_rounds=early_stopping_rounds,
+        verbose=verbose,
+        sample_weight_train=sample_weight_train,
+    )
+    pred = predict_proba(model, x_eval)
+    return {
+        "global_auc": float(binary_auc(y_eval, pred)),
+        "family_auc": _safe_auc_on_mask(y_eval, pred, eval_family_mask),
+        "best_iteration": int(best_iteration_or_default(model, params.iterations)),
+    }
+
+
+def run_family_pseudo_label_experiment(
+    *,
+    train_csv_path: str | Path,
+    family_key: str,
+    reference_pred: pd.Series,
+    reference_component_frame: pd.DataFrame | None,
+    feature_blocks: Sequence[str] | None,
+    params: CatBoostHyperParams,
+    holdout_size: float,
+    valid_size: float,
+    pseudo_pool_fraction: float,
+    repeats: int,
+    random_state: int,
+    early_stopping_rounds: int,
+    verbose: int,
+    upper_thresholds: Sequence[float],
+    lower_thresholds: Sequence[float],
+    pseudo_weights: Sequence[float],
+    label_mode: str,
+    scale_weight_by_confidence: bool,
+    require_teacher_agreement: bool,
+    max_teacher_std: float | None,
+    min_selected_rows: int,
+    metrics_path: str | Path,
+    results_csv_path: str | Path,
+) -> dict[str, Any]:
+    """Run an offline family-level pseudo-labeling sweep."""
+    if not (0.0 < float(holdout_size) < 0.5):
+        raise ValueError("holdout_size must be in (0, 0.5)")
+    if not (0.0 < float(valid_size) < 0.5):
+        raise ValueError("valid_size must be in (0, 0.5)")
+    if not (0.0 < float(pseudo_pool_fraction) < 0.9):
+        raise ValueError("pseudo_pool_fraction must be in (0, 0.9)")
+    if int(repeats) < 1:
+        raise ValueError("repeats must be >= 1")
+
+    train_df = load_csv(train_csv_path)
+    normalized_blocks = normalize_feature_blocks(feature_blocks)
+    stateless_blocks, stateful_blocks = partition_feature_blocks(normalized_blocks)
+    x_base, y = prepare_train_features(train_df, drop_id=True, feature_blocks=stateless_blocks)
+    family_series = build_segment5_family(train_df)
+    family_mask = family_series.eq(str(family_key))
+    family_rows = int(family_mask.sum())
+    if family_rows < 2000:
+        raise ValueError(f"family '{family_key}' has only {family_rows} rows; expected >= 2000")
+    family_positive_rate = float(y.loc[family_mask].mean())
+
+    reference_by_id = pd.Series(reference_pred, copy=True)
+    aligned_reference_pred = train_df[ID_COLUMN].map(reference_by_id)
+    if aligned_reference_pred.isna().any():
+        missing_ids = train_df.loc[aligned_reference_pred.isna(), ID_COLUMN].head(5).tolist()
+        raise ValueError(f"reference_pred missing train ids: {missing_ids}")
+    aligned_reference_pred = pd.Series(
+        aligned_reference_pred.astype("float64").values,
+        index=train_df.index,
+        dtype="float64",
+        name="reference_pred",
+    )
+    aligned_component_frame = _resolve_component_frame(train_df, reference_component_frame)
+    if aligned_component_frame is not None:
+        aligned_component_frame.index = train_df.index
+    if (require_teacher_agreement or max_teacher_std is not None) and aligned_component_frame is None:
+        raise ValueError(
+            "Teacher agreement/std filtering requires per-model `pred_*` OOF components. "
+            "Provide OOF inputs that merge into reference_component_frame."
+        )
+
+    config_rows: list[dict[str, Any]] = []
+    config_grid = list(product(upper_thresholds, lower_thresholds, pseudo_weights))
+
+    for repeat in range(int(repeats)):
+        split_seed = int(random_state) + int(repeat)
+        all_index = np.arange(len(train_df))
+        stratify_labels = _build_split_stratify_labels(y, family_mask)
+        fit_index, eval_index = train_test_split(
+            all_index,
+            test_size=float(holdout_size),
+            random_state=split_seed,
+            stratify=stratify_labels,
+        )
+        fit_index = pd.Index(sorted(fit_index))
+        eval_index = pd.Index(sorted(eval_index))
+        fit_family_index = fit_index[family_mask.loc[fit_index].to_numpy()]
+        if len(fit_family_index) < 1000:
+            raise ValueError(
+                f"family '{family_key}' leaves only {len(fit_family_index)} fit rows in repeat {repeat + 1}"
+            )
+
+        pseudo_split_y = y.loc[fit_family_index]
+        pseudo_stratify = pseudo_split_y if pseudo_split_y.nunique(dropna=False) >= 2 else None
+        family_real_index, pseudo_pool_index = train_test_split(
+            fit_family_index.to_numpy(),
+            test_size=float(pseudo_pool_fraction),
+            random_state=split_seed,
+            stratify=pseudo_stratify,
+        )
+        family_real_index = pd.Index(sorted(family_real_index))
+        pseudo_pool_index = pd.Index(sorted(pseudo_pool_index))
+        train_real_index = fit_index.difference(pseudo_pool_index)
+
+        train_real_y = y.loc[train_real_index]
+        train_real_family_mask = family_mask.loc[train_real_index]
+        inner_stratify = _build_split_stratify_labels(train_real_y, train_real_family_mask)
+        inner_train_index, valid_index = train_test_split(
+            train_real_index.to_numpy(),
+            test_size=float(valid_size),
+            random_state=split_seed,
+            stratify=inner_stratify,
+        )
+        inner_train_index = pd.Index(sorted(inner_train_index))
+        valid_index = pd.Index(sorted(valid_index))
+
+        x_inner_train_base = x_base.loc[inner_train_index]
+        x_valid_base = x_base.loc[valid_index]
+        x_eval_base = x_base.loc[eval_index]
+        x_pseudo_pool_base = x_base.loc[pseudo_pool_index]
+
+        x_inner_train, transformed_views = _apply_stateful_views(
+            x_inner_train_base,
+            stateful_blocks,
+            {
+                "valid": x_valid_base,
+                "eval": x_eval_base,
+                "pseudo_pool": x_pseudo_pool_base,
+            },
+        )
+        x_valid = transformed_views["valid"]
+        x_eval = transformed_views["eval"]
+        x_pseudo_pool = transformed_views["pseudo_pool"]
+
+        y_inner_train = y.loc[inner_train_index]
+        y_valid = y.loc[valid_index]
+        y_eval = y.loc[eval_index]
+        eval_family_mask = family_mask.loc[eval_index]
+
+        pseudo_pool_reference = aligned_reference_pred.loc[pseudo_pool_index]
+        pseudo_pool_truth = y.loc[pseudo_pool_index]
+        pseudo_pool_component = None if aligned_component_frame is None else aligned_component_frame.loc[pseudo_pool_index]
+        baseline_metrics = _fit_eval_classifier(
+            x_train=x_inner_train,
+            y_train=y_inner_train,
+            x_valid=x_valid,
+            y_valid=y_valid,
+            x_eval=x_eval,
+            y_eval=y_eval,
+            eval_family_mask=eval_family_mask,
+            params=params,
+            early_stopping_rounds=early_stopping_rounds,
+            verbose=verbose,
+        )
+        for upper_threshold, lower_threshold, pseudo_weight in config_grid:
+            selection_index, pseudo_target, selected_reference, selection_metrics = _select_pseudo_rows(
+                y_true=pseudo_pool_truth,
+                reference_pred=pseudo_pool_reference,
+                component_frame=pseudo_pool_component,
+                upper_threshold=float(upper_threshold),
+                lower_threshold=float(lower_threshold),
+                require_teacher_agreement=require_teacher_agreement,
+                max_teacher_std=max_teacher_std,
+                min_selected_rows=int(min_selected_rows),
+            )
+
+            row = {
+                "repeat": int(repeat + 1),
+                "split_seed": int(split_seed),
+                "family_key": str(family_key),
+                "upper_threshold": float(upper_threshold),
+                "lower_threshold": float(lower_threshold),
+                "pseudo_weight": float(pseudo_weight),
+                "label_mode": str(label_mode),
+                "scale_weight_by_confidence": bool(scale_weight_by_confidence),
+                "holdout_rows": int(len(eval_index)),
+                "holdout_family_rows": int(eval_family_mask.sum()),
+                "pseudo_pool_rows": int(len(pseudo_pool_index)),
+                "pseudo_pool_family_rows": int(len(pseudo_pool_index)),
+                "train_real_rows": int(len(inner_train_index)),
+                "valid_rows": int(len(valid_index)),
+                **selection_metrics,
+            }
+
+            row["baseline_global_auc"] = baseline_metrics["global_auc"]
+            row["baseline_family_auc"] = baseline_metrics["family_auc"]
+            row["baseline_best_iteration"] = baseline_metrics["best_iteration"]
+
+            if int(selection_metrics["selected_rows"]) < int(min_selected_rows):
+                row["pseudo_global_auc"] = None
+                row["pseudo_family_auc"] = None
+                row["delta_global_auc"] = None
+                row["delta_family_auc"] = None
+                row["pseudo_best_iteration"] = None
+                row["status"] = "skipped_low_selection"
+                config_rows.append(row)
+                continue
+
+            x_selected_pseudo = x_pseudo_pool.loc[selection_index]
+            pseudo_x, pseudo_y, pseudo_weight_array = _build_pseudo_training_rows(
+                x_selected=x_selected_pseudo,
+                pseudo_target=pseudo_target.loc[selection_index],
+                selected_reference=selected_reference.loc[selection_index],
+                pseudo_weight=float(pseudo_weight),
+                label_mode=label_mode,
+                scale_weight_by_confidence=scale_weight_by_confidence,
+            )
+            combined_x = pd.concat([x_inner_train, pseudo_x], axis=0, ignore_index=False)
+            combined_y = pd.concat([y_inner_train, pseudo_y], axis=0, ignore_index=False)
+            combined_weight = np.concatenate(
+                [
+                    np.ones(len(x_inner_train), dtype="float64"),
+                    pseudo_weight_array,
+                ]
+            )
+            fit_metrics = _fit_eval_classifier(
+                x_train=combined_x,
+                y_train=combined_y,
+                x_valid=x_valid,
+                y_valid=y_valid,
+                x_eval=x_eval,
+                y_eval=y_eval,
+                eval_family_mask=eval_family_mask,
+                params=params,
+                early_stopping_rounds=early_stopping_rounds,
+                verbose=verbose,
+                sample_weight_train=combined_weight,
+            )
+            row["pseudo_global_auc"] = fit_metrics["global_auc"]
+            row["pseudo_family_auc"] = fit_metrics["family_auc"]
+            row["delta_global_auc"] = float(fit_metrics["global_auc"] - baseline_metrics["global_auc"])
+            row["delta_family_auc"] = (
+                None
+                if baseline_metrics["family_auc"] is None or fit_metrics["family_auc"] is None
+                else float(fit_metrics["family_auc"] - baseline_metrics["family_auc"])
+            )
+            row["pseudo_best_iteration"] = fit_metrics["best_iteration"]
+            row["status"] = "ok"
+            config_rows.append(row)
+
+    results_df = pd.DataFrame(config_rows)
+    results_out = ensure_parent_dir(results_csv_path)
+    results_df.to_csv(results_out, index=False)
+
+    valid_rows = results_df.loc[results_df["status"].eq("ok")].copy()
+    summary_rows: list[dict[str, Any]] = []
+    if not valid_rows.empty:
+        group_columns = ["upper_threshold", "lower_threshold", "pseudo_weight"]
+        for (upper_threshold, lower_threshold, pseudo_weight), part in valid_rows.groupby(group_columns, dropna=False):
+            summary_rows.append(
+                {
+                    "upper_threshold": float(upper_threshold),
+                    "lower_threshold": float(lower_threshold),
+                    "pseudo_weight": float(pseudo_weight),
+                    "repeats": int(len(part)),
+                    "mean_delta_global_auc": float(part["delta_global_auc"].mean()),
+                    "std_delta_global_auc": float(part["delta_global_auc"].std(ddof=0)),
+                    "mean_delta_family_auc": (
+                        None
+                        if part["delta_family_auc"].dropna().empty
+                        else float(part["delta_family_auc"].dropna().mean())
+                    ),
+                    "mean_selected_rows": float(part["selected_rows"].mean()),
+                    "mean_selected_accuracy": (
+                        None
+                        if part["selected_accuracy"].dropna().empty
+                        else float(part["selected_accuracy"].dropna().mean())
+                    ),
+                }
+            )
+    summary_df = pd.DataFrame(summary_rows)
+    if not summary_df.empty:
+        summary_df = summary_df.sort_values(
+            by=["mean_delta_global_auc", "mean_delta_family_auc", "mean_selected_accuracy"],
+            ascending=[False, False, False],
+            na_position="last",
+        ).reset_index(drop=True)
+
+    payload: dict[str, Any] = {
+        "train_csv_path": str(train_csv_path),
+        "family_key": str(family_key),
+        "family_rows": int(family_rows),
+        "family_positive_rate": float(family_positive_rate),
+        "feature_blocks": list(normalized_blocks),
+        "holdout_size": float(holdout_size),
+        "valid_size": float(valid_size),
+        "pseudo_pool_fraction": float(pseudo_pool_fraction),
+        "repeats": int(repeats),
+        "random_state": int(random_state),
+        "require_teacher_agreement": bool(require_teacher_agreement),
+        "max_teacher_std": None if max_teacher_std is None else float(max_teacher_std),
+        "min_selected_rows": int(min_selected_rows),
+        "upper_thresholds": [float(value) for value in upper_thresholds],
+        "lower_thresholds": [float(value) for value in lower_thresholds],
+        "pseudo_weights": [float(value) for value in pseudo_weights],
+        "label_mode": str(label_mode),
+        "scale_weight_by_confidence": bool(scale_weight_by_confidence),
+        "results_csv_path": str(results_out),
+        "config_count": int(len(config_grid)),
+        "evaluated_runs": int(len(valid_rows)),
+        "best_config": None if summary_df.empty else summary_df.iloc[0].to_dict(),
+        "config_summary": summary_df.to_dict(orient="records"),
+    }
+    write_json(metrics_path, payload)
+    return payload

--- a/src/churn_baseline/pseudo_labeling.py
+++ b/src/churn_baseline/pseudo_labeling.py
@@ -17,7 +17,10 @@ from .data import infer_categorical_columns, load_csv, prepare_train_features
 from .evaluation import binary_auc
 from .feature_engineering import (
     BLOCK_G,
+    BLOCK_T,
     apply_coverage_backoff_features,
+    apply_ec_surface_fit_features,
+    fit_ec_surface_state,
     fit_coverage_backoff_state,
     normalize_feature_blocks,
     partition_feature_blocks,
@@ -122,7 +125,13 @@ def _apply_stateful_views(
         outputs = {
             name: apply_coverage_backoff_features(frame, coverage_state) for name, frame in outputs.items()
         }
-    unsupported = [block for block in normalized_stateful if block != BLOCK_G]
+    if BLOCK_T in normalized_stateful:
+        surface_state = fit_ec_surface_state(fit_out)
+        fit_out = apply_ec_surface_fit_features(fit_out, surface_state)
+        outputs = {
+            name: apply_ec_surface_fit_features(frame, surface_state) for name, frame in outputs.items()
+        }
+    unsupported = [block for block in normalized_stateful if block not in {BLOCK_G, BLOCK_T}]
     if unsupported:
         raise ValueError(
             "Unsupported stateful feature blocks for pseudo-labeling experiment: "

--- a/src/churn_baseline/rank_reranker.py
+++ b/src/churn_baseline/rank_reranker.py
@@ -1,0 +1,529 @@
+"""Ranking-aware reranker experiments over the incumbent teacher."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+from catboost import CatBoostRanker, Pool
+from sklearn.model_selection import StratifiedKFold
+
+from .artifacts import ensure_parent_dir, write_json
+from .config import CatBoostHyperParams, ID_COLUMN, TARGET_COLUMN
+from .data import infer_categorical_columns, load_csv
+from .diagnostics import _rank_average_predictions
+from .evaluation import binary_auc
+from .feature_engineering import normalize_feature_blocks
+from .pipeline import (
+    STRATIFY_TARGET,
+    _build_stratify_labels,
+    _prepare_train_matrix,
+    _transform_pair_with_stateful_blocks,
+    _transform_single_with_stateful_blocks,
+    normalize_stratify_mode,
+)
+from .specialist import _append_reference_features, _normalize_reference_component_frame
+
+
+PAIR_LOGIT_PAIRWISE = "PairLogitPairwise"
+YETI_RANK_PAIRWISE = "YetiRankPairwise"
+RANK_RERANKER_LOSSES: tuple[str, ...] = (PAIR_LOGIT_PAIRWISE, YETI_RANK_PAIRWISE)
+RANK_RERANKER_QUERY_LEVELS: tuple[str, ...] = (
+    "segment5",
+    "segment3",
+    "contract_internet_tenure",
+    "contract_tenure",
+    "contract",
+    "global",
+)
+
+
+def list_rank_reranker_losses() -> tuple[str, ...]:
+    """Return supported CatBoost ranker loss functions."""
+    return RANK_RERANKER_LOSSES
+
+
+def list_rank_reranker_query_levels() -> tuple[str, ...]:
+    """Return supported hierarchical query levels."""
+    return RANK_RERANKER_QUERY_LEVELS
+
+
+def _build_tenure_bin(tenure_values: pd.Series) -> pd.Series:
+    bins = [-np.inf, 6, 12, 24, 48, np.inf]
+    labels = ["0_6", "7_12", "13_24", "25_48", "49_plus"]
+    return pd.cut(tenure_values, bins=bins, labels=labels).astype(str)
+
+
+def _align_reference_prediction(
+    *,
+    train_ids: pd.Series,
+    reference_pred: pd.Series,
+    index: pd.Index,
+) -> pd.Series:
+    reference_by_id = pd.Series(reference_pred, copy=True)
+    if reference_by_id.index.has_duplicates:
+        duplicate_ids = pd.Index(reference_by_id.index[reference_by_id.index.duplicated()]).unique().tolist()[:5]
+        raise ValueError(
+            "reference_pred must be indexed by unique train ids and represent OOF predictions. "
+            f"Duplicate ids found: {duplicate_ids}"
+        )
+    aligned_reference = train_ids.map(reference_by_id)
+    if aligned_reference.isna().any():
+        missing_ids = train_ids.loc[aligned_reference.isna()].head(5).tolist()
+        raise ValueError(
+            "reference_pred must cover every train id with OOF-aligned predictions. "
+            f"Missing ids: {missing_ids}"
+        )
+    return pd.Series(aligned_reference.values, index=index, dtype="float64", name="reference_pred")
+
+
+def _build_query_candidate_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    contract = frame["Contract"].astype(str)
+    payment = frame["PaymentMethod"].astype(str)
+    internet = frame["InternetService"].astype(str)
+    paperless = frame["PaperlessBilling"].astype(str)
+    tenure = pd.to_numeric(frame["tenure"], errors="coerce").fillna(0.0)
+    tenure_bin = _build_tenure_bin(tenure)
+
+    payment_contract = payment + "__" + contract
+    segment3 = payment_contract + "__" + internet
+    return pd.DataFrame(
+        {
+            "segment5": segment3 + "__" + paperless + "__" + tenure_bin,
+            "segment3": segment3,
+            "contract_internet_tenure": contract + "__" + internet + "__" + tenure_bin,
+            "contract_tenure": contract + "__" + tenure_bin,
+            "contract": contract,
+            "global": pd.Series("__GLOBAL__", index=frame.index, dtype="object"),
+        },
+        index=frame.index,
+    )
+
+
+def _compute_query_eligibility(
+    labels: pd.Series,
+    y: pd.Series,
+    *,
+    min_rows: int,
+    min_positive_rows: int,
+    min_negative_rows: int,
+) -> pd.Series:
+    stats = pd.DataFrame({"label": labels.astype(str), "target": y.astype(int)}, index=y.index)
+    grouped = stats.groupby("label", dropna=False)["target"].agg(["size", "sum"])
+    grouped["neg"] = grouped["size"] - grouped["sum"]
+    eligible_labels = grouped.index[
+        grouped["size"].ge(int(min_rows))
+        & grouped["sum"].ge(int(min_positive_rows))
+        & grouped["neg"].ge(int(min_negative_rows))
+    ]
+    return labels.astype(str).isin(set(eligible_labels))
+
+
+def _assign_query_groups(
+    query_candidates: pd.DataFrame,
+    y: pd.Series,
+    *,
+    min_rows: int,
+    min_positive_rows: int,
+    min_negative_rows: int,
+) -> tuple[np.ndarray, pd.Series, dict[str, int]]:
+    selected_labels = pd.Series("__GLOBAL__", index=query_candidates.index, dtype="object")
+    selected_levels = pd.Series("global", index=query_candidates.index, dtype="object")
+    assigned = pd.Series(False, index=query_candidates.index, dtype=bool)
+
+    hierarchy = ("segment5", "segment3", "contract_internet_tenure", "contract_tenure", "contract")
+    for level_name in hierarchy:
+        labels = query_candidates[level_name].astype(str)
+        eligible = _compute_query_eligibility(
+            labels,
+            y,
+            min_rows=min_rows,
+            min_positive_rows=min_positive_rows,
+            min_negative_rows=min_negative_rows,
+        )
+        take_mask = eligible & ~assigned
+        selected_labels.loc[take_mask] = level_name + "::" + labels.loc[take_mask]
+        selected_levels.loc[take_mask] = level_name
+        assigned.loc[take_mask] = True
+
+    group_ids, _ = pd.factorize(selected_labels.astype(str), sort=False)
+    level_counts = {str(name): int(count) for name, count in selected_levels.value_counts(dropna=False).items()}
+    return group_ids.astype("int64"), selected_levels, level_counts
+
+
+def _sort_grouped_frame(
+    x: pd.DataFrame,
+    y: pd.Series,
+    group_ids: np.ndarray,
+) -> tuple[pd.DataFrame, pd.Series, np.ndarray]:
+    order = np.argsort(group_ids, kind="stable")
+    return x.iloc[order], y.iloc[order], np.asarray(group_ids, dtype="int64")[order]
+
+
+def _build_ranker(
+    *,
+    params: CatBoostHyperParams,
+    loss_function: str,
+) -> CatBoostRanker:
+    loss_value = str(loss_function).strip()
+    if loss_value not in RANK_RERANKER_LOSSES:
+        raise ValueError(f"Unsupported loss_function '{loss_function}'. Available: {RANK_RERANKER_LOSSES}")
+    return CatBoostRanker(
+        iterations=int(params.iterations),
+        learning_rate=float(params.learning_rate),
+        depth=int(params.depth),
+        l2_leaf_reg=float(params.l2_leaf_reg),
+        loss_function=loss_value,
+        eval_metric="PairAccuracy",
+        random_seed=int(params.random_seed),
+        allow_writing_files=False,
+        verbose=False,
+    )
+
+
+def _best_iteration_or_default(model: CatBoostRanker, default_iterations: int) -> int:
+    best_iter = model.get_best_iteration()
+    if best_iter is None or best_iter < 0:
+        return int(default_iterations)
+    return int(best_iter) + 1
+
+
+def _blend_rank_scores(
+    reference_pred: pd.Series,
+    ranker_score: pd.Series,
+    alpha: float,
+) -> pd.Series:
+    pred_matrix = np.column_stack(
+        [
+            reference_pred.astype("float64").to_numpy(),
+            ranker_score.astype("float64").to_numpy(),
+        ]
+    )
+    rank_matrix = np.zeros_like(pred_matrix, dtype="float64")
+    rank_matrix[:, 0] = pd.Series(pred_matrix[:, 0], index=reference_pred.index).rank(method="average").to_numpy(
+        dtype="float64"
+    )
+    rank_matrix[:, 1] = pd.Series(pred_matrix[:, 1], index=ranker_score.index).rank(method="average").to_numpy(
+        dtype="float64"
+    )
+    blended = (1.0 - float(alpha)) * rank_matrix[:, 0] + float(alpha) * rank_matrix[:, 1]
+    return pd.Series(blended, index=reference_pred.index, dtype="float64", name="candidate_score")
+
+
+def _save_model(model: CatBoostRanker, path: str | Path) -> Path:
+    out_path = ensure_parent_dir(path)
+    model.save_model(str(out_path))
+    return out_path
+
+
+def _build_sampled_pairs(
+    y_sorted: pd.Series,
+    group_sorted: np.ndarray,
+    *,
+    max_pairs_per_group: int,
+    random_seed: int,
+) -> np.ndarray:
+    labels = y_sorted.astype(int).to_numpy()
+    groups = np.asarray(group_sorted, dtype="int64")
+    if labels.shape[0] != groups.shape[0]:
+        raise ValueError("labels and group ids must have the same length")
+
+    rng = np.random.default_rng(int(random_seed))
+    pair_chunks: list[np.ndarray] = []
+    start = 0
+    total_rows = len(labels)
+    while start < total_rows:
+        end = start + 1
+        current_group = groups[start]
+        while end < total_rows and groups[end] == current_group:
+            end += 1
+
+        local_labels = labels[start:end]
+        pos_idx = np.flatnonzero(local_labels == 1) + start
+        neg_idx = np.flatnonzero(local_labels == 0) + start
+        if len(pos_idx) > 0 and len(neg_idx) > 0:
+            pair_count = min(int(max_pairs_per_group), int(len(pos_idx) * len(neg_idx)))
+            left = rng.choice(pos_idx, size=pair_count, replace=True)
+            right = rng.choice(neg_idx, size=pair_count, replace=True)
+            pair_chunks.append(np.column_stack([left, right]).astype("int32"))
+        start = end
+
+    if not pair_chunks:
+        raise ValueError("No valid ranking pairs could be generated from query groups")
+    return np.vstack(pair_chunks)
+
+
+def run_rank_reranker_cv(
+    *,
+    train_csv_path: str | Path,
+    model_path: str | Path,
+    metrics_path: str | Path,
+    oof_path: str | Path,
+    params: CatBoostHyperParams,
+    feature_blocks: Sequence[str] | None,
+    reference_pred: pd.Series,
+    reference_component_frame: pd.DataFrame | None,
+    folds: int,
+    random_state: int,
+    early_stopping_rounds: int,
+    verbose: int,
+    loss_function: str,
+    alpha_grid: Sequence[float],
+    stratify_mode: str = STRATIFY_TARGET,
+    min_query_rows: int = 50,
+    min_query_positive_rows: int = 3,
+    min_query_negative_rows: int = 10,
+    max_pairs_per_group: int = 1000,
+    include_logit_reference: bool = True,
+) -> dict[str, Any]:
+    """Train a CatBoost ranker over teacher-aware features and scan rank blends."""
+    if folds < 2:
+        raise ValueError("folds must be >= 2")
+    if not alpha_grid:
+        raise ValueError("alpha_grid must contain at least one value")
+
+    train_df = load_csv(train_csv_path)
+    normalized_blocks, _, stateful_blocks, x_base, y = _prepare_train_matrix(train_df, feature_blocks)
+    normalized_stratify_mode = normalize_stratify_mode(stratify_mode)
+    query_candidates = _build_query_candidate_frame(train_df)
+    aligned_reference = _align_reference_prediction(
+        train_ids=train_df[ID_COLUMN],
+        reference_pred=reference_pred,
+        index=x_base.index,
+    )
+    component_frame = _normalize_reference_component_frame(train_df[ID_COLUMN], reference_component_frame)
+    splitter = StratifiedKFold(
+        n_splits=int(folds),
+        shuffle=True,
+        random_state=int(random_state),
+    )
+    stratify_labels = _build_stratify_labels(
+        x_base,
+        y,
+        stratify_mode=normalized_stratify_mode,
+        min_count=max(int(folds), 2),
+    )
+
+    ranker_oof = pd.Series(index=x_base.index, dtype="float64", name="ranker_oof_score")
+    fold_rows: list[dict[str, Any]] = []
+    fold_iterations: list[int] = []
+    overall_query_level_counts: dict[str, int] = {}
+    disagreement_columns: list[str] = []
+
+    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x_base, stratify_labels), start=1):
+        x_train = x_base.iloc[train_idx]
+        y_train = y.iloc[train_idx]
+        x_valid = x_base.iloc[valid_idx]
+        y_valid = y.iloc[valid_idx]
+        x_train, x_valid = _transform_pair_with_stateful_blocks(x_train, x_valid, stateful_blocks)
+
+        train_reference = aligned_reference.iloc[train_idx]
+        valid_reference = aligned_reference.iloc[valid_idx]
+        train_components = component_frame.iloc[train_idx] if component_frame is not None else None
+        valid_components = component_frame.iloc[valid_idx] if component_frame is not None else None
+        x_train, train_disagreement_columns = _append_reference_features(
+            x_train,
+            reference_pred=train_reference,
+            reference_component_frame=train_components,
+            include_logit=include_logit_reference,
+        )
+        x_valid, valid_disagreement_columns = _append_reference_features(
+            x_valid,
+            reference_pred=valid_reference,
+            reference_component_frame=valid_components,
+            include_logit=include_logit_reference,
+        )
+        disagreement_columns = train_disagreement_columns or valid_disagreement_columns
+
+        train_query_ids, train_levels, train_level_counts = _assign_query_groups(
+            query_candidates.iloc[train_idx],
+            y_train,
+            min_rows=min_query_rows,
+            min_positive_rows=min_query_positive_rows,
+            min_negative_rows=min_query_negative_rows,
+        )
+        valid_query_ids, valid_levels, valid_level_counts = _assign_query_groups(
+            query_candidates.iloc[valid_idx],
+            y_valid,
+            min_rows=min_query_rows,
+            min_positive_rows=min_query_positive_rows,
+            min_negative_rows=min_query_negative_rows,
+        )
+        for name, count in train_level_counts.items():
+            overall_query_level_counts[name] = overall_query_level_counts.get(name, 0) + int(count)
+
+        cat_columns = infer_categorical_columns(x_train)
+        x_train_sorted, y_train_sorted, train_group_sorted = _sort_grouped_frame(x_train, y_train, train_query_ids)
+        x_valid_sorted, y_valid_sorted, valid_group_sorted = _sort_grouped_frame(x_valid, y_valid, valid_query_ids)
+
+        train_pairs = _build_sampled_pairs(
+            y_train_sorted,
+            train_group_sorted,
+            max_pairs_per_group=max_pairs_per_group,
+            random_seed=random_state + fold_number,
+        )
+        valid_pairs = _build_sampled_pairs(
+            y_valid_sorted,
+            valid_group_sorted,
+            max_pairs_per_group=max_pairs_per_group,
+            random_seed=random_state + folds + fold_number,
+        )
+        train_pool = Pool(
+            x_train_sorted,
+            label=y_train_sorted.astype(int),
+            group_id=train_group_sorted,
+            pairs=train_pairs,
+            cat_features=cat_columns,
+        )
+        valid_pool = Pool(
+            x_valid_sorted,
+            label=y_valid_sorted.astype(int),
+            group_id=valid_group_sorted,
+            pairs=valid_pairs,
+            cat_features=cat_columns,
+        )
+
+        model = _build_ranker(params=params, loss_function=loss_function)
+        model.fit(
+            train_pool,
+            eval_set=valid_pool,
+            use_best_model=True,
+            early_stopping_rounds=int(early_stopping_rounds),
+            verbose=int(verbose),
+        )
+        valid_rank_score = pd.Series(model.predict(x_valid), index=x_valid.index, dtype="float64")
+        ranker_oof.iloc[valid_idx] = valid_rank_score
+
+        fold_best_iteration = _best_iteration_or_default(model, params.iterations)
+        fold_iterations.append(int(fold_best_iteration))
+        best_iteration_raw = model.get_best_iteration()
+        fold_rows.append(
+            {
+                "fold": int(fold_number),
+                "train_rows": int(len(train_idx)),
+                "valid_rows": int(len(valid_idx)),
+                "train_query_count": int(len(np.unique(train_query_ids))),
+                "valid_query_count": int(len(np.unique(valid_query_ids))),
+                "train_query_level_counts": train_level_counts,
+                "valid_query_level_counts": valid_level_counts,
+                "reference_auc": float(binary_auc(y_valid, valid_reference)),
+                "ranker_auc": float(binary_auc(y_valid, valid_rank_score)),
+                "train_query_global_share": float(train_levels.eq("global").mean()),
+                "valid_query_global_share": float(valid_levels.eq("global").mean()),
+                "best_iteration": int(best_iteration_raw) if best_iteration_raw is not None and best_iteration_raw >= 0 else -1,
+                "final_iterations": int(fold_best_iteration),
+            }
+        )
+
+    if ranker_oof.isna().any():
+        raise ValueError("OOF ranker predictions contain NaN values")
+
+    alpha_rows: list[dict[str, Any]] = []
+    best_alpha = float(alpha_grid[0])
+    best_auc = float("-inf")
+    best_candidate = pd.Series(dtype="float64")
+    for alpha in alpha_grid:
+        candidate_score = _blend_rank_scores(aligned_reference, ranker_oof, float(alpha))
+        candidate_auc = binary_auc(y, candidate_score)
+        alpha_rows.append(
+            {
+                "alpha": float(alpha),
+                "candidate_oof_auc": float(candidate_auc),
+                "reference_oof_auc": float(binary_auc(y, aligned_reference)),
+                "ranker_oof_auc": float(binary_auc(y, ranker_oof)),
+            }
+        )
+        if candidate_auc > best_auc:
+            best_auc = float(candidate_auc)
+            best_alpha = float(alpha)
+            best_candidate = candidate_score
+
+    x_full = _transform_single_with_stateful_blocks(x_base, stateful_blocks)
+    x_full, _ = _append_reference_features(
+        x_full,
+        reference_pred=aligned_reference,
+        reference_component_frame=component_frame,
+        include_logit=include_logit_reference,
+    )
+    full_query_ids, full_query_levels, full_query_level_counts = _assign_query_groups(
+        query_candidates,
+        y,
+        min_rows=min_query_rows,
+        min_positive_rows=min_query_positive_rows,
+        min_negative_rows=min_query_negative_rows,
+    )
+    full_cat_columns = infer_categorical_columns(x_full)
+    x_full_sorted, y_full_sorted, full_group_sorted = _sort_grouped_frame(x_full, y, full_query_ids)
+    full_pairs = _build_sampled_pairs(
+        y_full_sorted,
+        full_group_sorted,
+        max_pairs_per_group=max_pairs_per_group,
+        random_seed=random_state + 10_000,
+    )
+    full_pool = Pool(
+        x_full_sorted,
+        label=y_full_sorted.astype(int),
+        group_id=full_group_sorted,
+        pairs=full_pairs,
+        cat_features=full_cat_columns,
+    )
+    final_iterations = max(int(np.median(fold_iterations)), 1)
+    full_params = CatBoostHyperParams(
+        iterations=final_iterations,
+        learning_rate=params.learning_rate,
+        depth=params.depth,
+        l2_leaf_reg=params.l2_leaf_reg,
+        random_seed=params.random_seed,
+        loss_function=params.loss_function,
+        eval_metric=params.eval_metric,
+    )
+    full_model = _build_ranker(params=full_params, loss_function=loss_function)
+    full_model.fit(full_pool, verbose=int(verbose))
+    _save_model(full_model, model_path)
+
+    oof_frame = pd.DataFrame(
+        {
+            ID_COLUMN: train_df[ID_COLUMN].values,
+            "target": y.astype(int).values,
+            "reference_pred": aligned_reference.values,
+            "ranker_score": ranker_oof.values,
+            "candidate_score": best_candidate.values,
+        }
+    )
+    ensure_parent_dir(oof_path)
+    oof_frame.to_csv(oof_path, index=False)
+
+    metrics: dict[str, Any] = {
+        "loss_function": str(loss_function),
+        "feature_blocks": list(normalized_blocks),
+        "feature_count": int(x_full.shape[1]),
+        "categorical_columns": full_cat_columns,
+        "teacher_disagreement_columns": list(disagreement_columns),
+        "cv_folds": int(folds),
+        "cv_fold_metrics": fold_rows,
+        "fold_final_iterations": [int(value) for value in fold_iterations],
+        "final_iterations": int(final_iterations),
+        "stratify_mode": normalized_stratify_mode,
+        "min_query_rows": int(min_query_rows),
+        "min_query_positive_rows": int(min_query_positive_rows),
+        "min_query_negative_rows": int(min_query_negative_rows),
+        "max_pairs_per_group": int(max_pairs_per_group),
+        "query_level_counts_cv_train": overall_query_level_counts,
+        "query_level_counts_full_train": full_query_level_counts,
+        "full_train_query_count": int(len(np.unique(full_query_ids))),
+        "full_train_global_share": float(full_query_levels.eq("global").mean()),
+        "reference_oof_auc": float(binary_auc(y, aligned_reference)),
+        "ranker_oof_auc": float(binary_auc(y, ranker_oof)),
+        "candidate_oof_auc": float(best_auc),
+        "delta_vs_reference_oof_auc": float(best_auc - binary_auc(y, aligned_reference)),
+        "best_alpha": float(best_alpha),
+        "alpha_scan": alpha_rows,
+        "model_path": str(model_path),
+        "oof_path": str(oof_path),
+        "target_column": TARGET_COLUMN,
+        "id_column": ID_COLUMN,
+    }
+    write_json(metrics_path, metrics)
+    return metrics

--- a/src/churn_baseline/rank_reranker.py
+++ b/src/churn_baseline/rank_reranker.py
@@ -13,7 +13,6 @@ from sklearn.model_selection import StratifiedKFold
 from .artifacts import ensure_parent_dir, write_json
 from .config import CatBoostHyperParams, ID_COLUMN, TARGET_COLUMN
 from .data import infer_categorical_columns, load_csv
-from .diagnostics import _rank_average_predictions
 from .evaluation import binary_auc
 from .feature_engineering import normalize_feature_blocks
 from .pipeline import (
@@ -24,7 +23,7 @@ from .pipeline import (
     _transform_single_with_stateful_blocks,
     normalize_stratify_mode,
 )
-from .specialist import _append_reference_features, _normalize_reference_component_frame
+from .specialist import _append_reference_features, _normalize_reference_component_frame, build_specialist_mask
 
 
 PAIR_LOGIT_PAIRWISE = "PairLogitPairwise"
@@ -38,6 +37,8 @@ RANK_RERANKER_QUERY_LEVELS: tuple[str, ...] = (
     "contract",
     "global",
 )
+_MIN_LOCAL_RERANK_TRAIN_ROWS = 2000
+_MIN_LOCAL_RERANK_VALID_ROWS = 500
 
 
 def list_rank_reranker_losses() -> tuple[str, ...]:
@@ -190,26 +191,16 @@ def _best_iteration_or_default(model: CatBoostRanker, default_iterations: int) -
     return int(best_iter) + 1
 
 
-def _blend_rank_scores(
+def _reorder_reference_by_rank(
     reference_pred: pd.Series,
     ranker_score: pd.Series,
-    alpha: float,
 ) -> pd.Series:
-    pred_matrix = np.column_stack(
-        [
-            reference_pred.astype("float64").to_numpy(),
-            ranker_score.astype("float64").to_numpy(),
-        ]
-    )
-    rank_matrix = np.zeros_like(pred_matrix, dtype="float64")
-    rank_matrix[:, 0] = pd.Series(pred_matrix[:, 0], index=reference_pred.index).rank(method="average").to_numpy(
-        dtype="float64"
-    )
-    rank_matrix[:, 1] = pd.Series(pred_matrix[:, 1], index=ranker_score.index).rank(method="average").to_numpy(
-        dtype="float64"
-    )
-    blended = (1.0 - float(alpha)) * rank_matrix[:, 0] + float(alpha) * rank_matrix[:, 1]
-    return pd.Series(blended, index=reference_pred.index, dtype="float64", name="candidate_score")
+    reference_values = reference_pred.astype("float64").to_numpy()
+    sorted_reference = np.sort(reference_values)
+    order = np.argsort(ranker_score.astype("float64").to_numpy(), kind="mergesort")
+    reordered = np.empty_like(sorted_reference)
+    reordered[order] = sorted_reference
+    return pd.Series(reordered, index=reference_pred.index, dtype="float64", name="candidate_score")
 
 
 def _save_model(model: CatBoostRanker, path: str | Path) -> Path:
@@ -277,6 +268,7 @@ def run_rank_reranker_cv(
     min_query_negative_rows: int = 10,
     max_pairs_per_group: int = 1000,
     include_logit_reference: bool = True,
+    preset: str | None = None,
 ) -> dict[str, Any]:
     """Train a CatBoost ranker over teacher-aware features and scan rank blends."""
     if folds < 2:
@@ -288,6 +280,16 @@ def run_rank_reranker_cv(
     normalized_blocks, _, stateful_blocks, x_base, y = _prepare_train_matrix(train_df, feature_blocks)
     normalized_stratify_mode = normalize_stratify_mode(stratify_mode)
     query_candidates = _build_query_candidate_frame(train_df)
+    local_mask = None
+    if preset is not None:
+        local_mask = build_specialist_mask(train_df, preset).astype(bool)
+        local_rows = int(local_mask.sum())
+        if local_rows < _MIN_LOCAL_RERANK_TRAIN_ROWS:
+            raise ValueError(
+                f"Preset '{preset}' selects only {local_rows} rows. Minimum required: {_MIN_LOCAL_RERANK_TRAIN_ROWS}"
+            )
+        if y.loc[local_mask].nunique() < 2:
+            raise ValueError(f"Preset '{preset}' must contain both classes.")
     aligned_reference = _align_reference_prediction(
         train_ids=train_df[ID_COLUMN],
         reference_pred=reference_pred,
@@ -337,16 +339,47 @@ def run_rank_reranker_cv(
         )
         disagreement_columns = train_disagreement_columns or valid_disagreement_columns
 
+        train_local_mask = None if local_mask is None else local_mask.iloc[train_idx].to_numpy(dtype=bool)
+        valid_local_mask = None if local_mask is None else local_mask.iloc[valid_idx].to_numpy(dtype=bool)
+        if train_local_mask is not None:
+            local_train_rows = int(np.sum(train_local_mask))
+            local_valid_rows = int(np.sum(valid_local_mask))
+            if local_train_rows < _MIN_LOCAL_RERANK_TRAIN_ROWS:
+                raise ValueError(
+                    f"Fold {fold_number} preset '{preset}' train rows {local_train_rows} below minimum."
+                )
+            if local_valid_rows < _MIN_LOCAL_RERANK_VALID_ROWS:
+                raise ValueError(
+                    f"Fold {fold_number} preset '{preset}' valid rows {local_valid_rows} below minimum."
+                )
+            x_train_fit = x_train.iloc[train_local_mask]
+            y_train_fit = y_train.iloc[train_local_mask]
+            x_valid_fit = x_valid.iloc[valid_local_mask]
+            y_valid_fit = y_valid.iloc[valid_local_mask]
+            train_reference_eval = train_reference.iloc[train_local_mask]
+            valid_reference_eval = valid_reference.iloc[valid_local_mask]
+            train_query_frame = query_candidates.iloc[train_idx].iloc[train_local_mask]
+            valid_query_frame = query_candidates.iloc[valid_idx].iloc[valid_local_mask]
+        else:
+            x_train_fit = x_train
+            y_train_fit = y_train
+            x_valid_fit = x_valid
+            y_valid_fit = y_valid
+            train_reference_eval = train_reference
+            valid_reference_eval = valid_reference
+            train_query_frame = query_candidates.iloc[train_idx]
+            valid_query_frame = query_candidates.iloc[valid_idx]
+
         train_query_ids, train_levels, train_level_counts = _assign_query_groups(
-            query_candidates.iloc[train_idx],
-            y_train,
+            train_query_frame,
+            y_train_fit,
             min_rows=min_query_rows,
             min_positive_rows=min_query_positive_rows,
             min_negative_rows=min_query_negative_rows,
         )
         valid_query_ids, valid_levels, valid_level_counts = _assign_query_groups(
-            query_candidates.iloc[valid_idx],
-            y_valid,
+            valid_query_frame,
+            y_valid_fit,
             min_rows=min_query_rows,
             min_positive_rows=min_query_positive_rows,
             min_negative_rows=min_query_negative_rows,
@@ -354,9 +387,17 @@ def run_rank_reranker_cv(
         for name, count in train_level_counts.items():
             overall_query_level_counts[name] = overall_query_level_counts.get(name, 0) + int(count)
 
-        cat_columns = infer_categorical_columns(x_train)
-        x_train_sorted, y_train_sorted, train_group_sorted = _sort_grouped_frame(x_train, y_train, train_query_ids)
-        x_valid_sorted, y_valid_sorted, valid_group_sorted = _sort_grouped_frame(x_valid, y_valid, valid_query_ids)
+        cat_columns = infer_categorical_columns(x_train_fit)
+        x_train_sorted, y_train_sorted, train_group_sorted = _sort_grouped_frame(
+            x_train_fit,
+            y_train_fit,
+            train_query_ids,
+        )
+        x_valid_sorted, y_valid_sorted, valid_group_sorted = _sort_grouped_frame(
+            x_valid_fit,
+            y_valid_fit,
+            valid_query_ids,
+        )
 
         train_pairs = _build_sampled_pairs(
             y_train_sorted,
@@ -393,8 +434,11 @@ def run_rank_reranker_cv(
             early_stopping_rounds=int(early_stopping_rounds),
             verbose=int(verbose),
         )
-        valid_rank_score = pd.Series(model.predict(x_valid), index=x_valid.index, dtype="float64")
-        ranker_oof.iloc[valid_idx] = valid_rank_score
+        valid_rank_score = pd.Series(model.predict(x_valid_fit), index=x_valid_fit.index, dtype="float64")
+        if valid_local_mask is not None:
+            ranker_oof.iloc[np.asarray(valid_idx)[valid_local_mask]] = valid_rank_score.values
+        else:
+            ranker_oof.iloc[valid_idx] = valid_rank_score.values
 
         fold_best_iteration = _best_iteration_or_default(model, params.iterations)
         fold_iterations.append(int(fold_best_iteration))
@@ -402,14 +446,14 @@ def run_rank_reranker_cv(
         fold_rows.append(
             {
                 "fold": int(fold_number),
-                "train_rows": int(len(train_idx)),
-                "valid_rows": int(len(valid_idx)),
+                "train_rows": int(len(y_train_fit)),
+                "valid_rows": int(len(y_valid_fit)),
                 "train_query_count": int(len(np.unique(train_query_ids))),
                 "valid_query_count": int(len(np.unique(valid_query_ids))),
                 "train_query_level_counts": train_level_counts,
                 "valid_query_level_counts": valid_level_counts,
-                "reference_auc": float(binary_auc(y_valid, valid_reference)),
-                "ranker_auc": float(binary_auc(y_valid, valid_rank_score)),
+                "reference_auc": float(binary_auc(y_valid_fit, valid_reference_eval)),
+                "ranker_auc": float(binary_auc(y_valid_fit, valid_rank_score)),
                 "train_query_global_share": float(train_levels.eq("global").mean()),
                 "valid_query_global_share": float(valid_levels.eq("global").mean()),
                 "best_iteration": int(best_iteration_raw) if best_iteration_raw is not None and best_iteration_raw >= 0 else -1,
@@ -417,22 +461,36 @@ def run_rank_reranker_cv(
             }
         )
 
-    if ranker_oof.isna().any():
-        raise ValueError("OOF ranker predictions contain NaN values")
+    scoring_mask = local_mask if local_mask is not None else pd.Series(True, index=x_base.index, dtype=bool)
+    if ranker_oof.loc[scoring_mask].isna().any():
+        raise ValueError("OOF ranker predictions contain NaN values on the scoring mask")
+    reference_auc_on_mask = binary_auc(y.loc[scoring_mask], aligned_reference.loc[scoring_mask])
+    ranker_auc_on_mask = binary_auc(y.loc[scoring_mask], ranker_oof.loc[scoring_mask])
 
     alpha_rows: list[dict[str, Any]] = []
     best_alpha = float(alpha_grid[0])
     best_auc = float("-inf")
-    best_candidate = pd.Series(dtype="float64")
+    best_candidate = aligned_reference.copy()
     for alpha in alpha_grid:
-        candidate_score = _blend_rank_scores(aligned_reference, ranker_oof, float(alpha))
+        candidate_score = aligned_reference.copy()
+        reordered_reference = _reorder_reference_by_rank(
+            aligned_reference.loc[scoring_mask],
+            ranker_oof.loc[scoring_mask],
+        )
+        candidate_score.loc[scoring_mask] = (
+            (1.0 - float(alpha)) * aligned_reference.loc[scoring_mask].astype("float64")
+            + float(alpha) * reordered_reference
+        ).values
         candidate_auc = binary_auc(y, candidate_score)
+        candidate_auc_on_mask = binary_auc(y.loc[scoring_mask], candidate_score.loc[scoring_mask])
         alpha_rows.append(
             {
                 "alpha": float(alpha),
                 "candidate_oof_auc": float(candidate_auc),
+                "candidate_oof_auc_on_mask": float(candidate_auc_on_mask),
                 "reference_oof_auc": float(binary_auc(y, aligned_reference)),
-                "ranker_oof_auc": float(binary_auc(y, ranker_oof)),
+                "reference_oof_auc_on_mask": float(reference_auc_on_mask),
+                "ranker_oof_auc_on_mask": float(ranker_auc_on_mask),
             }
         )
         if candidate_auc > best_auc:
@@ -447,15 +505,23 @@ def run_rank_reranker_cv(
         reference_component_frame=component_frame,
         include_logit=include_logit_reference,
     )
+    if local_mask is not None:
+        x_full_fit = x_full.loc[local_mask]
+        y_full_fit = y.loc[local_mask]
+        full_query_frame = query_candidates.loc[local_mask]
+    else:
+        x_full_fit = x_full
+        y_full_fit = y
+        full_query_frame = query_candidates
     full_query_ids, full_query_levels, full_query_level_counts = _assign_query_groups(
-        query_candidates,
-        y,
+        full_query_frame,
+        y_full_fit,
         min_rows=min_query_rows,
         min_positive_rows=min_query_positive_rows,
         min_negative_rows=min_query_negative_rows,
     )
-    full_cat_columns = infer_categorical_columns(x_full)
-    x_full_sorted, y_full_sorted, full_group_sorted = _sort_grouped_frame(x_full, y, full_query_ids)
+    full_cat_columns = infer_categorical_columns(x_full_fit)
+    x_full_sorted, y_full_sorted, full_group_sorted = _sort_grouped_frame(x_full_fit, y_full_fit, full_query_ids)
     full_pairs = _build_sampled_pairs(
         y_full_sorted,
         full_group_sorted,
@@ -487,6 +553,7 @@ def run_rank_reranker_cv(
         {
             ID_COLUMN: train_df[ID_COLUMN].values,
             "target": y.astype(int).values,
+            "is_scoring_mask": scoring_mask.astype(int).values,
             "reference_pred": aligned_reference.values,
             "ranker_score": ranker_oof.values,
             "candidate_score": best_candidate.values,
@@ -497,8 +564,9 @@ def run_rank_reranker_cv(
 
     metrics: dict[str, Any] = {
         "loss_function": str(loss_function),
+        "preset": str(preset) if preset is not None else None,
         "feature_blocks": list(normalized_blocks),
-        "feature_count": int(x_full.shape[1]),
+        "feature_count": int(x_full_fit.shape[1]),
         "categorical_columns": full_cat_columns,
         "teacher_disagreement_columns": list(disagreement_columns),
         "cv_folds": int(folds),
@@ -514,9 +582,13 @@ def run_rank_reranker_cv(
         "query_level_counts_full_train": full_query_level_counts,
         "full_train_query_count": int(len(np.unique(full_query_ids))),
         "full_train_global_share": float(full_query_levels.eq("global").mean()),
+        "scoring_mask_rows": int(scoring_mask.sum()),
+        "scoring_mask_share": float(scoring_mask.mean()),
         "reference_oof_auc": float(binary_auc(y, aligned_reference)),
-        "ranker_oof_auc": float(binary_auc(y, ranker_oof)),
+        "reference_oof_auc_on_mask": float(reference_auc_on_mask),
+        "ranker_oof_auc_on_mask": float(ranker_auc_on_mask),
         "candidate_oof_auc": float(best_auc),
+        "candidate_oof_auc_on_mask": float(binary_auc(y.loc[scoring_mask], best_candidate.loc[scoring_mask])),
         "delta_vs_reference_oof_auc": float(best_auc - binary_auc(y, aligned_reference)),
         "best_alpha": float(best_alpha),
         "alpha_scan": alpha_rows,

--- a/src/churn_baseline/specialist.py
+++ b/src/churn_baseline/specialist.py
@@ -51,6 +51,7 @@ EC_MTM_DSL_PAPERLESS_ANY = "ec_mtm_dsl_paperless_any"
 CLASSIFIER = "classifier"
 RESIDUAL = "residual"
 FEATURE = "feature"
+GATED = "gated"
 
 SPECIALIST_PRESETS: dict[str, str] = {
     EARLY_MANUAL_INTERNET: (
@@ -115,7 +116,7 @@ _MIN_SPECIALIST_VALID_ROWS = 500
 PLATT = "platt"
 ISOTONIC = "isotonic"
 CALIBRATION_METHODS: tuple[str, ...] = (PLATT, ISOTONIC)
-SPECIALIST_APPROACHES: tuple[str, ...] = (CLASSIFIER, RESIDUAL, FEATURE)
+SPECIALIST_APPROACHES: tuple[str, ...] = (CLASSIFIER, RESIDUAL, FEATURE, GATED)
 _TEACHER_COMPONENT_PREFIX = "teacher_component_"
 
 
@@ -505,6 +506,41 @@ def _append_family_stack_features(
     return out
 
 
+def _append_family_gating_features(
+    x: pd.DataFrame,
+    *,
+    specialist_mask: pd.Series,
+    reference_pred: pd.Series,
+) -> tuple[pd.DataFrame, list[str]]:
+    out = x.copy()
+    specialist_mask_aligned = specialist_mask.reindex(out.index).fillna(False).astype(bool)
+    reference_pred_aligned = reference_pred.reindex(out.index).astype("float64")
+
+    family_reference_delta = pd.Series(0.0, index=out.index, dtype="float64")
+    family_reference_delta.loc[specialist_mask_aligned] = (
+        reference_pred_aligned.loc[specialist_mask_aligned].astype("float64").values - 0.5
+    )
+
+    gating_columns = ["family_focus_mask", "family_focus_reference_delta"]
+    out[gating_columns[0]] = specialist_mask_aligned.astype("int8").values
+    out[gating_columns[1]] = family_reference_delta.astype("float64").values
+    return out, gating_columns
+
+
+def _build_family_sample_weight(
+    index: pd.Index,
+    *,
+    specialist_mask: pd.Series,
+    family_weight: float,
+) -> pd.Series:
+    if float(family_weight) <= 0.0:
+        raise ValueError(f"family_weight must be > 0, got {family_weight}")
+    specialist_mask_aligned = specialist_mask.reindex(index).fillna(False).astype(bool)
+    weights = np.ones(len(index), dtype="float64")
+    weights[specialist_mask_aligned.to_numpy(dtype=bool)] = float(family_weight)
+    return pd.Series(weights, index=index, dtype="float64", name="sample_weight")
+
+
 def _fit_specialist_classifier_bundle(
     *,
     train_csv_path: str | Path,
@@ -815,6 +851,276 @@ def run_specialist_override_cv(
         "delta_vs_reference_oof_auc": float(binary_auc(y, candidate_best) - binary_auc(y, reference_pred)),
         "model_path": str(model_path),
         "oof_path": str(oof_path),
+        "target_column": TARGET_COLUMN,
+        "id_column": ID_COLUMN,
+    }
+    write_json(metrics_path, metrics)
+    return metrics
+
+
+def run_gated_challenger_cv(
+    *,
+    train_csv_path: str | Path,
+    preset: str,
+    reference_pred: pd.Series,
+    reference_component_frame: pd.DataFrame | None,
+    params: CatBoostHyperParams,
+    feature_blocks: Sequence[str] | None,
+    folds: int,
+    random_state: int,
+    early_stopping_rounds: int,
+    verbose: int,
+    alpha_grid: Sequence[float],
+    family_weight: float,
+    model_path: str | Path,
+    metrics_path: str | Path,
+    oof_path: str | Path,
+) -> dict[str, Any]:
+    """Train a global challenger with family gating features and weighted loss."""
+    if folds < 2:
+        raise ValueError("folds must be >= 2")
+
+    train_df = load_csv(train_csv_path)
+    normalized_blocks, _, stateful_blocks, x, y = _prepare_train_matrix(train_df, feature_blocks)
+    specialist_mask = build_specialist_mask(train_df, preset).astype(bool)
+    mask_rows = int(specialist_mask.sum())
+    if mask_rows < _MIN_SPECIALIST_TRAIN_ROWS:
+        raise ValueError(
+            f"Preset '{preset}' selects only {mask_rows} rows. Minimum required: {_MIN_SPECIALIST_TRAIN_ROWS}"
+        )
+    if y.loc[specialist_mask].nunique() < 2:
+        raise ValueError(f"Preset '{preset}' must contain both classes.")
+
+    reference_by_id = pd.Series(reference_pred, copy=True)
+    reference_pred_aligned = train_df[ID_COLUMN].map(reference_by_id)
+    if reference_pred_aligned.isna().any():
+        missing_ids = train_df.loc[reference_pred_aligned.isna(), ID_COLUMN].head(5).tolist()
+        raise ValueError(f"reference_pred missing ids from train: {missing_ids}")
+    reference_pred_aligned = pd.Series(
+        reference_pred_aligned.values,
+        index=x.index,
+        dtype="float64",
+        name="reference_pred",
+    )
+    component_frame = _normalize_reference_component_frame(train_df[ID_COLUMN], reference_component_frame)
+
+    splitter = StratifiedKFold(n_splits=folds, shuffle=True, random_state=random_state)
+    challenger_pred = pd.Series(index=x.index, dtype="float64", name="challenger_pred")
+    fold_rows: list[dict[str, Any]] = []
+    fold_iterations: list[int] = []
+    disagreement_columns: list[str] = []
+    gating_columns: list[str] = []
+
+    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x, y), start=1):
+        x_train = x.iloc[train_idx]
+        y_train = y.iloc[train_idx]
+        x_valid = x.iloc[valid_idx]
+        y_valid = y.iloc[valid_idx]
+        x_train, x_valid = _transform_pair_with_stateful_blocks(x_train, x_valid, stateful_blocks)
+
+        train_reference = reference_pred_aligned.iloc[train_idx]
+        valid_reference = reference_pred_aligned.iloc[valid_idx]
+        train_components = component_frame.iloc[train_idx] if component_frame is not None else None
+        valid_components = component_frame.iloc[valid_idx] if component_frame is not None else None
+        x_train, train_disagreement_columns = _append_reference_features(
+            x_train,
+            reference_pred=train_reference,
+            reference_component_frame=train_components,
+            include_logit=True,
+        )
+        x_valid, valid_disagreement_columns = _append_reference_features(
+            x_valid,
+            reference_pred=valid_reference,
+            reference_component_frame=valid_components,
+            include_logit=True,
+        )
+        if train_disagreement_columns != valid_disagreement_columns:
+            raise RuntimeError("Teacher disagreement feature mismatch between train and valid folds.")
+        if not disagreement_columns:
+            disagreement_columns = list(train_disagreement_columns)
+
+        x_train, train_gating_columns = _append_family_gating_features(
+            x_train,
+            specialist_mask=specialist_mask.iloc[train_idx],
+            reference_pred=train_reference,
+        )
+        x_valid, valid_gating_columns = _append_family_gating_features(
+            x_valid,
+            specialist_mask=specialist_mask.iloc[valid_idx],
+            reference_pred=valid_reference,
+        )
+        if train_gating_columns != valid_gating_columns:
+            raise RuntimeError("Family gating feature mismatch between train and valid folds.")
+        if not gating_columns:
+            gating_columns = list(train_gating_columns)
+
+        sample_weight_train = _build_family_sample_weight(
+            x_train.index,
+            specialist_mask=specialist_mask.iloc[train_idx],
+            family_weight=family_weight,
+        )
+        sample_weight_valid = _build_family_sample_weight(
+            x_valid.index,
+            specialist_mask=specialist_mask.iloc[valid_idx],
+            family_weight=family_weight,
+        )
+        cat_columns = infer_categorical_columns(x_train)
+        fold_model = fit_with_validation(
+            x_train=x_train,
+            y_train=y_train,
+            x_valid=x_valid,
+            y_valid=y_valid,
+            cat_columns=cat_columns,
+            params=CatBoostHyperParams(
+                iterations=params.iterations,
+                learning_rate=params.learning_rate,
+                depth=params.depth,
+                l2_leaf_reg=params.l2_leaf_reg,
+                random_seed=random_state,
+                loss_function=params.loss_function,
+                eval_metric=params.eval_metric,
+            ),
+            early_stopping_rounds=early_stopping_rounds,
+            verbose=verbose,
+            sample_weight_train=sample_weight_train,
+            sample_weight_valid=sample_weight_valid,
+        )
+
+        fold_pred = predict_proba(fold_model, x_valid)
+        challenger_pred.iloc[valid_idx] = fold_pred.values
+
+        fold_final_iterations = best_iteration_or_default(fold_model, params.iterations)
+        best_iteration = fold_model.get_best_iteration()
+        if best_iteration is None or best_iteration < 0:
+            best_iteration = fold_final_iterations - 1
+        fold_iterations.append(fold_final_iterations)
+
+        valid_mask = specialist_mask.iloc[valid_idx].to_numpy(dtype=bool)
+        fold_rows.append(
+            {
+                "fold": fold_number,
+                "valid_rows": int(len(valid_idx)),
+                "valid_mask_rows": int(np.sum(valid_mask)),
+                "family_weight": float(family_weight),
+                "reference_auc": binary_auc(y_valid, reference_pred_aligned.iloc[valid_idx]),
+                "challenger_auc": binary_auc(y_valid, fold_pred),
+                "reference_auc_on_mask": binary_auc(y_valid.iloc[valid_mask], reference_pred_aligned.iloc[valid_idx].iloc[valid_mask]),
+                "challenger_auc_on_mask": binary_auc(y_valid.iloc[valid_mask], fold_pred.iloc[valid_mask]),
+                "best_iteration": int(best_iteration),
+                "final_iterations": int(fold_final_iterations),
+            }
+        )
+
+    if challenger_pred.isna().any():
+        raise RuntimeError("Gated challenger OOF predictions contain missing values.")
+
+    alpha_scan_rows: list[dict[str, Any]] = []
+    for alpha in alpha_grid:
+        alpha_value = float(alpha)
+        candidate = ((1.0 - alpha_value) * reference_pred_aligned + alpha_value * challenger_pred).astype("float64")
+        alpha_scan_rows.append(
+            {
+                "alpha": alpha_value,
+                "oof_auc": binary_auc(y, candidate),
+                "oof_auc_on_mask": binary_auc(y.loc[specialist_mask], candidate.loc[specialist_mask]),
+                "reference_auc_on_mask": binary_auc(y.loc[specialist_mask], reference_pred_aligned.loc[specialist_mask]),
+            }
+        )
+
+    best_alpha_row = max(alpha_scan_rows, key=lambda row: row["oof_auc"])
+    best_alpha = float(best_alpha_row["alpha"])
+    candidate_best = ((1.0 - best_alpha) * reference_pred_aligned + best_alpha * challenger_pred).astype("float64")
+
+    x_full = _transform_single_with_stateful_blocks(x, stateful_blocks)
+    x_full, disagreement_columns_full = _append_reference_features(
+        x_full,
+        reference_pred=reference_pred_aligned,
+        reference_component_frame=component_frame,
+        include_logit=True,
+    )
+    if disagreement_columns and disagreement_columns_full != disagreement_columns:
+        raise RuntimeError("Teacher disagreement feature mismatch between CV folds and full train.")
+    if not disagreement_columns:
+        disagreement_columns = list(disagreement_columns_full)
+
+    x_full, gating_columns_full = _append_family_gating_features(
+        x_full,
+        specialist_mask=specialist_mask,
+        reference_pred=reference_pred_aligned,
+    )
+    if gating_columns and gating_columns_full != gating_columns:
+        raise RuntimeError("Family gating feature mismatch between CV folds and full train.")
+    if not gating_columns:
+        gating_columns = list(gating_columns_full)
+
+    sample_weight_full = _build_family_sample_weight(
+        x_full.index,
+        specialist_mask=specialist_mask,
+        family_weight=family_weight,
+    )
+    cat_columns = infer_categorical_columns(x_full)
+    final_iterations = max(int(round(float(np.mean(fold_iterations)))), 1)
+    full_model = fit_full_train(
+        x_train=x_full,
+        y_train=y,
+        cat_columns=cat_columns,
+        params=CatBoostHyperParams(
+            iterations=final_iterations,
+            learning_rate=params.learning_rate,
+            depth=params.depth,
+            l2_leaf_reg=params.l2_leaf_reg,
+            random_seed=params.random_seed,
+            loss_function=params.loss_function,
+            eval_metric=params.eval_metric,
+        ),
+        verbose=verbose,
+        sample_weight=sample_weight_full,
+    )
+    save_model(full_model, model_path)
+
+    oof_output = pd.DataFrame(
+        {
+            ID_COLUMN: train_df[ID_COLUMN].values,
+            "target": y.astype(int).values,
+            "specialist_mask": specialist_mask.astype("int8").values,
+            "reference_pred": reference_pred_aligned.values,
+            "challenger_pred": challenger_pred.values,
+            "candidate_pred": candidate_best.values,
+        }
+    )
+    oof_out_path = ensure_parent_dir(oof_path)
+    oof_output.to_csv(oof_out_path, index=False)
+
+    metrics: dict[str, Any] = {
+        "preset": preset,
+        "preset_description": SPECIALIST_PRESETS[preset],
+        "approach": GATED,
+        "train_rows": int(len(train_df)),
+        "specialist_rows": mask_rows,
+        "specialist_row_share": float(mask_rows / max(len(train_df), 1)),
+        "specialist_positive_rate": float(y.loc[specialist_mask].mean()),
+        "family_weight": float(family_weight),
+        "feature_count": int(x_full.shape[1]),
+        "feature_columns": list(x_full.columns),
+        "feature_blocks": list(normalized_blocks),
+        "teacher_disagreement_columns": disagreement_columns,
+        "family_gating_columns": gating_columns,
+        "categorical_columns": cat_columns,
+        "cv_folds": int(folds),
+        "cv_fold_metrics": fold_rows,
+        "fold_final_iterations": [int(value) for value in fold_iterations],
+        "final_iterations": int(final_iterations),
+        "alpha_scan": alpha_scan_rows,
+        "best_alpha": best_alpha,
+        "reference_oof_auc": binary_auc(y, reference_pred_aligned),
+        "reference_oof_auc_on_mask": binary_auc(y.loc[specialist_mask], reference_pred_aligned.loc[specialist_mask]),
+        "challenger_oof_auc": binary_auc(y, challenger_pred),
+        "challenger_oof_auc_on_mask": binary_auc(y.loc[specialist_mask], challenger_pred.loc[specialist_mask]),
+        "candidate_oof_auc": binary_auc(y, candidate_best),
+        "candidate_oof_auc_on_mask": binary_auc(y.loc[specialist_mask], candidate_best.loc[specialist_mask]),
+        "delta_vs_reference_oof_auc": float(binary_auc(y, candidate_best) - binary_auc(y, reference_pred_aligned)),
+        "model_path": str(model_path),
+        "oof_path": str(oof_out_path),
         "target_column": TARGET_COLUMN,
         "id_column": ID_COLUMN,
     }

--- a/src/churn_baseline/specialist.py
+++ b/src/churn_baseline/specialist.py
@@ -1,0 +1,1506 @@
+"""Specialist-model experiments for hard churn cohorts."""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+from catboost import CatBoostRegressor
+from sklearn.isotonic import IsotonicRegression
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import StratifiedKFold
+
+from .artifacts import ensure_parent_dir, write_json
+from .config import CatBoostHyperParams, ID_COLUMN, TARGET_COLUMN
+from .data import infer_categorical_columns, load_csv
+from .evaluation import binary_auc
+from .feature_engineering import normalize_feature_blocks, partition_feature_blocks
+from .modeling import best_iteration_or_default, fit_full_train, fit_with_validation, load_model, predict_proba, save_model
+from .pipeline import _prepare_test_matrix, _prepare_train_matrix, _transform_pair_with_stateful_blocks, _transform_single_with_stateful_blocks
+
+
+EARLY_MANUAL_INTERNET = "early_manual_internet"
+EARLY_ALL_INTERNET = "early_all_internet"
+FIBER_PAPERLESS_EARLY = "fiber_paperless_early"
+LATE_MTM_FIBER = "late_mtm_fiber"
+LATE_MTM_FIBER_PAPERLESS = "late_mtm_fiber_paperless"
+LONG_FIBER_ANY = "long_fiber_any"
+MANUAL_NO_INTERNET = "manual_no_internet"
+ONE_YEAR_FIBER_ANY = "one_year_fiber_any"
+ONE_YEAR_DSL_ANY = "one_year_dsl_any"
+TWO_YEAR_FIBER_ANY = "two_year_fiber_any"
+ONE_YEAR_FIBER_PAPERLESS_49PLUS = "one_year_fiber_paperless_49plus"
+TWO_YEAR_FIBER_PAPERLESS_49PLUS = "two_year_fiber_paperless_49plus"
+MTM_DSL_PAPERLESS_25_48_MANUAL = "mtm_dsl_paperless_25_48_manual"
+MTM_NOINTERNET_MAILED_0_24 = "mtm_nointernet_mailed_0_24"
+CLASSIFIER = "classifier"
+RESIDUAL = "residual"
+
+SPECIALIST_PRESETS: dict[str, str] = {
+    EARLY_MANUAL_INTERNET: (
+        "Month-to-month, internet activo, tenure <= 24, payment manual "
+        "(Electronic check o Mailed check)."
+    ),
+    EARLY_ALL_INTERNET: "Month-to-month, internet activo, tenure <= 24.",
+    FIBER_PAPERLESS_EARLY: (
+        "Month-to-month, Fiber optic, PaperlessBilling=Yes, tenure <= 24."
+    ),
+    LATE_MTM_FIBER: "Month-to-month, Fiber optic, tenure > 24.",
+    LATE_MTM_FIBER_PAPERLESS: (
+        "Month-to-month, Fiber optic, PaperlessBilling=Yes, tenure > 24."
+    ),
+    LONG_FIBER_ANY: "One year o Two year, Fiber optic, tenure > 24.",
+    MANUAL_NO_INTERNET: "InternetService=No con payment manual (Electronic o Mailed check).",
+    ONE_YEAR_FIBER_ANY: "One year, Fiber optic, cualquier tenure.",
+    ONE_YEAR_DSL_ANY: "One year, DSL, cualquier tenure.",
+    TWO_YEAR_FIBER_ANY: "Two year, Fiber optic, cualquier tenure.",
+    ONE_YEAR_FIBER_PAPERLESS_49PLUS: "One year, Fiber optic, PaperlessBilling=Yes, tenure >= 49.",
+    TWO_YEAR_FIBER_PAPERLESS_49PLUS: "Two year, Fiber optic, PaperlessBilling=Yes, tenure >= 49.",
+    MTM_DSL_PAPERLESS_25_48_MANUAL: (
+        "Month-to-month, DSL, PaperlessBilling=Yes, tenure 25-48, "
+        "payment manual (Electronic check o Mailed check)."
+    ),
+    MTM_NOINTERNET_MAILED_0_24: (
+        "Month-to-month, InternetService=No, Mailed check, tenure <= 24."
+    ),
+}
+
+_MIN_SPECIALIST_TRAIN_ROWS = 2000
+_MIN_SPECIALIST_VALID_ROWS = 500
+PLATT = "platt"
+ISOTONIC = "isotonic"
+CALIBRATION_METHODS: tuple[str, ...] = (PLATT, ISOTONIC)
+SPECIALIST_APPROACHES: tuple[str, ...] = (CLASSIFIER, RESIDUAL)
+_TEACHER_COMPONENT_PREFIX = "teacher_component_"
+
+
+def list_specialist_presets() -> dict[str, str]:
+    """Return supported specialist presets and descriptions."""
+    return dict(SPECIALIST_PRESETS)
+
+
+def list_calibration_methods() -> tuple[str, ...]:
+    """Return supported local calibration methods."""
+    return CALIBRATION_METHODS
+
+
+def list_specialist_approaches() -> tuple[str, ...]:
+    """Return supported local specialist experiment approaches."""
+    return SPECIALIST_APPROACHES
+
+
+def normalize_binary_target(target: pd.Series) -> pd.Series:
+    """Normalize binary target to 0/1 integers."""
+    if pd.api.types.is_numeric_dtype(target):
+        unique_values = set(pd.Series(target).dropna().astype(int).unique().tolist())
+        if unique_values.issubset({0, 1}):
+            return pd.Series(target, copy=True).astype(int)
+
+    mapped = target.astype(str).map({"Yes": 1, "No": 0})
+    if mapped.isna().any():
+        sample = target.loc[mapped.isna()].astype(str).unique().tolist()[:5]
+        raise ValueError(f"Unsupported target labels for binary normalization: {sample}")
+    return mapped.astype(int)
+
+
+def build_specialist_mask(frame: pd.DataFrame, preset: str) -> pd.Series:
+    """Build boolean mask for a supported specialist preset."""
+    required = ["Contract", "InternetService", "PaymentMethod", "PaperlessBilling", "tenure"]
+    missing = [column for column in required if column not in frame.columns]
+    if missing:
+        raise ValueError(f"Specialist preset '{preset}' requires columns: {missing}")
+
+    contract = frame["Contract"].astype(str)
+    internet = frame["InternetService"].astype(str)
+    payment = frame["PaymentMethod"].astype(str)
+    paperless = frame["PaperlessBilling"].astype(str)
+    tenure = pd.to_numeric(frame["tenure"], errors="coerce").fillna(0.0)
+
+    if preset == EARLY_MANUAL_INTERNET:
+        return (
+            contract.eq("Month-to-month")
+            & internet.ne("No")
+            & tenure.le(24)
+            & payment.isin(["Electronic check", "Mailed check"])
+        )
+    if preset == EARLY_ALL_INTERNET:
+        return contract.eq("Month-to-month") & internet.ne("No") & tenure.le(24)
+    if preset == FIBER_PAPERLESS_EARLY:
+        return (
+            contract.eq("Month-to-month")
+            & internet.eq("Fiber optic")
+            & paperless.eq("Yes")
+            & tenure.le(24)
+        )
+    if preset == LATE_MTM_FIBER:
+        return contract.eq("Month-to-month") & internet.eq("Fiber optic") & tenure.gt(24)
+    if preset == LATE_MTM_FIBER_PAPERLESS:
+        return (
+            contract.eq("Month-to-month")
+            & internet.eq("Fiber optic")
+            & paperless.eq("Yes")
+            & tenure.gt(24)
+        )
+    if preset == LONG_FIBER_ANY:
+        return contract.isin(["One year", "Two year"]) & internet.eq("Fiber optic") & tenure.gt(24)
+    if preset == MANUAL_NO_INTERNET:
+        return internet.eq("No") & payment.isin(["Electronic check", "Mailed check"])
+    if preset == ONE_YEAR_FIBER_ANY:
+        return contract.eq("One year") & internet.eq("Fiber optic")
+    if preset == ONE_YEAR_DSL_ANY:
+        return contract.eq("One year") & internet.eq("DSL")
+    if preset == TWO_YEAR_FIBER_ANY:
+        return contract.eq("Two year") & internet.eq("Fiber optic")
+    if preset == ONE_YEAR_FIBER_PAPERLESS_49PLUS:
+        return contract.eq("One year") & internet.eq("Fiber optic") & paperless.eq("Yes") & tenure.ge(49)
+    if preset == TWO_YEAR_FIBER_PAPERLESS_49PLUS:
+        return contract.eq("Two year") & internet.eq("Fiber optic") & paperless.eq("Yes") & tenure.ge(49)
+    if preset == MTM_DSL_PAPERLESS_25_48_MANUAL:
+        return (
+            contract.eq("Month-to-month")
+            & internet.eq("DSL")
+            & paperless.eq("Yes")
+            & tenure.between(25, 48)
+            & payment.isin(["Electronic check", "Mailed check"])
+        )
+    if preset == MTM_NOINTERNET_MAILED_0_24:
+        return (
+            contract.eq("Month-to-month")
+            & internet.eq("No")
+            & payment.eq("Mailed check")
+            & tenure.le(24)
+        )
+    raise ValueError(f"Unsupported specialist preset '{preset}'. Available: {sorted(SPECIALIST_PRESETS)}")
+
+
+def build_reference_prediction(
+    merged_oof: pd.DataFrame,
+    weights: dict[str, float],
+) -> pd.Series:
+    """Build weighted reference prediction from merged OOF matrix."""
+    reference = pd.Series(0.0, index=merged_oof.index, dtype="float64")
+    missing = []
+    for name, weight in weights.items():
+        column = f"pred_{name}"
+        if column not in merged_oof.columns:
+            missing.append(column)
+            continue
+        reference = reference + float(weight) * merged_oof[column].astype("float64")
+    if missing:
+        raise ValueError(f"Missing weighted OOF columns: {missing}")
+    return pd.Series(reference.values, index=merged_oof[ID_COLUMN].values, dtype="float64", name="reference_pred")
+
+
+def _save_pickle(path: str | Path, payload: Any) -> Path:
+    out_path = ensure_parent_dir(path)
+    with out_path.open("wb") as fh:
+        pickle.dump(payload, fh)
+    return out_path
+
+
+def _load_pickle(path: str | Path) -> Any:
+    with Path(path).open("rb") as fh:
+        return pickle.load(fh)
+
+
+def _prob_to_logit(probabilities: pd.Series | np.ndarray, epsilon: float = 1e-6) -> np.ndarray:
+    probs = np.clip(np.asarray(probabilities, dtype="float64"), epsilon, 1.0 - epsilon)
+    return np.log(probs / (1.0 - probs))
+
+
+def _clip_probability(pred: pd.Series | np.ndarray, epsilon: float = 1e-6) -> pd.Series:
+    clipped = np.clip(np.asarray(pred, dtype="float64"), epsilon, 1.0 - epsilon)
+    return pd.Series(clipped, index=getattr(pred, "index", None), dtype="float64")
+
+
+def _normalize_reference_component_frame(
+    ids: pd.Series,
+    reference_component_frame: pd.DataFrame | None,
+) -> pd.DataFrame | None:
+    if reference_component_frame is None:
+        return None
+    if ID_COLUMN not in reference_component_frame.columns:
+        raise ValueError(f"reference_component_frame must contain column '{ID_COLUMN}'")
+
+    component_columns = [
+        column
+        for column in reference_component_frame.columns
+        if column != ID_COLUMN and str(column).startswith("pred_")
+    ]
+    if not component_columns:
+        raise ValueError("reference_component_frame must contain at least one 'pred_*' column")
+
+    component_frame = ids.to_frame(name=ID_COLUMN).merge(
+        reference_component_frame[[ID_COLUMN, *component_columns]].copy(),
+        how="left",
+        on=ID_COLUMN,
+        validate="one_to_one",
+    )
+    if component_frame[component_columns].isna().any().any():
+        missing_ids = component_frame.loc[
+            component_frame[component_columns].isna().any(axis=1),
+            ID_COLUMN,
+        ].head(5).tolist()
+        raise ValueError(f"reference_component_frame missing ids: {missing_ids}")
+    return component_frame
+
+
+def _append_teacher_disagreement_features(
+    x: pd.DataFrame,
+    reference_pred: pd.Series,
+    reference_component_frame: pd.DataFrame | None,
+) -> tuple[pd.DataFrame, list[str]]:
+    if reference_component_frame is None:
+        return x, []
+
+    component_columns = [column for column in reference_component_frame.columns if column != ID_COLUMN]
+    out = x.copy()
+    component_matrix = reference_component_frame[component_columns].to_numpy(dtype="float64")
+    disagreement_columns: list[str] = []
+
+    for column in component_columns:
+        feature_name = f"{_TEACHER_COMPONENT_PREFIX}{str(column).removeprefix('pred_')}"
+        out[feature_name] = reference_component_frame[column].astype("float64").values
+        disagreement_columns.append(feature_name)
+
+    component_mean = component_matrix.mean(axis=1)
+    component_std = component_matrix.std(axis=1)
+    component_min = component_matrix.min(axis=1)
+    component_max = component_matrix.max(axis=1)
+    sorted_components = np.sort(component_matrix, axis=1)
+    top_gap = sorted_components[:, -1] - sorted_components[:, -2] if component_matrix.shape[1] >= 2 else np.zeros(len(out), dtype="float64")
+
+    derived_features = {
+        "teacher_component_mean": component_mean,
+        "teacher_component_std": component_std,
+        "teacher_component_range": component_max - component_min,
+        "teacher_component_top_gap": top_gap,
+        "teacher_reference_minus_component_mean": reference_pred.astype("float64").values - component_mean,
+    }
+
+    component_feature_lookup = {
+        str(column).removeprefix("pred_"): f"{_TEACHER_COMPONENT_PREFIX}{str(column).removeprefix('pred_')}"
+        for column in component_columns
+    }
+    pair_candidates = (("cb", "xgb"), ("cb", "rv"), ("xgb", "rv"), ("cb", "r"), ("xgb", "r"))
+    for left_name, right_name in pair_candidates:
+        left_feature = component_feature_lookup.get(left_name)
+        right_feature = component_feature_lookup.get(right_name)
+        if left_feature is None or right_feature is None:
+            continue
+        delta = out[left_feature].astype("float64") - out[right_feature].astype("float64")
+        feature_base = f"teacher_{left_name}_minus_{right_name}"
+        derived_features[feature_base] = delta.values
+        derived_features[f"{feature_base}_abs"] = delta.abs().values
+
+    for feature_name, values in derived_features.items():
+        out[feature_name] = np.asarray(values, dtype="float64")
+        disagreement_columns.append(feature_name)
+
+    return out, disagreement_columns
+
+
+def _append_reference_features(
+    x: pd.DataFrame,
+    *,
+    reference_pred: pd.Series,
+    reference_component_frame: pd.DataFrame | None,
+    include_logit: bool,
+) -> tuple[pd.DataFrame, list[str]]:
+    """Append reference and optional teacher-disagreement features to a matrix."""
+    out = x.copy()
+    out["reference_pred_feature"] = reference_pred.astype("float64").values
+    if include_logit:
+        out["reference_logit_feature"] = _prob_to_logit(reference_pred)
+    return _append_teacher_disagreement_features(out, reference_pred, reference_component_frame)
+
+
+def _prepare_specialist_test_matrix(
+    *,
+    test_df: pd.DataFrame,
+    feature_blocks: Sequence[str] | None,
+    train_csv_path: str | Path | None,
+) -> tuple[tuple[str, ...], pd.DataFrame]:
+    """Prepare specialist inference features, including fit-aware blocks when requested."""
+    normalized_blocks = normalize_feature_blocks(feature_blocks)
+    stateless_blocks, stateful_blocks = partition_feature_blocks(normalized_blocks)
+    if stateful_blocks and train_csv_path is None:
+        raise ValueError(
+            "train_csv_path is required for specialist inference when using fit-aware "
+            f"feature blocks: {list(stateful_blocks)}"
+        )
+    x_test = _prepare_test_matrix(
+        test_df,
+        stateless_blocks=stateless_blocks,
+        stateful_blocks=stateful_blocks,
+        train_csv_path=train_csv_path,
+    )
+    return normalized_blocks, x_test
+
+
+def _fit_local_calibrator(method: str, pred: pd.Series, y_true: pd.Series) -> dict[str, Any]:
+    method_value = str(method).strip().lower()
+    if method_value == PLATT:
+        model = LogisticRegression(solver="lbfgs", max_iter=1000)
+        model.fit(_prob_to_logit(pred).reshape(-1, 1), y_true.astype(int))
+        return {"method": method_value, "model": model}
+    if method_value == ISOTONIC:
+        model = IsotonicRegression(out_of_bounds="clip")
+        model.fit(np.asarray(pred, dtype="float64"), y_true.astype(int))
+        return {"method": method_value, "model": model}
+    raise ValueError(f"Unsupported calibration method '{method}'. Available: {CALIBRATION_METHODS}")
+
+
+def _predict_local_calibrator(bundle: dict[str, Any], pred: pd.Series | np.ndarray) -> pd.Series:
+    method_value = str(bundle["method"]).strip().lower()
+    model = bundle["model"]
+    pred_array = np.asarray(pred, dtype="float64")
+    if method_value == PLATT:
+        calibrated = model.predict_proba(_prob_to_logit(pred_array).reshape(-1, 1))[:, 1]
+    elif method_value == ISOTONIC:
+        calibrated = model.predict(pred_array)
+    else:
+        raise ValueError(f"Unsupported calibration method '{method_value}'.")
+    return pd.Series(calibrated, index=getattr(pred, "index", None), dtype="float64")
+
+
+def run_specialist_override_cv(
+    *,
+    train_csv_path: str | Path,
+    preset: str,
+    reference_pred: pd.Series,
+    reference_component_frame: pd.DataFrame | None,
+    params: CatBoostHyperParams,
+    feature_blocks: Sequence[str] | None,
+    folds: int,
+    random_state: int,
+    early_stopping_rounds: int,
+    verbose: int,
+    alpha_grid: Sequence[float],
+    model_path: str | Path,
+    metrics_path: str | Path,
+    oof_path: str | Path,
+) -> dict[str, Any]:
+    """Train a specialist model on a hard cohort and scan local override alpha."""
+    if folds < 2:
+        raise ValueError("folds must be >= 2")
+
+    train_df = load_csv(train_csv_path)
+    normalized_blocks, _, stateful_blocks, x, y = _prepare_train_matrix(train_df, feature_blocks)
+    specialist_mask = build_specialist_mask(train_df, preset).astype(bool)
+
+    reference_by_id = pd.Series(reference_pred, copy=True)
+    reference_pred = train_df[ID_COLUMN].map(reference_by_id)
+    if reference_pred.isna().any():
+        missing_ids = train_df.loc[reference_pred.isna(), ID_COLUMN].head(5).tolist()
+        raise ValueError(f"reference_pred missing ids from train: {missing_ids}")
+    reference_pred = pd.Series(reference_pred.values, index=x.index, dtype="float64", name="reference_pred")
+    component_frame = _normalize_reference_component_frame(train_df[ID_COLUMN], reference_component_frame)
+    mask_rows = int(specialist_mask.sum())
+    if mask_rows < _MIN_SPECIALIST_TRAIN_ROWS:
+        raise ValueError(
+            f"Preset '{preset}' selects only {mask_rows} rows. Minimum required: {_MIN_SPECIALIST_TRAIN_ROWS}"
+        )
+    if y.loc[specialist_mask].nunique() < 2:
+        raise ValueError(f"Preset '{preset}' must contain both classes.")
+
+    splitter = StratifiedKFold(n_splits=folds, shuffle=True, random_state=random_state)
+    specialist_pred = pd.Series(index=x.index, dtype="float64", name="specialist_pred")
+    fold_rows: list[dict[str, Any]] = []
+    fold_iterations: list[int] = []
+    disagreement_columns: list[str] = []
+
+    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x, y), start=1):
+        x_train = x.iloc[train_idx]
+        y_train = y.iloc[train_idx]
+        x_valid = x.iloc[valid_idx]
+        y_valid = y.iloc[valid_idx]
+        x_train, x_valid = _transform_pair_with_stateful_blocks(x_train, x_valid, stateful_blocks)
+
+        train_mask = specialist_mask.iloc[train_idx].to_numpy(dtype=bool)
+        valid_mask = specialist_mask.iloc[valid_idx].to_numpy(dtype=bool)
+
+        specialist_train_rows = int(np.sum(train_mask))
+        specialist_valid_rows = int(np.sum(valid_mask))
+        if specialist_train_rows < _MIN_SPECIALIST_TRAIN_ROWS:
+            raise ValueError(
+                f"Fold {fold_number} preset '{preset}' train rows {specialist_train_rows} below minimum."
+            )
+        if specialist_valid_rows < _MIN_SPECIALIST_VALID_ROWS:
+            raise ValueError(
+                f"Fold {fold_number} preset '{preset}' valid rows {specialist_valid_rows} below minimum."
+            )
+        if y_train.iloc[train_mask].nunique() < 2 or y_valid.iloc[valid_mask].nunique() < 2:
+            raise ValueError(f"Fold {fold_number} preset '{preset}' lost one class in train or valid.")
+
+        train_reference = reference_pred.iloc[train_idx]
+        valid_reference = reference_pred.iloc[valid_idx]
+        train_components = component_frame.iloc[train_idx] if component_frame is not None else None
+        valid_components = component_frame.iloc[valid_idx] if component_frame is not None else None
+        x_train, train_disagreement_columns = _append_reference_features(
+            x_train,
+            reference_pred=train_reference,
+            reference_component_frame=train_components,
+            include_logit=False,
+        )
+        x_valid, valid_disagreement_columns = _append_reference_features(
+            x_valid,
+            reference_pred=valid_reference,
+            reference_component_frame=valid_components,
+            include_logit=False,
+        )
+        if train_disagreement_columns != valid_disagreement_columns:
+            raise RuntimeError("Teacher disagreement feature mismatch between train and valid folds.")
+        if not disagreement_columns:
+            disagreement_columns = list(train_disagreement_columns)
+        cat_columns = infer_categorical_columns(x_train)
+
+        fold_model = fit_with_validation(
+            x_train=x_train.iloc[train_mask],
+            y_train=y_train.iloc[train_mask],
+            x_valid=x_valid.iloc[valid_mask],
+            y_valid=y_valid.iloc[valid_mask],
+            cat_columns=cat_columns,
+            params=CatBoostHyperParams(
+                iterations=params.iterations,
+                learning_rate=params.learning_rate,
+                depth=params.depth,
+                l2_leaf_reg=params.l2_leaf_reg,
+                random_seed=random_state,
+                loss_function=params.loss_function,
+                eval_metric=params.eval_metric,
+            ),
+            early_stopping_rounds=early_stopping_rounds,
+            verbose=verbose,
+        )
+
+        valid_specialist_pred = predict_proba(fold_model, x_valid.iloc[valid_mask])
+        specialist_pred.iloc[np.asarray(valid_idx)[valid_mask]] = valid_specialist_pred.values
+
+        fold_final_iterations = best_iteration_or_default(fold_model, params.iterations)
+        best_iteration = fold_model.get_best_iteration()
+        if best_iteration is None or best_iteration < 0:
+            best_iteration = fold_final_iterations - 1
+        fold_iterations.append(fold_final_iterations)
+
+        reference_on_mask = reference_pred.iloc[valid_idx].iloc[valid_mask]
+        reference_auc = binary_auc(y_valid.iloc[valid_mask], reference_on_mask)
+        specialist_auc = binary_auc(y_valid.iloc[valid_mask], valid_specialist_pred)
+        fold_rows.append(
+            {
+                "fold": fold_number,
+                "specialist_train_rows": specialist_train_rows,
+                "specialist_valid_rows": specialist_valid_rows,
+                "specialist_positive_rate_train": float(y_train.iloc[train_mask].mean()),
+                "specialist_positive_rate_valid": float(y_valid.iloc[valid_mask].mean()),
+                "reference_auc_on_mask": reference_auc,
+                "specialist_auc_on_mask": specialist_auc,
+                "delta_auc_on_mask": float(specialist_auc - reference_auc),
+                "best_iteration": int(best_iteration),
+                "final_iterations": int(fold_final_iterations),
+            }
+        )
+
+    if specialist_pred.loc[specialist_mask].isna().any():
+        raise RuntimeError("Specialist OOF predictions contain missing values inside the target cohort.")
+
+    alpha_scan_rows: list[dict[str, Any]] = []
+    for alpha in alpha_grid:
+        alpha_value = float(alpha)
+        candidate = reference_pred.copy()
+        candidate.loc[specialist_mask] = (
+            (1.0 - alpha_value) * reference_pred.loc[specialist_mask]
+            + alpha_value * specialist_pred.loc[specialist_mask]
+        )
+        alpha_scan_rows.append(
+            {
+                "alpha": alpha_value,
+                "oof_auc": binary_auc(y, candidate),
+                "oof_auc_on_mask": binary_auc(y.loc[specialist_mask], candidate.loc[specialist_mask]),
+                "reference_auc_on_mask": binary_auc(y.loc[specialist_mask], reference_pred.loc[specialist_mask]),
+            }
+        )
+
+    best_alpha_row = max(alpha_scan_rows, key=lambda row: row["oof_auc"])
+    best_alpha = float(best_alpha_row["alpha"])
+    candidate_best = reference_pred.copy()
+    candidate_best.loc[specialist_mask] = (
+        (1.0 - best_alpha) * reference_pred.loc[specialist_mask]
+        + best_alpha * specialist_pred.loc[specialist_mask]
+    )
+
+    final_iterations = max(int(round(float(np.mean(fold_iterations)))), 1)
+    x_full = _transform_single_with_stateful_blocks(x, stateful_blocks)
+    x_full, disagreement_columns_full = _append_reference_features(
+        x_full,
+        reference_pred=reference_pred,
+        reference_component_frame=component_frame,
+        include_logit=False,
+    )
+    if disagreement_columns and disagreement_columns_full != disagreement_columns:
+        raise RuntimeError("Teacher disagreement feature mismatch between CV folds and full train.")
+    if not disagreement_columns:
+        disagreement_columns = list(disagreement_columns_full)
+    cat_columns = infer_categorical_columns(x_full)
+    full_model = fit_full_train(
+        x_train=x_full.loc[specialist_mask],
+        y_train=y.loc[specialist_mask],
+        cat_columns=cat_columns,
+        params=CatBoostHyperParams(
+            iterations=final_iterations,
+            learning_rate=params.learning_rate,
+            depth=params.depth,
+            l2_leaf_reg=params.l2_leaf_reg,
+            random_seed=params.random_seed,
+            loss_function=params.loss_function,
+            eval_metric=params.eval_metric,
+        ),
+        verbose=verbose,
+    )
+    save_model(full_model, model_path)
+
+    oof_output = pd.DataFrame(
+        {
+            ID_COLUMN: train_df[ID_COLUMN].values,
+            "target": y.astype(int).values,
+            "specialist_mask": specialist_mask.astype("int8").values,
+            "reference_pred": reference_pred.values,
+            "specialist_pred": specialist_pred.values,
+            "candidate_pred": candidate_best.values,
+        }
+    )
+    oof_out_path = ensure_parent_dir(oof_path)
+    oof_output.to_csv(oof_out_path, index=False)
+
+    metrics: dict[str, Any] = {
+        "preset": preset,
+        "preset_description": SPECIALIST_PRESETS[preset],
+        "train_rows": int(len(train_df)),
+        "specialist_rows": mask_rows,
+        "specialist_row_share": float(mask_rows / max(len(train_df), 1)),
+        "specialist_positive_rate": float(y.loc[specialist_mask].mean()),
+        "feature_count": int(x_full.shape[1]),
+        "feature_columns": list(x_full.columns),
+        "feature_blocks": list(normalized_blocks),
+        "teacher_disagreement_columns": disagreement_columns,
+        "categorical_columns": cat_columns,
+        "cv_folds": int(folds),
+        "cv_fold_metrics": fold_rows,
+        "fold_final_iterations": [int(value) for value in fold_iterations],
+        "final_iterations": int(final_iterations),
+        "alpha_scan": alpha_scan_rows,
+        "best_alpha": best_alpha,
+        "reference_oof_auc": binary_auc(y, reference_pred),
+        "reference_oof_auc_on_mask": binary_auc(y.loc[specialist_mask], reference_pred.loc[specialist_mask]),
+        "specialist_oof_auc_on_mask": binary_auc(y.loc[specialist_mask], specialist_pred.loc[specialist_mask]),
+        "candidate_oof_auc": binary_auc(y, candidate_best),
+        "candidate_oof_auc_on_mask": binary_auc(y.loc[specialist_mask], candidate_best.loc[specialist_mask]),
+        "delta_vs_reference_oof_auc": float(binary_auc(y, candidate_best) - binary_auc(y, reference_pred)),
+        "model_path": str(model_path),
+        "oof_path": str(oof_path),
+        "target_column": TARGET_COLUMN,
+        "id_column": ID_COLUMN,
+    }
+    write_json(metrics_path, metrics)
+    return metrics
+
+
+def run_residual_reranker_cv(
+    *,
+    train_csv_path: str | Path,
+    preset: str,
+    reference_pred: pd.Series,
+    reference_component_frame: pd.DataFrame | None,
+    params: CatBoostHyperParams,
+    feature_blocks: Sequence[str] | None,
+    folds: int,
+    random_state: int,
+    early_stopping_rounds: int,
+    verbose: int,
+    alpha_grid: Sequence[float],
+    model_path: str | Path,
+    metrics_path: str | Path,
+    oof_path: str | Path,
+) -> dict[str, Any]:
+    """Train a local residual reranker over the incumbent score inside a hard cohort."""
+    if folds < 2:
+        raise ValueError("folds must be >= 2")
+
+    train_df = load_csv(train_csv_path)
+    normalized_blocks, _, stateful_blocks, x, y = _prepare_train_matrix(train_df, feature_blocks)
+    specialist_mask = build_specialist_mask(train_df, preset).astype(bool)
+
+    reference_by_id = pd.Series(reference_pred, copy=True)
+    reference_pred = train_df[ID_COLUMN].map(reference_by_id)
+    if reference_pred.isna().any():
+        missing_ids = train_df.loc[reference_pred.isna(), ID_COLUMN].head(5).tolist()
+        raise ValueError(f"reference_pred missing ids from train: {missing_ids}")
+    reference_pred = pd.Series(reference_pred.values, index=x.index, dtype="float64", name="reference_pred")
+    component_frame = _normalize_reference_component_frame(train_df[ID_COLUMN], reference_component_frame)
+
+    mask_rows = int(specialist_mask.sum())
+    if mask_rows < _MIN_SPECIALIST_TRAIN_ROWS:
+        raise ValueError(
+            f"Preset '{preset}' selects only {mask_rows} rows. Minimum required: {_MIN_SPECIALIST_TRAIN_ROWS}"
+        )
+    if y.loc[specialist_mask].nunique() < 2:
+        raise ValueError(f"Preset '{preset}' must contain both classes.")
+
+    splitter = StratifiedKFold(n_splits=folds, shuffle=True, random_state=random_state)
+    residual_pred = pd.Series(index=x.index, dtype="float64", name="residual_pred")
+    fold_rows: list[dict[str, Any]] = []
+    fold_iterations: list[int] = []
+    disagreement_columns: list[str] = []
+
+    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x, y), start=1):
+        x_train = x.iloc[train_idx]
+        y_train = y.iloc[train_idx]
+        x_valid = x.iloc[valid_idx]
+        y_valid = y.iloc[valid_idx]
+        x_train, x_valid = _transform_pair_with_stateful_blocks(x_train, x_valid, stateful_blocks)
+
+        train_mask = specialist_mask.iloc[train_idx].to_numpy(dtype=bool)
+        valid_mask = specialist_mask.iloc[valid_idx].to_numpy(dtype=bool)
+
+        specialist_train_rows = int(np.sum(train_mask))
+        specialist_valid_rows = int(np.sum(valid_mask))
+        if specialist_train_rows < _MIN_SPECIALIST_TRAIN_ROWS:
+            raise ValueError(
+                f"Fold {fold_number} preset '{preset}' train rows {specialist_train_rows} below minimum."
+            )
+        if specialist_valid_rows < _MIN_SPECIALIST_VALID_ROWS:
+            raise ValueError(
+                f"Fold {fold_number} preset '{preset}' valid rows {specialist_valid_rows} below minimum."
+            )
+        if y_train.iloc[train_mask].nunique() < 2 or y_valid.iloc[valid_mask].nunique() < 2:
+            raise ValueError(f"Fold {fold_number} preset '{preset}' lost one class in train or valid.")
+
+        reference_train_mask = reference_pred.iloc[train_idx].iloc[train_mask]
+        reference_valid_mask = reference_pred.iloc[valid_idx].iloc[valid_mask]
+        train_reference = reference_pred.iloc[train_idx]
+        valid_reference = reference_pred.iloc[valid_idx]
+        train_components = component_frame.iloc[train_idx] if component_frame is not None else None
+        valid_components = component_frame.iloc[valid_idx] if component_frame is not None else None
+        x_train, train_disagreement_columns = _append_reference_features(
+            x_train,
+            reference_pred=train_reference,
+            reference_component_frame=train_components,
+            include_logit=True,
+        )
+        x_valid, valid_disagreement_columns = _append_reference_features(
+            x_valid,
+            reference_pred=valid_reference,
+            reference_component_frame=valid_components,
+            include_logit=True,
+        )
+        if train_disagreement_columns != valid_disagreement_columns:
+            raise RuntimeError("Teacher disagreement feature mismatch between train and valid folds.")
+        if not disagreement_columns:
+            disagreement_columns = list(train_disagreement_columns)
+        cat_columns = infer_categorical_columns(x_train)
+        y_train_residual = y_train.iloc[train_mask].astype("float64") - reference_train_mask.astype("float64")
+
+        fold_model = CatBoostRegressor(
+            iterations=params.iterations,
+            learning_rate=params.learning_rate,
+            depth=params.depth,
+            l2_leaf_reg=params.l2_leaf_reg,
+            random_seed=random_state,
+            loss_function="RMSE",
+            eval_metric="RMSE",
+            verbose=verbose,
+        )
+        fold_model.fit(
+            x_train.iloc[train_mask],
+            y_train_residual,
+            cat_features=cat_columns,
+            eval_set=(
+                x_valid.iloc[valid_mask],
+                y_valid.iloc[valid_mask].astype("float64") - reference_valid_mask.astype("float64"),
+            ),
+            use_best_model=True,
+            early_stopping_rounds=early_stopping_rounds,
+            verbose=verbose,
+        )
+
+        valid_residual_pred = pd.Series(
+            fold_model.predict(x_valid.iloc[valid_mask]),
+            index=x_valid.iloc[valid_mask].index,
+            dtype="float64",
+        )
+        residual_pred.iloc[np.asarray(valid_idx)[valid_mask]] = valid_residual_pred.values
+
+        fold_final_iterations = best_iteration_or_default(fold_model, params.iterations)
+        best_iteration = fold_model.get_best_iteration()
+        if best_iteration is None or best_iteration < 0:
+            best_iteration = fold_final_iterations - 1
+        fold_iterations.append(fold_final_iterations)
+
+        reference_auc = binary_auc(y_valid.iloc[valid_mask], reference_valid_mask)
+        reranked_valid = _clip_probability(reference_valid_mask + valid_residual_pred)
+        reranked_auc = binary_auc(y_valid.iloc[valid_mask], reranked_valid)
+        fold_rows.append(
+            {
+                "fold": fold_number,
+                "specialist_train_rows": specialist_train_rows,
+                "specialist_valid_rows": specialist_valid_rows,
+                "specialist_positive_rate_train": float(y_train.iloc[train_mask].mean()),
+                "specialist_positive_rate_valid": float(y_valid.iloc[valid_mask].mean()),
+                "reference_auc_on_mask": reference_auc,
+                "reranked_auc_on_mask": reranked_auc,
+                "delta_auc_on_mask": float(reranked_auc - reference_auc),
+                "best_iteration": int(best_iteration),
+                "final_iterations": int(fold_final_iterations),
+            }
+        )
+
+    if residual_pred.loc[specialist_mask].isna().any():
+        raise RuntimeError("Residual OOF predictions contain missing values inside the target cohort.")
+
+    alpha_scan_rows: list[dict[str, Any]] = []
+    for alpha in alpha_grid:
+        alpha_value = float(alpha)
+        candidate = reference_pred.copy()
+        candidate.loc[specialist_mask] = _clip_probability(
+            reference_pred.loc[specialist_mask] + alpha_value * residual_pred.loc[specialist_mask]
+        ).values
+        alpha_scan_rows.append(
+            {
+                "alpha": alpha_value,
+                "oof_auc": binary_auc(y, candidate),
+                "oof_auc_on_mask": binary_auc(y.loc[specialist_mask], candidate.loc[specialist_mask]),
+                "reference_auc_on_mask": binary_auc(y.loc[specialist_mask], reference_pred.loc[specialist_mask]),
+            }
+        )
+
+    best_alpha_row = max(alpha_scan_rows, key=lambda row: row["oof_auc"])
+    best_alpha = float(best_alpha_row["alpha"])
+    candidate_best = reference_pred.copy()
+    candidate_best.loc[specialist_mask] = _clip_probability(
+        reference_pred.loc[specialist_mask] + best_alpha * residual_pred.loc[specialist_mask]
+    ).values
+
+    final_iterations = max(int(round(float(np.mean(fold_iterations)))), 1)
+    x_full = _transform_single_with_stateful_blocks(x, stateful_blocks)
+    x_full, disagreement_columns_full = _append_reference_features(
+        x_full,
+        reference_pred=reference_pred,
+        reference_component_frame=component_frame,
+        include_logit=True,
+    )
+    if disagreement_columns and disagreement_columns_full != disagreement_columns:
+        raise RuntimeError("Teacher disagreement feature mismatch between CV folds and full train.")
+    if not disagreement_columns:
+        disagreement_columns = list(disagreement_columns_full)
+    cat_columns = infer_categorical_columns(x_full)
+    full_model = CatBoostRegressor(
+        iterations=final_iterations,
+        learning_rate=params.learning_rate,
+        depth=params.depth,
+        l2_leaf_reg=params.l2_leaf_reg,
+        random_seed=params.random_seed,
+        loss_function="RMSE",
+        eval_metric="RMSE",
+        verbose=verbose,
+    )
+    full_model.fit(
+        x_full.loc[specialist_mask],
+        (y.loc[specialist_mask].astype("float64") - reference_pred.loc[specialist_mask].astype("float64")),
+        cat_features=cat_columns,
+        verbose=verbose,
+    )
+    save_model(full_model, model_path)
+
+    oof_output = pd.DataFrame(
+        {
+            ID_COLUMN: train_df[ID_COLUMN].values,
+            "target": y.astype(int).values,
+            "specialist_mask": specialist_mask.astype("int8").values,
+            "reference_pred": reference_pred.values,
+            "residual_pred": residual_pred.values,
+            "candidate_pred": candidate_best.values,
+        }
+    )
+    oof_out_path = ensure_parent_dir(oof_path)
+    oof_output.to_csv(oof_out_path, index=False)
+
+    metrics: dict[str, Any] = {
+        "preset": preset,
+        "preset_description": SPECIALIST_PRESETS[preset],
+        "approach": RESIDUAL,
+        "train_rows": int(len(train_df)),
+        "specialist_rows": mask_rows,
+        "specialist_row_share": float(mask_rows / max(len(train_df), 1)),
+        "specialist_positive_rate": float(y.loc[specialist_mask].mean()),
+        "feature_count": int(x_full.shape[1]),
+        "feature_columns": list(x_full.columns),
+        "feature_blocks": list(normalized_blocks),
+        "teacher_disagreement_columns": disagreement_columns,
+        "categorical_columns": cat_columns,
+        "cv_folds": int(folds),
+        "cv_fold_metrics": fold_rows,
+        "fold_final_iterations": [int(value) for value in fold_iterations],
+        "final_iterations": int(final_iterations),
+        "alpha_scan": alpha_scan_rows,
+        "best_alpha": best_alpha,
+        "reference_oof_auc": binary_auc(y, reference_pred),
+        "reference_oof_auc_on_mask": binary_auc(y.loc[specialist_mask], reference_pred.loc[specialist_mask]),
+        "reranked_oof_auc_on_mask": binary_auc(y.loc[specialist_mask], candidate_best.loc[specialist_mask]),
+        "candidate_oof_auc": binary_auc(y, candidate_best),
+        "candidate_oof_auc_on_mask": binary_auc(y.loc[specialist_mask], candidate_best.loc[specialist_mask]),
+        "delta_vs_reference_oof_auc": float(binary_auc(y, candidate_best) - binary_auc(y, reference_pred)),
+        "model_path": str(model_path),
+        "oof_path": str(oof_path),
+        "target_column": TARGET_COLUMN,
+        "id_column": ID_COLUMN,
+    }
+    write_json(metrics_path, metrics)
+    return metrics
+
+
+def run_local_calibrator_cv(
+    *,
+    train_csv_path: str | Path,
+    preset: str,
+    reference_pred: pd.Series,
+    method: str,
+    folds: int,
+    random_state: int,
+    alpha_grid: Sequence[float],
+    model_path: str | Path,
+    metrics_path: str | Path,
+    oof_path: str | Path,
+) -> dict[str, Any]:
+    """Fit a local calibrator on incumbent scores inside a hard cohort."""
+    if folds < 2:
+        raise ValueError("folds must be >= 2")
+    if str(method).strip().lower() not in CALIBRATION_METHODS:
+        raise ValueError(f"Unsupported calibration method '{method}'. Available: {CALIBRATION_METHODS}")
+
+    train_df = load_csv(train_csv_path)
+    y = normalize_binary_target(train_df[TARGET_COLUMN])
+    specialist_mask = build_specialist_mask(train_df, preset).astype(bool)
+
+    reference_by_id = pd.Series(reference_pred, copy=True)
+    reference_pred = train_df[ID_COLUMN].map(reference_by_id)
+    if reference_pred.isna().any():
+        missing_ids = train_df.loc[reference_pred.isna(), ID_COLUMN].head(5).tolist()
+        raise ValueError(f"reference_pred missing ids from train: {missing_ids}")
+    reference_pred = pd.Series(reference_pred.values, index=train_df.index, dtype="float64", name="reference_pred")
+
+    mask_rows = int(specialist_mask.sum())
+    if mask_rows < _MIN_SPECIALIST_TRAIN_ROWS:
+        raise ValueError(
+            f"Preset '{preset}' selects only {mask_rows} rows. Minimum required: {_MIN_SPECIALIST_TRAIN_ROWS}"
+        )
+    if y.loc[specialist_mask].nunique() < 2:
+        raise ValueError(f"Preset '{preset}' must contain both classes.")
+
+    splitter = StratifiedKFold(n_splits=folds, shuffle=True, random_state=random_state)
+    calibrated_pred = pd.Series(index=train_df.index, dtype="float64", name="calibrated_pred")
+    fold_rows: list[dict[str, Any]] = []
+
+    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(train_df, y), start=1):
+        y_train = y.iloc[train_idx]
+        y_valid = y.iloc[valid_idx]
+        train_mask = specialist_mask.iloc[train_idx].to_numpy(dtype=bool)
+        valid_mask = specialist_mask.iloc[valid_idx].to_numpy(dtype=bool)
+
+        specialist_train_rows = int(np.sum(train_mask))
+        specialist_valid_rows = int(np.sum(valid_mask))
+        if specialist_train_rows < _MIN_SPECIALIST_TRAIN_ROWS:
+            raise ValueError(
+                f"Fold {fold_number} preset '{preset}' train rows {specialist_train_rows} below minimum."
+            )
+        if specialist_valid_rows < _MIN_SPECIALIST_VALID_ROWS:
+            raise ValueError(
+                f"Fold {fold_number} preset '{preset}' valid rows {specialist_valid_rows} below minimum."
+            )
+        if y_train.iloc[train_mask].nunique() < 2 or y_valid.iloc[valid_mask].nunique() < 2:
+            raise ValueError(f"Fold {fold_number} preset '{preset}' lost one class in train or valid.")
+
+        train_pred_mask = reference_pred.iloc[train_idx].iloc[train_mask]
+        valid_pred_mask = reference_pred.iloc[valid_idx].iloc[valid_mask]
+        bundle = _fit_local_calibrator(
+            method=method,
+            pred=train_pred_mask,
+            y_true=y_train.iloc[train_mask],
+        )
+        valid_calibrated_pred = _predict_local_calibrator(bundle, valid_pred_mask)
+        calibrated_pred.iloc[np.asarray(valid_idx)[valid_mask]] = valid_calibrated_pred.values
+
+        reference_auc = binary_auc(y_valid.iloc[valid_mask], valid_pred_mask)
+        calibrated_auc = binary_auc(y_valid.iloc[valid_mask], valid_calibrated_pred)
+        fold_rows.append(
+            {
+                "fold": fold_number,
+                "specialist_train_rows": specialist_train_rows,
+                "specialist_valid_rows": specialist_valid_rows,
+                "specialist_positive_rate_train": float(y_train.iloc[train_mask].mean()),
+                "specialist_positive_rate_valid": float(y_valid.iloc[valid_mask].mean()),
+                "reference_auc_on_mask": reference_auc,
+                "calibrated_auc_on_mask": calibrated_auc,
+                "delta_auc_on_mask": float(calibrated_auc - reference_auc),
+            }
+        )
+
+    if calibrated_pred.loc[specialist_mask].isna().any():
+        raise RuntimeError("Calibrated OOF predictions contain missing values inside the target cohort.")
+
+    alpha_scan_rows: list[dict[str, Any]] = []
+    for alpha in alpha_grid:
+        alpha_value = float(alpha)
+        candidate = reference_pred.copy()
+        candidate.loc[specialist_mask] = (
+            (1.0 - alpha_value) * reference_pred.loc[specialist_mask]
+            + alpha_value * calibrated_pred.loc[specialist_mask]
+        )
+        alpha_scan_rows.append(
+            {
+                "alpha": alpha_value,
+                "oof_auc": binary_auc(y, candidate),
+                "oof_auc_on_mask": binary_auc(y.loc[specialist_mask], candidate.loc[specialist_mask]),
+                "reference_auc_on_mask": binary_auc(y.loc[specialist_mask], reference_pred.loc[specialist_mask]),
+            }
+        )
+
+    best_alpha_row = max(alpha_scan_rows, key=lambda row: row["oof_auc"])
+    best_alpha = float(best_alpha_row["alpha"])
+    candidate_best = reference_pred.copy()
+    candidate_best.loc[specialist_mask] = (
+        (1.0 - best_alpha) * reference_pred.loc[specialist_mask]
+        + best_alpha * calibrated_pred.loc[specialist_mask]
+    )
+
+    full_bundle = _fit_local_calibrator(
+        method=method,
+        pred=reference_pred.loc[specialist_mask],
+        y_true=y.loc[specialist_mask],
+    )
+    _save_pickle(
+        model_path,
+        {
+            "preset": preset,
+            "method": str(method).strip().lower(),
+            "alpha": best_alpha,
+            "calibrator": full_bundle,
+        },
+    )
+
+    oof_output = pd.DataFrame(
+        {
+            ID_COLUMN: train_df[ID_COLUMN].values,
+            "target": y.astype(int).values,
+            "specialist_mask": specialist_mask.astype("int8").values,
+            "reference_pred": reference_pred.values,
+            "calibrated_pred": calibrated_pred.values,
+            "candidate_pred": candidate_best.values,
+        }
+    )
+    oof_out_path = ensure_parent_dir(oof_path)
+    oof_output.to_csv(oof_out_path, index=False)
+
+    metrics: dict[str, Any] = {
+        "preset": preset,
+        "preset_description": SPECIALIST_PRESETS[preset],
+        "calibration_method": str(method).strip().lower(),
+        "train_rows": int(len(train_df)),
+        "specialist_rows": mask_rows,
+        "specialist_row_share": float(mask_rows / max(len(train_df), 1)),
+        "specialist_positive_rate": float(y.loc[specialist_mask].mean()),
+        "cv_folds": int(folds),
+        "cv_fold_metrics": fold_rows,
+        "alpha_scan": alpha_scan_rows,
+        "best_alpha": best_alpha,
+        "reference_oof_auc": binary_auc(y, reference_pred),
+        "reference_oof_auc_on_mask": binary_auc(y.loc[specialist_mask], reference_pred.loc[specialist_mask]),
+        "calibrated_oof_auc_on_mask": binary_auc(y.loc[specialist_mask], calibrated_pred.loc[specialist_mask]),
+        "candidate_oof_auc": binary_auc(y, candidate_best),
+        "candidate_oof_auc_on_mask": binary_auc(y.loc[specialist_mask], candidate_best.loc[specialist_mask]),
+        "delta_vs_reference_oof_auc": float(binary_auc(y, candidate_best) - binary_auc(y, reference_pred)),
+        "model_path": str(model_path),
+        "oof_path": str(oof_path),
+        "target_column": TARGET_COLUMN,
+        "id_column": ID_COLUMN,
+    }
+    write_json(metrics_path, metrics)
+    return metrics
+
+
+def make_specialist_override_prediction(
+    *,
+    test_csv_path: str | Path,
+    reference_submission_path: str | Path,
+    reference_component_frame: pd.DataFrame | None = None,
+    train_csv_path: str | Path | None = None,
+    model_path: str | Path,
+    preset: str,
+    feature_blocks: Sequence[str] | None,
+    alpha: float,
+) -> pd.DataFrame:
+    """Apply a trained specialist override on top of a reference submission."""
+    if float(alpha) < 0.0 or float(alpha) > 1.0:
+        raise ValueError(f"alpha must be in [0, 1], got {alpha}")
+
+    test_df = load_csv(test_csv_path)
+    reference_submission = pd.read_csv(reference_submission_path)
+    if ID_COLUMN not in reference_submission.columns or "Churn" not in reference_submission.columns:
+        raise ValueError(f"{reference_submission_path} must contain columns '{ID_COLUMN}' and 'Churn'.")
+
+    _, x_test = _prepare_specialist_test_matrix(
+        test_df=test_df,
+        feature_blocks=feature_blocks,
+        train_csv_path=train_csv_path,
+    )
+    specialist_mask = build_specialist_mask(test_df, preset).astype(bool)
+    specialist_model = load_model(model_path)
+    output = test_df[[ID_COLUMN]].merge(reference_submission[[ID_COLUMN, "Churn"]], how="left", on=ID_COLUMN, validate="one_to_one")
+    if output["Churn"].isna().any():
+        missing_ids = output.loc[output["Churn"].isna(), ID_COLUMN].head(5).tolist()
+        raise ValueError(f"reference submission missing ids from test: {missing_ids}")
+    component_frame = _normalize_reference_component_frame(test_df[ID_COLUMN], reference_component_frame)
+    x_test, _ = _append_reference_features(
+        x_test,
+        reference_pred=pd.Series(output["Churn"].astype("float64").values, index=x_test.index, dtype="float64"),
+        reference_component_frame=component_frame,
+        include_logit=False,
+    )
+    specialist_pred = pd.Series(np.nan, index=x_test.index, dtype="float64")
+    expected_columns = list(getattr(specialist_model, "feature_names_", []))
+    if expected_columns:
+        missing = [column for column in expected_columns if column not in x_test.columns]
+        if missing:
+            raise ValueError(f"Missing inference columns for specialist model: {missing}")
+        x_test = x_test.loc[:, expected_columns]
+    specialist_pred.loc[specialist_mask] = predict_proba(specialist_model, x_test.loc[specialist_mask]).values
+    output["specialist_mask"] = specialist_mask.astype("int8").values
+    output["specialist_pred"] = specialist_pred.values
+    output.loc[specialist_mask, "Churn"] = (
+        (1.0 - float(alpha)) * output.loc[specialist_mask, "Churn"].astype("float64")
+        + float(alpha) * specialist_pred.loc[specialist_mask]
+    )
+    return output
+
+
+def _load_reference_submission_frame(
+    *,
+    test_df: pd.DataFrame,
+    reference_submission_path: str | Path,
+) -> pd.DataFrame:
+    """Load and align a reference submission against the test ids."""
+    reference_submission = pd.read_csv(reference_submission_path)
+    if ID_COLUMN not in reference_submission.columns or "Churn" not in reference_submission.columns:
+        raise ValueError(f"{reference_submission_path} must contain columns '{ID_COLUMN}' and 'Churn'.")
+
+    output = test_df[[ID_COLUMN]].merge(
+        reference_submission[[ID_COLUMN, "Churn"]],
+        how="left",
+        on=ID_COLUMN,
+        validate="one_to_one",
+    )
+    if output["Churn"].isna().any():
+        missing_ids = output.loc[output["Churn"].isna(), ID_COLUMN].head(5).tolist()
+        raise ValueError(f"reference submission missing ids from test: {missing_ids}")
+    return output
+
+
+def _predict_catboost_ensemble_frame(
+    *,
+    test_df: pd.DataFrame,
+    model_paths: Sequence[str | Path],
+    feature_blocks: Sequence[str] | None,
+    train_csv_path: str | Path | None = None,
+) -> pd.Series:
+    """Predict average CatBoost probabilities for a list of models on test rows."""
+    paths = [str(path) for path in model_paths if str(path).strip()]
+    if not paths:
+        raise ValueError("model_paths must contain at least one model path")
+
+    _, x_test = _prepare_specialist_test_matrix(
+        test_df=test_df,
+        feature_blocks=feature_blocks,
+        train_csv_path=train_csv_path,
+    )
+    total = np.zeros(len(test_df), dtype="float64")
+
+    for model_path in paths:
+        model = load_model(model_path)
+        expected_columns = list(getattr(model, "feature_names_", []))
+        x_model = x_test.loc[:, expected_columns] if expected_columns else x_test
+        total += predict_proba(model, x_model).to_numpy(dtype="float64")
+
+    return pd.Series(total / len(paths), index=test_df.index, dtype="float64")
+
+
+def build_teacher_reference_component_frame(
+    *,
+    test_csv_path: str | Path,
+    train_csv_path: str | Path | None = None,
+    cb_model_paths: Sequence[str | Path],
+    cb_feature_blocks: Sequence[str] | None,
+    r_model_path: str | Path,
+    r_feature_blocks: Sequence[str] | None,
+    cbxgblgb_submission_path: str | Path,
+    cbxgblgb_weights: dict[str, float],
+    cbr_submission_path: str | Path,
+    cbr_weights: dict[str, float],
+    cbrv_submission_path: str | Path,
+    cbrv_weights: dict[str, float],
+) -> tuple[pd.DataFrame, dict[str, Any]]:
+    """Reconstruct incumbent teacher components from validated blend submissions."""
+    required_cbxgblgb = {"cb", "xgb", "lgb"}
+    required_cbr = {"cb", "xgb", "lgb", "r"}
+    required_cbrv = {"cb", "xgb", "lgb", "r", "rv"}
+    if not required_cbxgblgb.issubset(cbxgblgb_weights):
+        raise ValueError(f"cbxgblgb_weights must contain {sorted(required_cbxgblgb)}")
+    if not required_cbr.issubset(cbr_weights):
+        raise ValueError(f"cbr_weights must contain {sorted(required_cbr)}")
+    if not required_cbrv.issubset(cbrv_weights):
+        raise ValueError(f"cbrv_weights must contain {sorted(required_cbrv)}")
+
+    test_df = load_csv(test_csv_path)
+    test_ids = test_df[ID_COLUMN].copy()
+
+    cb_pred = _predict_catboost_ensemble_frame(
+        test_df=test_df,
+        model_paths=cb_model_paths,
+        feature_blocks=cb_feature_blocks,
+        train_csv_path=train_csv_path,
+    ).to_numpy(dtype="float64")
+    r_pred = _predict_catboost_ensemble_frame(
+        test_df=test_df,
+        model_paths=[r_model_path],
+        feature_blocks=r_feature_blocks,
+        train_csv_path=train_csv_path,
+    ).to_numpy(dtype="float64")
+
+    cbxgblgb_frame = _load_reference_submission_frame(
+        test_df=test_df,
+        reference_submission_path=cbxgblgb_submission_path,
+    )
+    cbr_frame = _load_reference_submission_frame(
+        test_df=test_df,
+        reference_submission_path=cbr_submission_path,
+    )
+    cbrv_frame = _load_reference_submission_frame(
+        test_df=test_df,
+        reference_submission_path=cbrv_submission_path,
+    )
+
+    a0 = float(cbxgblgb_weights["xgb"])
+    b0 = float(cbxgblgb_weights["lgb"])
+    a1 = float(cbr_weights["xgb"])
+    b1 = float(cbr_weights["lgb"])
+    determinant = a0 * b1 - a1 * b0
+    if abs(determinant) < 1e-12:
+        raise ValueError(f"Blend system is ill-conditioned for xgb/lgb reconstruction: det={determinant}")
+
+    rhs0 = cbxgblgb_frame["Churn"].astype("float64").to_numpy(dtype="float64") - float(cbxgblgb_weights["cb"]) * cb_pred
+    rhs1 = (
+        cbr_frame["Churn"].astype("float64").to_numpy(dtype="float64")
+        - float(cbr_weights["cb"]) * cb_pred
+        - float(cbr_weights["r"]) * r_pred
+    )
+
+    xgb_pred = (rhs0 * b1 - rhs1 * b0) / determinant
+    lgb_pred = (a0 * rhs1 - a1 * rhs0) / determinant
+    rv_pred = (
+        cbrv_frame["Churn"].astype("float64").to_numpy(dtype="float64")
+        - float(cbrv_weights["cb"]) * cb_pred
+        - float(cbrv_weights["xgb"]) * xgb_pred
+        - float(cbrv_weights["lgb"]) * lgb_pred
+        - float(cbrv_weights["r"]) * r_pred
+    ) / float(cbrv_weights["rv"])
+
+    component_frame = pd.DataFrame(
+        {
+            ID_COLUMN: test_ids,
+            "pred_cb": cb_pred,
+            "pred_xgb": xgb_pred,
+            "pred_lgb": lgb_pred,
+            "pred_r": r_pred,
+            "pred_rv": rv_pred,
+        }
+    )
+
+    reconstructed_cbxgblgb = (
+        float(cbxgblgb_weights["cb"]) * component_frame["pred_cb"]
+        + float(cbxgblgb_weights["xgb"]) * component_frame["pred_xgb"]
+        + float(cbxgblgb_weights["lgb"]) * component_frame["pred_lgb"]
+    )
+    reconstructed_cbr = (
+        float(cbr_weights["cb"]) * component_frame["pred_cb"]
+        + float(cbr_weights["xgb"]) * component_frame["pred_xgb"]
+        + float(cbr_weights["lgb"]) * component_frame["pred_lgb"]
+        + float(cbr_weights["r"]) * component_frame["pred_r"]
+    )
+    reconstructed_cbrv = (
+        float(cbrv_weights["cb"]) * component_frame["pred_cb"]
+        + float(cbrv_weights["xgb"]) * component_frame["pred_xgb"]
+        + float(cbrv_weights["lgb"]) * component_frame["pred_lgb"]
+        + float(cbrv_weights["r"]) * component_frame["pred_r"]
+        + float(cbrv_weights["rv"]) * component_frame["pred_rv"]
+    )
+
+    report: dict[str, Any] = {
+        "test_csv_path": str(test_csv_path),
+        "train_csv_path": None if train_csv_path is None else str(train_csv_path),
+        "cb_model_paths": [str(path) for path in cb_model_paths],
+        "cb_feature_blocks": list(normalize_feature_blocks(cb_feature_blocks)),
+        "r_model_path": str(r_model_path),
+        "r_feature_blocks": list(normalize_feature_blocks(r_feature_blocks)),
+        "cbxgblgb_submission_path": str(cbxgblgb_submission_path),
+        "cbr_submission_path": str(cbr_submission_path),
+        "cbrv_submission_path": str(cbrv_submission_path),
+        "rows": int(len(component_frame)),
+        "component_reconstruction": {
+            "cbxgblgb_max_abs_err": float(
+                np.max(np.abs(reconstructed_cbxgblgb.to_numpy(dtype="float64") - cbxgblgb_frame["Churn"].astype("float64").to_numpy(dtype="float64")))
+            ),
+            "cbr_max_abs_err": float(
+                np.max(np.abs(reconstructed_cbr.to_numpy(dtype="float64") - cbr_frame["Churn"].astype("float64").to_numpy(dtype="float64")))
+            ),
+            "cbrv_max_abs_err": float(
+                np.max(np.abs(reconstructed_cbrv.to_numpy(dtype="float64") - cbrv_frame["Churn"].astype("float64").to_numpy(dtype="float64")))
+            ),
+        },
+        "component_ranges": {
+            column: {
+                "min": float(component_frame[column].min()),
+                "max": float(component_frame[column].max()),
+            }
+            for column in ["pred_cb", "pred_xgb", "pred_lgb", "pred_r", "pred_rv"]
+        },
+    }
+    return component_frame, report
+
+
+def _apply_residual_reranker_frame(
+    *,
+    test_df: pd.DataFrame,
+    reference_frame: pd.DataFrame,
+    reference_component_frame: pd.DataFrame | None,
+    train_csv_path: str | Path | None,
+    model_path: str | Path,
+    preset: str,
+    feature_blocks: Sequence[str] | None,
+    alpha: float,
+) -> pd.DataFrame:
+    """Apply a residual reranker over an in-memory reference submission frame."""
+    if float(alpha) < 0.0 or float(alpha) > 1.0:
+        raise ValueError(f"alpha must be in [0, 1], got {alpha}")
+    if ID_COLUMN not in reference_frame.columns or "Churn" not in reference_frame.columns:
+        raise ValueError("reference_frame must contain 'id' and 'Churn' columns.")
+
+    _, x_test = _prepare_specialist_test_matrix(
+        test_df=test_df,
+        feature_blocks=feature_blocks,
+        train_csv_path=train_csv_path,
+    )
+    component_frame = _normalize_reference_component_frame(test_df[ID_COLUMN], reference_component_frame)
+    specialist_mask = build_specialist_mask(test_df, preset).astype(bool)
+    output = test_df[[ID_COLUMN]].merge(
+        reference_frame[[ID_COLUMN, "Churn"]],
+        how="left",
+        on=ID_COLUMN,
+        validate="one_to_one",
+    )
+    if output["Churn"].isna().any():
+        missing_ids = output.loc[output["Churn"].isna(), ID_COLUMN].head(5).tolist()
+        raise ValueError(f"reference frame missing ids from test: {missing_ids}")
+
+    x_test, _ = _append_reference_features(
+        x_test,
+        reference_pred=pd.Series(output["Churn"].astype("float64").values, index=x_test.index, dtype="float64"),
+        reference_component_frame=component_frame,
+        include_logit=True,
+    )
+
+    residual_model = CatBoostRegressor()
+    residual_model.load_model(str(model_path))
+    expected_columns = list(getattr(residual_model, "feature_names_", []))
+    if expected_columns:
+        missing = [column for column in expected_columns if column not in x_test.columns]
+        if missing:
+            raise ValueError(f"Missing inference columns for residual reranker: {missing}")
+        x_test = x_test.loc[:, expected_columns]
+
+    residual_pred = pd.Series(np.nan, index=x_test.index, dtype="float64")
+    residual_pred.loc[specialist_mask] = residual_model.predict(x_test.loc[specialist_mask])
+    output["specialist_mask"] = specialist_mask.astype("int8").values
+    output["residual_pred"] = residual_pred.values
+    output.loc[specialist_mask, "Churn"] = _clip_probability(
+        output.loc[specialist_mask, "Churn"].astype("float64") + float(alpha) * residual_pred.loc[specialist_mask]
+    ).values
+    return output
+
+
+def make_residual_reranker_prediction(
+    *,
+    test_csv_path: str | Path,
+    reference_submission_path: str | Path,
+    reference_component_frame: pd.DataFrame | None = None,
+    train_csv_path: str | Path | None = None,
+    model_path: str | Path,
+    preset: str,
+    feature_blocks: Sequence[str] | None,
+    alpha: float,
+) -> pd.DataFrame:
+    """Apply a trained residual reranker on top of a reference submission."""
+    test_df = load_csv(test_csv_path)
+    reference_frame = _load_reference_submission_frame(
+        test_df=test_df,
+        reference_submission_path=reference_submission_path,
+    )
+    return _apply_residual_reranker_frame(
+        test_df=test_df,
+        reference_frame=reference_frame,
+        reference_component_frame=reference_component_frame,
+        train_csv_path=train_csv_path,
+        model_path=model_path,
+        preset=preset,
+        feature_blocks=feature_blocks,
+        alpha=alpha,
+    )
+
+
+def make_residual_reranker_chain_submission(
+    *,
+    test_csv_path: str | Path,
+    reference_submission_path: str | Path,
+    reference_component_frame: pd.DataFrame | None = None,
+    train_csv_path: str | Path | None = None,
+    reference_mode: str = "previous",
+    steps: Sequence[dict[str, Any]],
+    output_csv_path: str | Path,
+    report_path: str | Path,
+) -> dict[str, Any]:
+    """Apply a sequence of residual rerankers over a reference submission and write artifacts."""
+    if not steps:
+        raise ValueError("steps must contain at least one residual reranker spec.")
+    if reference_mode not in {"previous", "base"}:
+        raise ValueError(f"reference_mode must be 'previous' or 'base', got {reference_mode!r}")
+    if reference_component_frame is not None and reference_mode != "base":
+        raise ValueError("teacher-aware chaining requires reference_mode='base' when reference_component_frame is provided")
+
+    test_df = load_csv(test_csv_path)
+    current_output = _load_reference_submission_frame(
+        test_df=test_df,
+        reference_submission_path=reference_submission_path,
+    )
+    base_output = current_output.copy()
+    base_pred = current_output["Churn"].astype("float64").copy()
+    step_rows: list[dict[str, Any]] = []
+
+    for index, raw_step in enumerate(steps, start=1):
+        preset = str(raw_step["preset"])
+        model_path = str(raw_step["model_path"])
+        alpha = float(raw_step["alpha"])
+        feature_blocks = normalize_feature_blocks(raw_step.get("feature_blocks"))
+        reference_frame = current_output[[ID_COLUMN, "Churn"]].copy() if reference_mode == "previous" else base_output[[ID_COLUMN, "Churn"]].copy()
+
+        step_output = _apply_residual_reranker_frame(
+            test_df=test_df,
+            reference_frame=reference_frame,
+            reference_component_frame=reference_component_frame,
+            train_csv_path=train_csv_path,
+            model_path=model_path,
+            preset=preset,
+            feature_blocks=feature_blocks,
+            alpha=alpha,
+        )
+        if reference_mode == "base":
+            next_output = current_output[[ID_COLUMN, "Churn"]].copy()
+            step_mask = step_output["specialist_mask"].astype(bool)
+            next_output.loc[step_mask, "Churn"] = step_output.loc[step_mask, "Churn"].astype("float64").values
+            next_output["specialist_mask"] = step_output["specialist_mask"].astype("int8").values
+            if "residual_pred" in step_output.columns:
+                next_output["residual_pred"] = step_output["residual_pred"].values
+            if "specialist_pred" in step_output.columns:
+                next_output["specialist_pred"] = step_output["specialist_pred"].values
+        else:
+            next_output = step_output
+
+        delta = next_output["Churn"].astype("float64") - current_output["Churn"].astype("float64")
+        changed_mask = delta.abs().gt(1e-15)
+        step_rows.append(
+            {
+                "step": int(index),
+                "preset": preset,
+                "model_path": model_path,
+                "alpha": alpha,
+                "feature_blocks": list(feature_blocks),
+                "mask_rows": int(next_output["specialist_mask"].sum()),
+                "changed_rows": int(changed_mask.sum()),
+                "mae_shift_vs_previous": float(delta.abs().mean()),
+                "max_abs_shift_vs_previous": float(delta.abs().max()),
+            }
+        )
+        current_output = next_output[[ID_COLUMN, "Churn"]].copy()
+
+    out_path = ensure_parent_dir(output_csv_path)
+    current_output.to_csv(out_path, index=False)
+
+    final_delta = current_output["Churn"].astype("float64") - base_pred
+    report: dict[str, Any] = {
+        "test_csv_path": str(test_csv_path),
+        "train_csv_path": None if train_csv_path is None else str(train_csv_path),
+        "reference_submission_path": str(reference_submission_path),
+        "reference_mode": reference_mode,
+        "output_csv_path": str(output_csv_path),
+        "report_path": str(report_path),
+        "steps": step_rows,
+        "test_rows": int(len(current_output)),
+        "changed_rows_vs_base": int(final_delta.abs().gt(1e-15).sum()),
+        "mae_vs_base": float(final_delta.abs().mean()),
+        "max_abs_shift_vs_base": float(final_delta.abs().max()),
+        "min_pred": float(current_output["Churn"].min()),
+        "max_pred": float(current_output["Churn"].max()),
+    }
+    write_json(report_path, report)
+    return report
+
+
+def make_local_calibrated_prediction(
+    *,
+    test_csv_path: str | Path,
+    reference_submission_path: str | Path,
+    model_path: str | Path,
+) -> pd.DataFrame:
+    """Apply a saved local calibrator bundle on top of a reference submission."""
+    bundle = _load_pickle(model_path)
+    preset = str(bundle["preset"])
+    alpha = float(bundle["alpha"])
+    calibrator = dict(bundle["calibrator"])
+
+    if alpha < 0.0 or alpha > 1.0:
+        raise ValueError(f"alpha must be in [0, 1], got {alpha}")
+
+    test_df = load_csv(test_csv_path)
+    reference_submission = pd.read_csv(reference_submission_path)
+    if ID_COLUMN not in reference_submission.columns or "Churn" not in reference_submission.columns:
+        raise ValueError(f"{reference_submission_path} must contain columns '{ID_COLUMN}' and 'Churn'.")
+
+    output = test_df[[ID_COLUMN]].merge(reference_submission[[ID_COLUMN, "Churn"]], how="left", on=ID_COLUMN, validate="one_to_one")
+    if output["Churn"].isna().any():
+        missing_ids = output.loc[output["Churn"].isna(), ID_COLUMN].head(5).tolist()
+        raise ValueError(f"reference submission missing ids from test: {missing_ids}")
+
+    specialist_mask = build_specialist_mask(test_df, preset).astype(bool)
+    reference_pred = pd.Series(output["Churn"].astype("float64").values, index=output.index)
+    calibrated_pred = pd.Series(np.nan, index=output.index, dtype="float64")
+    calibrated_pred.loc[specialist_mask] = _predict_local_calibrator(
+        calibrator,
+        reference_pred.loc[specialist_mask],
+    ).values
+
+    output["specialist_mask"] = specialist_mask.astype("int8").values
+    output["calibrated_pred"] = calibrated_pred.values
+    output.loc[specialist_mask, "Churn"] = (
+        (1.0 - alpha) * output.loc[specialist_mask, "Churn"].astype("float64")
+        + alpha * calibrated_pred.loc[specialist_mask]
+    )
+    return output

--- a/src/churn_baseline/specialist.py
+++ b/src/churn_baseline/specialist.py
@@ -45,6 +45,8 @@ MTM_NOINTERNET_NO_0_6 = "mtm_nointernet_no_0_6"
 EC_MTM_FIBER_PAPERLESS_0_6 = "ec_mtm_fiber_paperless_0_6"
 EC_MTM_FIBER_PAPERLESS_25_48 = "ec_mtm_fiber_paperless_25_48"
 EC_MTM_FIBER_PAPERLESS_ANY = "ec_mtm_fiber_paperless_any"
+EC_MTM_DSL_PAPERLESS_0_6 = "ec_mtm_dsl_paperless_0_6"
+EC_MTM_DSL_PAPERLESS_ANY = "ec_mtm_dsl_paperless_any"
 CLASSIFIER = "classifier"
 RESIDUAL = "residual"
 
@@ -94,6 +96,12 @@ SPECIALIST_PRESETS: dict[str, str] = {
     ),
     EC_MTM_FIBER_PAPERLESS_ANY: (
         "Electronic check, Month-to-month, Fiber optic, PaperlessBilling=Yes, cualquier tenure."
+    ),
+    EC_MTM_DSL_PAPERLESS_0_6: (
+        "Electronic check, Month-to-month, DSL, PaperlessBilling=Yes, tenure <= 6."
+    ),
+    EC_MTM_DSL_PAPERLESS_ANY: (
+        "Electronic check, Month-to-month, DSL, PaperlessBilling=Yes, cualquier tenure."
     ),
 }
 
@@ -239,6 +247,21 @@ def build_specialist_mask(frame: pd.DataFrame, preset: str) -> pd.Series:
         return (
             contract.eq("Month-to-month")
             & internet.eq("Fiber optic")
+            & payment.eq("Electronic check")
+            & paperless.eq("Yes")
+        )
+    if preset == EC_MTM_DSL_PAPERLESS_0_6:
+        return (
+            contract.eq("Month-to-month")
+            & internet.eq("DSL")
+            & payment.eq("Electronic check")
+            & paperless.eq("Yes")
+            & tenure.le(6)
+        )
+    if preset == EC_MTM_DSL_PAPERLESS_ANY:
+        return (
+            contract.eq("Month-to-month")
+            & internet.eq("DSL")
             & payment.eq("Electronic check")
             & paperless.eq("Yes")
         )

--- a/src/churn_baseline/specialist.py
+++ b/src/churn_baseline/specialist.py
@@ -31,11 +31,17 @@ LONG_FIBER_ANY = "long_fiber_any"
 MANUAL_NO_INTERNET = "manual_no_internet"
 ONE_YEAR_FIBER_ANY = "one_year_fiber_any"
 ONE_YEAR_DSL_ANY = "one_year_dsl_any"
+ONE_YEAR_DSL_PAPERLESS_49PLUS = "one_year_dsl_paperless_49plus"
 TWO_YEAR_FIBER_ANY = "two_year_fiber_any"
+TWO_YEAR_DSL_PAPERLESS_49PLUS = "two_year_dsl_paperless_49plus"
 ONE_YEAR_FIBER_PAPERLESS_49PLUS = "one_year_fiber_paperless_49plus"
+ONE_YEAR_FIBER_PAPERLESS_25_48 = "one_year_fiber_paperless_25_48"
 TWO_YEAR_FIBER_PAPERLESS_49PLUS = "two_year_fiber_paperless_49plus"
+TWO_YEAR_FIBER_NOPAPERLESS_49PLUS = "two_year_fiber_nopaperless_49plus"
 MTM_DSL_PAPERLESS_25_48_MANUAL = "mtm_dsl_paperless_25_48_manual"
+MTM_DSL_PAPERLESS_25_48_ANY = "mtm_dsl_paperless_25_48_any"
 MTM_NOINTERNET_MAILED_0_24 = "mtm_nointernet_mailed_0_24"
+MTM_NOINTERNET_NO_0_6 = "mtm_nointernet_no_0_6"
 CLASSIFIER = "classifier"
 RESIDUAL = "residual"
 
@@ -56,15 +62,26 @@ SPECIALIST_PRESETS: dict[str, str] = {
     MANUAL_NO_INTERNET: "InternetService=No con payment manual (Electronic o Mailed check).",
     ONE_YEAR_FIBER_ANY: "One year, Fiber optic, cualquier tenure.",
     ONE_YEAR_DSL_ANY: "One year, DSL, cualquier tenure.",
+    ONE_YEAR_DSL_PAPERLESS_49PLUS: "One year, DSL, PaperlessBilling=Yes, tenure >= 49.",
     TWO_YEAR_FIBER_ANY: "Two year, Fiber optic, cualquier tenure.",
+    TWO_YEAR_DSL_PAPERLESS_49PLUS: "Two year, DSL, PaperlessBilling=Yes, tenure >= 49.",
     ONE_YEAR_FIBER_PAPERLESS_49PLUS: "One year, Fiber optic, PaperlessBilling=Yes, tenure >= 49.",
+    ONE_YEAR_FIBER_PAPERLESS_25_48: "One year, Fiber optic, PaperlessBilling=Yes, tenure 25-48.",
     TWO_YEAR_FIBER_PAPERLESS_49PLUS: "Two year, Fiber optic, PaperlessBilling=Yes, tenure >= 49.",
+    TWO_YEAR_FIBER_NOPAPERLESS_49PLUS: "Two year, Fiber optic, PaperlessBilling=No, tenure >= 49.",
     MTM_DSL_PAPERLESS_25_48_MANUAL: (
         "Month-to-month, DSL, PaperlessBilling=Yes, tenure 25-48, "
         "payment manual (Electronic check o Mailed check)."
     ),
+    MTM_DSL_PAPERLESS_25_48_ANY: (
+        "Month-to-month, DSL, PaperlessBilling=Yes, tenure 25-48, "
+        "cualquier payment method."
+    ),
     MTM_NOINTERNET_MAILED_0_24: (
         "Month-to-month, InternetService=No, Mailed check, tenure <= 24."
+    ),
+    MTM_NOINTERNET_NO_0_6: (
+        "Month-to-month, InternetService=No, PaperlessBilling=No, tenure <= 6."
     ),
 }
 
@@ -152,12 +169,20 @@ def build_specialist_mask(frame: pd.DataFrame, preset: str) -> pd.Series:
         return contract.eq("One year") & internet.eq("Fiber optic")
     if preset == ONE_YEAR_DSL_ANY:
         return contract.eq("One year") & internet.eq("DSL")
+    if preset == ONE_YEAR_DSL_PAPERLESS_49PLUS:
+        return contract.eq("One year") & internet.eq("DSL") & paperless.eq("Yes") & tenure.ge(49)
     if preset == TWO_YEAR_FIBER_ANY:
         return contract.eq("Two year") & internet.eq("Fiber optic")
+    if preset == TWO_YEAR_DSL_PAPERLESS_49PLUS:
+        return contract.eq("Two year") & internet.eq("DSL") & paperless.eq("Yes") & tenure.ge(49)
     if preset == ONE_YEAR_FIBER_PAPERLESS_49PLUS:
         return contract.eq("One year") & internet.eq("Fiber optic") & paperless.eq("Yes") & tenure.ge(49)
+    if preset == ONE_YEAR_FIBER_PAPERLESS_25_48:
+        return contract.eq("One year") & internet.eq("Fiber optic") & paperless.eq("Yes") & tenure.between(25, 48)
     if preset == TWO_YEAR_FIBER_PAPERLESS_49PLUS:
         return contract.eq("Two year") & internet.eq("Fiber optic") & paperless.eq("Yes") & tenure.ge(49)
+    if preset == TWO_YEAR_FIBER_NOPAPERLESS_49PLUS:
+        return contract.eq("Two year") & internet.eq("Fiber optic") & paperless.eq("No") & tenure.ge(49)
     if preset == MTM_DSL_PAPERLESS_25_48_MANUAL:
         return (
             contract.eq("Month-to-month")
@@ -166,12 +191,21 @@ def build_specialist_mask(frame: pd.DataFrame, preset: str) -> pd.Series:
             & tenure.between(25, 48)
             & payment.isin(["Electronic check", "Mailed check"])
         )
+    if preset == MTM_DSL_PAPERLESS_25_48_ANY:
+        return contract.eq("Month-to-month") & internet.eq("DSL") & paperless.eq("Yes") & tenure.between(25, 48)
     if preset == MTM_NOINTERNET_MAILED_0_24:
         return (
             contract.eq("Month-to-month")
             & internet.eq("No")
             & payment.eq("Mailed check")
             & tenure.le(24)
+        )
+    if preset == MTM_NOINTERNET_NO_0_6:
+        return (
+            contract.eq("Month-to-month")
+            & internet.eq("No")
+            & paperless.eq("No")
+            & tenure.le(6)
         )
     raise ValueError(f"Unsupported specialist preset '{preset}'. Available: {sorted(SPECIALIST_PRESETS)}")
 

--- a/src/churn_baseline/specialist.py
+++ b/src/churn_baseline/specialist.py
@@ -42,6 +42,9 @@ MTM_DSL_PAPERLESS_25_48_MANUAL = "mtm_dsl_paperless_25_48_manual"
 MTM_DSL_PAPERLESS_25_48_ANY = "mtm_dsl_paperless_25_48_any"
 MTM_NOINTERNET_MAILED_0_24 = "mtm_nointernet_mailed_0_24"
 MTM_NOINTERNET_NO_0_6 = "mtm_nointernet_no_0_6"
+EC_MTM_FIBER_PAPERLESS_0_6 = "ec_mtm_fiber_paperless_0_6"
+EC_MTM_FIBER_PAPERLESS_25_48 = "ec_mtm_fiber_paperless_25_48"
+EC_MTM_FIBER_PAPERLESS_ANY = "ec_mtm_fiber_paperless_any"
 CLASSIFIER = "classifier"
 RESIDUAL = "residual"
 
@@ -82,6 +85,15 @@ SPECIALIST_PRESETS: dict[str, str] = {
     ),
     MTM_NOINTERNET_NO_0_6: (
         "Month-to-month, InternetService=No, PaperlessBilling=No, tenure <= 6."
+    ),
+    EC_MTM_FIBER_PAPERLESS_0_6: (
+        "Electronic check, Month-to-month, Fiber optic, PaperlessBilling=Yes, tenure <= 6."
+    ),
+    EC_MTM_FIBER_PAPERLESS_25_48: (
+        "Electronic check, Month-to-month, Fiber optic, PaperlessBilling=Yes, tenure 25-48."
+    ),
+    EC_MTM_FIBER_PAPERLESS_ANY: (
+        "Electronic check, Month-to-month, Fiber optic, PaperlessBilling=Yes, cualquier tenure."
     ),
 }
 
@@ -206,6 +218,29 @@ def build_specialist_mask(frame: pd.DataFrame, preset: str) -> pd.Series:
             & internet.eq("No")
             & paperless.eq("No")
             & tenure.le(6)
+        )
+    if preset == EC_MTM_FIBER_PAPERLESS_0_6:
+        return (
+            contract.eq("Month-to-month")
+            & internet.eq("Fiber optic")
+            & payment.eq("Electronic check")
+            & paperless.eq("Yes")
+            & tenure.le(6)
+        )
+    if preset == EC_MTM_FIBER_PAPERLESS_25_48:
+        return (
+            contract.eq("Month-to-month")
+            & internet.eq("Fiber optic")
+            & payment.eq("Electronic check")
+            & paperless.eq("Yes")
+            & tenure.between(25, 48)
+        )
+    if preset == EC_MTM_FIBER_PAPERLESS_ANY:
+        return (
+            contract.eq("Month-to-month")
+            & internet.eq("Fiber optic")
+            & payment.eq("Electronic check")
+            & paperless.eq("Yes")
         )
     raise ValueError(f"Unsupported specialist preset '{preset}'. Available: {sorted(SPECIALIST_PRESETS)}")
 

--- a/src/churn_baseline/specialist.py
+++ b/src/churn_baseline/specialist.py
@@ -50,6 +50,7 @@ EC_MTM_DSL_PAPERLESS_0_6 = "ec_mtm_dsl_paperless_0_6"
 EC_MTM_DSL_PAPERLESS_ANY = "ec_mtm_dsl_paperless_any"
 CLASSIFIER = "classifier"
 RESIDUAL = "residual"
+FEATURE = "feature"
 
 SPECIALIST_PRESETS: dict[str, str] = {
     EARLY_MANUAL_INTERNET: (
@@ -114,7 +115,7 @@ _MIN_SPECIALIST_VALID_ROWS = 500
 PLATT = "platt"
 ISOTONIC = "isotonic"
 CALIBRATION_METHODS: tuple[str, ...] = (PLATT, ISOTONIC)
-SPECIALIST_APPROACHES: tuple[str, ...] = (CLASSIFIER, RESIDUAL)
+SPECIALIST_APPROACHES: tuple[str, ...] = (CLASSIFIER, RESIDUAL, FEATURE)
 _TEACHER_COMPONENT_PREFIX = "teacher_component_"
 
 
@@ -469,7 +470,42 @@ def _predict_local_calibrator(bundle: dict[str, Any], pred: pd.Series | np.ndarr
     return pd.Series(calibrated, index=getattr(pred, "index", None), dtype="float64")
 
 
-def run_specialist_override_cv(
+def _derive_family_model_path(model_path: str | Path) -> Path:
+    path = Path(model_path)
+    suffix = path.suffix or ".cbm"
+    return path.with_name(f"{path.stem}_family{suffix}")
+
+
+def _append_family_stack_features(
+    x: pd.DataFrame,
+    *,
+    specialist_mask: pd.Series,
+    specialist_pred: pd.Series,
+    reference_pred: pd.Series,
+    neutral_value: float = 0.5,
+) -> pd.DataFrame:
+    out = x.copy()
+    specialist_mask_aligned = specialist_mask.reindex(out.index).fillna(False).astype(bool)
+    specialist_pred_aligned = specialist_pred.reindex(out.index)
+    reference_pred_aligned = reference_pred.reindex(out.index).astype("float64")
+
+    family_pred_feature = pd.Series(float(neutral_value), index=out.index, dtype="float64")
+    family_pred_feature.loc[specialist_mask_aligned] = (
+        specialist_pred_aligned.loc[specialist_mask_aligned].astype("float64").values
+    )
+    family_delta_feature = pd.Series(0.0, index=out.index, dtype="float64")
+    family_delta_feature.loc[specialist_mask_aligned] = (
+        specialist_pred_aligned.loc[specialist_mask_aligned].astype("float64").values
+        - reference_pred_aligned.loc[specialist_mask_aligned].astype("float64").values
+    )
+
+    out["family_specialist_pred_feature"] = family_pred_feature.astype("float64").values
+    out["family_specialist_available"] = specialist_mask_aligned.astype("int8").values
+    out["family_specialist_delta_vs_reference"] = family_delta_feature.astype("float64").values
+    return out
+
+
+def _fit_specialist_classifier_bundle(
     *,
     train_csv_path: str | Path,
     preset: str,
@@ -481,12 +517,8 @@ def run_specialist_override_cv(
     random_state: int,
     early_stopping_rounds: int,
     verbose: int,
-    alpha_grid: Sequence[float],
     model_path: str | Path,
-    metrics_path: str | Path,
-    oof_path: str | Path,
 ) -> dict[str, Any]:
-    """Train a specialist model on a hard cohort and scan local override alpha."""
     if folds < 2:
         raise ValueError("folds must be >= 2")
 
@@ -495,11 +527,16 @@ def run_specialist_override_cv(
     specialist_mask = build_specialist_mask(train_df, preset).astype(bool)
 
     reference_by_id = pd.Series(reference_pred, copy=True)
-    reference_pred = train_df[ID_COLUMN].map(reference_by_id)
-    if reference_pred.isna().any():
-        missing_ids = train_df.loc[reference_pred.isna(), ID_COLUMN].head(5).tolist()
+    reference_pred_aligned = train_df[ID_COLUMN].map(reference_by_id)
+    if reference_pred_aligned.isna().any():
+        missing_ids = train_df.loc[reference_pred_aligned.isna(), ID_COLUMN].head(5).tolist()
         raise ValueError(f"reference_pred missing ids from train: {missing_ids}")
-    reference_pred = pd.Series(reference_pred.values, index=x.index, dtype="float64", name="reference_pred")
+    reference_pred_aligned = pd.Series(
+        reference_pred_aligned.values,
+        index=x.index,
+        dtype="float64",
+        name="reference_pred",
+    )
     component_frame = _normalize_reference_component_frame(train_df[ID_COLUMN], reference_component_frame)
     mask_rows = int(specialist_mask.sum())
     if mask_rows < _MIN_SPECIALIST_TRAIN_ROWS:
@@ -538,8 +575,8 @@ def run_specialist_override_cv(
         if y_train.iloc[train_mask].nunique() < 2 or y_valid.iloc[valid_mask].nunique() < 2:
             raise ValueError(f"Fold {fold_number} preset '{preset}' lost one class in train or valid.")
 
-        train_reference = reference_pred.iloc[train_idx]
-        valid_reference = reference_pred.iloc[valid_idx]
+        train_reference = reference_pred_aligned.iloc[train_idx]
+        valid_reference = reference_pred_aligned.iloc[valid_idx]
         train_components = component_frame.iloc[train_idx] if component_frame is not None else None
         valid_components = component_frame.iloc[valid_idx] if component_frame is not None else None
         x_train, train_disagreement_columns = _append_reference_features(
@@ -588,7 +625,7 @@ def run_specialist_override_cv(
             best_iteration = fold_final_iterations - 1
         fold_iterations.append(fold_final_iterations)
 
-        reference_on_mask = reference_pred.iloc[valid_idx].iloc[valid_mask]
+        reference_on_mask = reference_pred_aligned.iloc[valid_idx].iloc[valid_mask]
         reference_auc = binary_auc(y_valid.iloc[valid_mask], reference_on_mask)
         specialist_auc = binary_auc(y_valid.iloc[valid_mask], valid_specialist_pred)
         fold_rows.append(
@@ -608,6 +645,111 @@ def run_specialist_override_cv(
 
     if specialist_pred.loc[specialist_mask].isna().any():
         raise RuntimeError("Specialist OOF predictions contain missing values inside the target cohort.")
+
+    final_iterations = max(int(round(float(np.mean(fold_iterations)))), 1)
+    x_full = _transform_single_with_stateful_blocks(x, stateful_blocks)
+    x_full_local, disagreement_columns_full = _append_reference_features(
+        x_full,
+        reference_pred=reference_pred_aligned,
+        reference_component_frame=component_frame,
+        include_logit=False,
+    )
+    if disagreement_columns and disagreement_columns_full != disagreement_columns:
+        raise RuntimeError("Teacher disagreement feature mismatch between CV folds and full train.")
+    if not disagreement_columns:
+        disagreement_columns = list(disagreement_columns_full)
+    cat_columns = infer_categorical_columns(x_full_local)
+    full_model = fit_full_train(
+        x_train=x_full_local.loc[specialist_mask],
+        y_train=y.loc[specialist_mask],
+        cat_columns=cat_columns,
+        params=CatBoostHyperParams(
+            iterations=final_iterations,
+            learning_rate=params.learning_rate,
+            depth=params.depth,
+            l2_leaf_reg=params.l2_leaf_reg,
+            random_seed=params.random_seed,
+            loss_function=params.loss_function,
+            eval_metric=params.eval_metric,
+        ),
+        verbose=verbose,
+    )
+    save_model(full_model, model_path)
+
+    full_specialist_pred = pd.Series(index=x.index, dtype="float64", name="specialist_pred_full")
+    full_specialist_pred.loc[specialist_mask] = predict_proba(
+        full_model,
+        x_full_local.loc[specialist_mask],
+    ).values
+
+    return {
+        "train_df": train_df,
+        "normalized_blocks": normalized_blocks,
+        "stateful_blocks": stateful_blocks,
+        "x": x,
+        "y": y,
+        "specialist_mask": specialist_mask,
+        "mask_rows": mask_rows,
+        "reference_pred": reference_pred_aligned,
+        "reference_component_frame": component_frame,
+        "specialist_pred": specialist_pred,
+        "specialist_pred_full": full_specialist_pred,
+        "fold_rows": fold_rows,
+        "fold_final_iterations": [int(value) for value in fold_iterations],
+        "final_iterations": int(final_iterations),
+        "teacher_disagreement_columns": disagreement_columns,
+        "specialist_feature_count": int(x_full_local.shape[1]),
+        "specialist_feature_columns": list(x_full_local.columns),
+        "specialist_categorical_columns": cat_columns,
+        "model_path": str(model_path),
+    }
+
+
+def run_specialist_override_cv(
+    *,
+    train_csv_path: str | Path,
+    preset: str,
+    reference_pred: pd.Series,
+    reference_component_frame: pd.DataFrame | None,
+    params: CatBoostHyperParams,
+    feature_blocks: Sequence[str] | None,
+    folds: int,
+    random_state: int,
+    early_stopping_rounds: int,
+    verbose: int,
+    alpha_grid: Sequence[float],
+    model_path: str | Path,
+    metrics_path: str | Path,
+    oof_path: str | Path,
+) -> dict[str, Any]:
+    """Train a specialist model on a hard cohort and scan local override alpha."""
+    bundle = _fit_specialist_classifier_bundle(
+        train_csv_path=train_csv_path,
+        preset=preset,
+        reference_pred=reference_pred,
+        reference_component_frame=reference_component_frame,
+        params=params,
+        feature_blocks=feature_blocks,
+        folds=folds,
+        random_state=random_state,
+        early_stopping_rounds=early_stopping_rounds,
+        verbose=verbose,
+        model_path=model_path,
+    )
+    train_df = bundle["train_df"]
+    normalized_blocks = bundle["normalized_blocks"]
+    y = bundle["y"]
+    specialist_mask = bundle["specialist_mask"]
+    mask_rows = bundle["mask_rows"]
+    reference_pred = bundle["reference_pred"]
+    specialist_pred = bundle["specialist_pred"]
+    fold_rows = bundle["fold_rows"]
+    fold_iterations = bundle["fold_final_iterations"]
+    final_iterations = bundle["final_iterations"]
+    disagreement_columns = bundle["teacher_disagreement_columns"]
+    feature_count = bundle["specialist_feature_count"]
+    feature_columns = bundle["specialist_feature_columns"]
+    cat_columns = bundle["specialist_categorical_columns"]
 
     alpha_scan_rows: list[dict[str, Any]] = []
     for alpha in alpha_grid:
@@ -634,36 +776,6 @@ def run_specialist_override_cv(
         + best_alpha * specialist_pred.loc[specialist_mask]
     )
 
-    final_iterations = max(int(round(float(np.mean(fold_iterations)))), 1)
-    x_full = _transform_single_with_stateful_blocks(x, stateful_blocks)
-    x_full, disagreement_columns_full = _append_reference_features(
-        x_full,
-        reference_pred=reference_pred,
-        reference_component_frame=component_frame,
-        include_logit=False,
-    )
-    if disagreement_columns and disagreement_columns_full != disagreement_columns:
-        raise RuntimeError("Teacher disagreement feature mismatch between CV folds and full train.")
-    if not disagreement_columns:
-        disagreement_columns = list(disagreement_columns_full)
-    cat_columns = infer_categorical_columns(x_full)
-    full_model = fit_full_train(
-        x_train=x_full.loc[specialist_mask],
-        y_train=y.loc[specialist_mask],
-        cat_columns=cat_columns,
-        params=CatBoostHyperParams(
-            iterations=final_iterations,
-            learning_rate=params.learning_rate,
-            depth=params.depth,
-            l2_leaf_reg=params.l2_leaf_reg,
-            random_seed=params.random_seed,
-            loss_function=params.loss_function,
-            eval_metric=params.eval_metric,
-        ),
-        verbose=verbose,
-    )
-    save_model(full_model, model_path)
-
     oof_output = pd.DataFrame(
         {
             ID_COLUMN: train_df[ID_COLUMN].values,
@@ -684,8 +796,8 @@ def run_specialist_override_cv(
         "specialist_rows": mask_rows,
         "specialist_row_share": float(mask_rows / max(len(train_df), 1)),
         "specialist_positive_rate": float(y.loc[specialist_mask].mean()),
-        "feature_count": int(x_full.shape[1]),
-        "feature_columns": list(x_full.columns),
+        "feature_count": int(feature_count),
+        "feature_columns": list(feature_columns),
         "feature_blocks": list(normalized_blocks),
         "teacher_disagreement_columns": disagreement_columns,
         "categorical_columns": cat_columns,
@@ -703,6 +815,215 @@ def run_specialist_override_cv(
         "delta_vs_reference_oof_auc": float(binary_auc(y, candidate_best) - binary_auc(y, reference_pred)),
         "model_path": str(model_path),
         "oof_path": str(oof_path),
+        "target_column": TARGET_COLUMN,
+        "id_column": ID_COLUMN,
+    }
+    write_json(metrics_path, metrics)
+    return metrics
+
+
+def run_family_feature_challenger_cv(
+    *,
+    train_csv_path: str | Path,
+    preset: str,
+    reference_pred: pd.Series,
+    reference_component_frame: pd.DataFrame | None,
+    params: CatBoostHyperParams,
+    feature_blocks: Sequence[str] | None,
+    folds: int,
+    random_state: int,
+    early_stopping_rounds: int,
+    verbose: int,
+    alpha_grid: Sequence[float],
+    model_path: str | Path,
+    metrics_path: str | Path,
+    oof_path: str | Path,
+) -> dict[str, Any]:
+    """Train a family-specific classifier, expose its OOF predictions as global features, and evaluate a challenger."""
+    family_model_path = _derive_family_model_path(model_path)
+    bundle = _fit_specialist_classifier_bundle(
+        train_csv_path=train_csv_path,
+        preset=preset,
+        reference_pred=reference_pred,
+        reference_component_frame=reference_component_frame,
+        params=params,
+        feature_blocks=feature_blocks,
+        folds=folds,
+        random_state=random_state,
+        early_stopping_rounds=early_stopping_rounds,
+        verbose=verbose,
+        model_path=family_model_path,
+    )
+
+    train_df = bundle["train_df"]
+    normalized_blocks = bundle["normalized_blocks"]
+    stateful_blocks = bundle["stateful_blocks"]
+    x = bundle["x"]
+    y = bundle["y"]
+    specialist_mask = bundle["specialist_mask"]
+    mask_rows = bundle["mask_rows"]
+    reference_pred = bundle["reference_pred"]
+    specialist_pred = bundle["specialist_pred"]
+    specialist_pred_full = bundle["specialist_pred_full"]
+
+    splitter = StratifiedKFold(n_splits=folds, shuffle=True, random_state=random_state)
+    challenger_pred = pd.Series(index=x.index, dtype="float64", name="challenger_pred")
+    fold_rows: list[dict[str, Any]] = []
+    fold_iterations: list[int] = []
+
+    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x, y), start=1):
+        x_train = x.iloc[train_idx]
+        y_train = y.iloc[train_idx]
+        x_valid = x.iloc[valid_idx]
+        y_valid = y.iloc[valid_idx]
+        x_train, x_valid = _transform_pair_with_stateful_blocks(x_train, x_valid, stateful_blocks)
+        x_train = _append_family_stack_features(
+            x_train,
+            specialist_mask=specialist_mask.iloc[train_idx],
+            specialist_pred=specialist_pred.iloc[train_idx],
+            reference_pred=reference_pred.iloc[train_idx],
+        )
+        x_valid = _append_family_stack_features(
+            x_valid,
+            specialist_mask=specialist_mask.iloc[valid_idx],
+            specialist_pred=specialist_pred.iloc[valid_idx],
+            reference_pred=reference_pred.iloc[valid_idx],
+        )
+        cat_columns = infer_categorical_columns(x_train)
+
+        fold_model = fit_with_validation(
+            x_train=x_train,
+            y_train=y_train,
+            x_valid=x_valid,
+            y_valid=y_valid,
+            cat_columns=cat_columns,
+            params=CatBoostHyperParams(
+                iterations=params.iterations,
+                learning_rate=params.learning_rate,
+                depth=params.depth,
+                l2_leaf_reg=params.l2_leaf_reg,
+                random_seed=random_state,
+                loss_function=params.loss_function,
+                eval_metric=params.eval_metric,
+            ),
+            early_stopping_rounds=early_stopping_rounds,
+            verbose=verbose,
+        )
+
+        fold_pred = predict_proba(fold_model, x_valid)
+        challenger_pred.iloc[valid_idx] = fold_pred.values
+
+        fold_final_iterations = best_iteration_or_default(fold_model, params.iterations)
+        best_iteration = fold_model.get_best_iteration()
+        if best_iteration is None or best_iteration < 0:
+            best_iteration = fold_final_iterations - 1
+        fold_iterations.append(fold_final_iterations)
+        valid_mask = specialist_mask.iloc[valid_idx].to_numpy(dtype=bool)
+        fold_rows.append(
+            {
+                "fold": fold_number,
+                "valid_rows": int(len(valid_idx)),
+                "valid_mask_rows": int(np.sum(valid_mask)),
+                "reference_auc": binary_auc(y_valid, reference_pred.iloc[valid_idx]),
+                "challenger_auc": binary_auc(y_valid, fold_pred),
+                "reference_auc_on_mask": binary_auc(y_valid.iloc[valid_mask], reference_pred.iloc[valid_idx].iloc[valid_mask]),
+                "challenger_auc_on_mask": binary_auc(y_valid.iloc[valid_mask], fold_pred.iloc[valid_mask]),
+                "best_iteration": int(best_iteration),
+                "final_iterations": int(fold_final_iterations),
+            }
+        )
+
+    if challenger_pred.isna().any():
+        raise RuntimeError("Challenger OOF predictions contain missing values.")
+
+    alpha_scan_rows: list[dict[str, Any]] = []
+    for alpha in alpha_grid:
+        alpha_value = float(alpha)
+        candidate = ((1.0 - alpha_value) * reference_pred + alpha_value * challenger_pred).astype("float64")
+        alpha_scan_rows.append(
+            {
+                "alpha": alpha_value,
+                "oof_auc": binary_auc(y, candidate),
+                "oof_auc_on_mask": binary_auc(y.loc[specialist_mask], candidate.loc[specialist_mask]),
+                "reference_auc_on_mask": binary_auc(y.loc[specialist_mask], reference_pred.loc[specialist_mask]),
+            }
+        )
+
+    best_alpha_row = max(alpha_scan_rows, key=lambda row: row["oof_auc"])
+    best_alpha = float(best_alpha_row["alpha"])
+    candidate_best = ((1.0 - best_alpha) * reference_pred + best_alpha * challenger_pred).astype("float64")
+
+    x_full = _transform_single_with_stateful_blocks(x, stateful_blocks)
+    x_full = _append_family_stack_features(
+        x_full,
+        specialist_mask=specialist_mask,
+        specialist_pred=specialist_pred_full,
+        reference_pred=reference_pred,
+    )
+    cat_columns = infer_categorical_columns(x_full)
+    final_iterations = max(int(round(float(np.mean(fold_iterations)))), 1)
+    full_model = fit_full_train(
+        x_train=x_full,
+        y_train=y,
+        cat_columns=cat_columns,
+        params=CatBoostHyperParams(
+            iterations=final_iterations,
+            learning_rate=params.learning_rate,
+            depth=params.depth,
+            l2_leaf_reg=params.l2_leaf_reg,
+            random_seed=params.random_seed,
+            loss_function=params.loss_function,
+            eval_metric=params.eval_metric,
+        ),
+        verbose=verbose,
+    )
+    save_model(full_model, model_path)
+
+    oof_output = pd.DataFrame(
+        {
+            ID_COLUMN: train_df[ID_COLUMN].values,
+            "target": y.astype(int).values,
+            "specialist_mask": specialist_mask.astype("int8").values,
+            "reference_pred": reference_pred.values,
+            "family_specialist_pred": specialist_pred.values,
+            "challenger_pred": challenger_pred.values,
+            "candidate_pred": candidate_best.values,
+        }
+    )
+    oof_out_path = ensure_parent_dir(oof_path)
+    oof_output.to_csv(oof_out_path, index=False)
+
+    metrics: dict[str, Any] = {
+        "preset": preset,
+        "preset_description": SPECIALIST_PRESETS[preset],
+        "approach": FEATURE,
+        "stacking_mode": "single_level_oof",
+        "train_rows": int(len(train_df)),
+        "specialist_rows": mask_rows,
+        "specialist_row_share": float(mask_rows / max(len(train_df), 1)),
+        "specialist_positive_rate": float(y.loc[specialist_mask].mean()),
+        "feature_count": int(x_full.shape[1]),
+        "feature_columns": list(x_full.columns),
+        "feature_blocks": list(normalized_blocks),
+        "teacher_disagreement_columns": bundle["teacher_disagreement_columns"],
+        "categorical_columns": cat_columns,
+        "cv_folds": int(folds),
+        "cv_fold_metrics": fold_rows,
+        "fold_final_iterations": [int(value) for value in fold_iterations],
+        "final_iterations": int(final_iterations),
+        "alpha_scan": alpha_scan_rows,
+        "best_alpha": best_alpha,
+        "reference_oof_auc": binary_auc(y, reference_pred),
+        "reference_oof_auc_on_mask": binary_auc(y.loc[specialist_mask], reference_pred.loc[specialist_mask]),
+        "family_specialist_oof_auc_on_mask": binary_auc(y.loc[specialist_mask], specialist_pred.loc[specialist_mask]),
+        "challenger_oof_auc": binary_auc(y, challenger_pred),
+        "challenger_oof_auc_on_mask": binary_auc(y.loc[specialist_mask], challenger_pred.loc[specialist_mask]),
+        "candidate_oof_auc": binary_auc(y, candidate_best),
+        "candidate_oof_auc_on_mask": binary_auc(y.loc[specialist_mask], candidate_best.loc[specialist_mask]),
+        "delta_vs_reference_oof_auc": float(binary_auc(y, candidate_best) - binary_auc(y, reference_pred)),
+        "global_model_path": str(model_path),
+        "family_model_path": str(family_model_path),
+        "oof_path": str(oof_out_path),
         "target_column": TARGET_COLUMN,
         "id_column": ID_COLUMN,
     }

--- a/src/churn_baseline/specialist.py
+++ b/src/churn_baseline/specialist.py
@@ -45,6 +45,7 @@ MTM_NOINTERNET_NO_0_6 = "mtm_nointernet_no_0_6"
 EC_MTM_FIBER_PAPERLESS_0_6 = "ec_mtm_fiber_paperless_0_6"
 EC_MTM_FIBER_PAPERLESS_25_48 = "ec_mtm_fiber_paperless_25_48"
 EC_MTM_FIBER_PAPERLESS_ANY = "ec_mtm_fiber_paperless_any"
+EC_MTM_FIBER_ANY = "ec_mtm_fiber_any"
 EC_MTM_DSL_PAPERLESS_0_6 = "ec_mtm_dsl_paperless_0_6"
 EC_MTM_DSL_PAPERLESS_ANY = "ec_mtm_dsl_paperless_any"
 CLASSIFIER = "classifier"
@@ -96,6 +97,9 @@ SPECIALIST_PRESETS: dict[str, str] = {
     ),
     EC_MTM_FIBER_PAPERLESS_ANY: (
         "Electronic check, Month-to-month, Fiber optic, PaperlessBilling=Yes, cualquier tenure."
+    ),
+    EC_MTM_FIBER_ANY: (
+        "Electronic check, Month-to-month, Fiber optic, cualquier PaperlessBilling, cualquier tenure."
     ),
     EC_MTM_DSL_PAPERLESS_0_6: (
         "Electronic check, Month-to-month, DSL, PaperlessBilling=Yes, tenure <= 6."
@@ -249,6 +253,12 @@ def build_specialist_mask(frame: pd.DataFrame, preset: str) -> pd.Series:
             & internet.eq("Fiber optic")
             & payment.eq("Electronic check")
             & paperless.eq("Yes")
+        )
+    if preset == EC_MTM_FIBER_ANY:
+        return (
+            contract.eq("Month-to-month")
+            & internet.eq("Fiber optic")
+            & payment.eq("Electronic check")
         )
     if preset == EC_MTM_DSL_PAPERLESS_0_6:
         return (

--- a/src/churn_baseline/submission_forensics.py
+++ b/src/churn_baseline/submission_forensics.py
@@ -1,0 +1,352 @@
+"""Submission forensics: join local artifacts with Kaggle submission history."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .artifacts import ensure_parent_dir, write_json
+from .diagnostics import utc_now_iso
+from .kaggle_api import build_authenticated_api
+
+
+LOCAL_SUBMISSION_PREFIX = "artifacts/submissions/"
+PRIMARY_METRIC_PRIORITY: tuple[str, ...] = (
+    "delta_vs_v3_oof_auc",
+    "delta_oof_auc",
+    "delta_vs_reference_oof_auc",
+    "candidate_oof_auc",
+    "ensemble_oof_auc",
+    "full_auc",
+    "oof_auc",
+    "cv_mean_auc",
+    "holdout_auc",
+)
+
+
+def _normalize_submission_path(raw: str) -> str:
+    normalized = str(raw).replace("\\", "/").strip()
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def _iter_submission_strings(payload: Any) -> list[str]:
+    found: list[str] = []
+
+    def walk(value: Any) -> None:
+        if isinstance(value, dict):
+            for child in value.values():
+                walk(child)
+            return
+        if isinstance(value, list):
+            for child in value:
+                walk(child)
+            return
+        if not isinstance(value, str):
+            return
+        normalized = _normalize_submission_path(value)
+        if normalized.lower().endswith(".csv") and LOCAL_SUBMISSION_PREFIX in normalized:
+            found.append(normalized)
+
+    walk(payload)
+    return sorted(set(found))
+
+
+def _flatten_numeric_leaves(payload: Any) -> dict[str, float]:
+    flat: dict[str, float] = {}
+
+    def walk(value: Any, prefix: str) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                next_prefix = f"{prefix}.{key}" if prefix else str(key)
+                walk(child, next_prefix)
+            return
+        if isinstance(value, list):
+            for idx, child in enumerate(value):
+                next_prefix = f"{prefix}[{idx}]"
+                walk(child, next_prefix)
+            return
+        if isinstance(value, bool):
+            return
+        if isinstance(value, (int, float)) and np.isfinite(float(value)):
+            flat[prefix] = float(value)
+
+    walk(payload, "")
+    return flat
+
+
+def _select_primary_metric(flat_metrics: dict[str, float]) -> tuple[str | None, float | None]:
+    if not flat_metrics:
+        return None, None
+    for metric_name in PRIMARY_METRIC_PRIORITY:
+        for key, value in flat_metrics.items():
+            if key == metric_name or key.endswith(f".{metric_name}"):
+                return metric_name, float(value)
+    return None, None
+
+
+def _report_priority(report_path: str, *, has_metric: bool) -> tuple[int, str]:
+    name = Path(report_path).name.lower()
+    if name.startswith("submission_candidate_"):
+        bucket = 0
+    elif name.startswith("candidate_submission_"):
+        bucket = 1
+    elif name.startswith("validation_protocol_"):
+        bucket = 2
+    elif "submission" in name:
+        bucket = 3
+    else:
+        bucket = 4
+    metric_penalty = 0 if has_metric else 1
+    return (bucket, metric_penalty, name)
+
+
+def _infer_submission_family(file_name: str) -> str:
+    name = file_name.lower()
+    if "residual-hier" in name:
+        return "residual_hierarchy"
+    if "rvblend" in name:
+        return "teacher_blend_rv"
+    if "rblend" in name:
+        return "teacher_blend_r"
+    if "blend-grid" in name:
+        return "blend_scan"
+    if "multiseed" in name:
+        return "catboost_multiseed"
+    if "pseudo" in name:
+        return "pseudo_labeling"
+    return "generic"
+
+
+def _submission_to_dict(submission: Any) -> dict[str, Any]:
+    if hasattr(submission, "to_dict"):
+        payload = submission.to_dict()
+        if isinstance(payload, dict):
+            return payload
+    return {
+        "ref": getattr(submission, "ref", None),
+        "totalBytes": getattr(submission, "total_bytes", None),
+        "date": getattr(submission, "date", None),
+        "description": getattr(submission, "description", None),
+        "errorDescription": getattr(submission, "error_description", None),
+        "fileName": getattr(submission, "file_name", None),
+        "publicScore": getattr(submission, "public_score", None),
+        "privateScore": getattr(submission, "private_score", None),
+        "status": getattr(submission, "status", None),
+        "submittedBy": getattr(submission, "submitted_by", None),
+        "submittedByRef": getattr(submission, "submitted_by_ref", None),
+        "teamName": getattr(submission, "team_name", None),
+        "url": getattr(submission, "url", None),
+    }
+
+
+def fetch_kaggle_submission_history(competition: str) -> pd.DataFrame:
+    """Return Kaggle submission history for the current account."""
+    api = build_authenticated_api()
+    raw_rows: list[dict[str, Any]] = []
+    for submission in api.competition_submissions(competition):
+        payload = _submission_to_dict(submission)
+        raw_rows.append(
+            {
+                "ref": int(payload["ref"]),
+                "file_name": str(payload.get("fileName") or ""),
+                "date": str(payload.get("date") or ""),
+                "description": str(payload.get("description") or ""),
+                "status": str(payload.get("status") or ""),
+                "public_score": None if payload.get("publicScore") in (None, "") else float(payload["publicScore"]),
+                "private_score": None if payload.get("privateScore") in (None, "") else float(payload["privateScore"]),
+            }
+        )
+    history = pd.DataFrame(raw_rows)
+    if history.empty:
+        return history
+    history["date"] = pd.to_datetime(history["date"], utc=True, errors="coerce")
+    history = history.sort_values("date", ascending=False).reset_index(drop=True)
+    history["submission_family"] = history["file_name"].map(_infer_submission_family)
+    history["local_submission_path"] = history["file_name"].map(lambda value: f"{LOCAL_SUBMISSION_PREFIX}{value}")
+    return history
+
+
+def scan_local_submission_reports(reports_dir: str | Path) -> tuple[pd.DataFrame, dict[str, list[dict[str, Any]]]]:
+    """Scan report JSONs and map them to submission CSV references."""
+    report_rows: list[dict[str, Any]] = []
+    per_submission_name: dict[str, list[dict[str, Any]]] = {}
+
+    for report_path in sorted(Path(reports_dir).glob("*.json")):
+        try:
+            payload = json.loads(report_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        submission_paths = _iter_submission_strings(payload)
+        if not submission_paths:
+            continue
+        flat_metrics = _flatten_numeric_leaves(payload)
+        metric_name, metric_value = _select_primary_metric(flat_metrics)
+        report_record = {
+            "report_path": str(report_path).replace("\\", "/"),
+            "report_name": report_path.name,
+            "submission_paths": submission_paths,
+            "primary_metric_name": metric_name,
+            "primary_metric_value": metric_value,
+            "all_metric_names": sorted(flat_metrics),
+        }
+        report_rows.append(
+            {
+                "report_path": report_record["report_path"],
+                "report_name": report_record["report_name"],
+                "linked_submission_count": int(len(submission_paths)),
+                "primary_metric_name": metric_name,
+                "primary_metric_value": metric_value,
+            }
+        )
+        for submission_path in submission_paths:
+            submission_name = Path(submission_path).name
+            per_submission_name.setdefault(submission_name, []).append(report_record)
+
+    return pd.DataFrame(report_rows), per_submission_name
+
+
+def build_submission_forensics(
+    *,
+    competition: str,
+    reports_dir: str | Path,
+    submissions_dir: str | Path,
+) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, Any]]:
+    """Build a joined submission ledger and summary."""
+    kaggle_history = fetch_kaggle_submission_history(competition)
+    report_frame, report_map = scan_local_submission_reports(reports_dir)
+
+    local_submission_files = sorted(str(path).replace("\\", "/") for path in Path(submissions_dir).glob("*.csv"))
+    local_submission_names = {Path(path).name for path in local_submission_files}
+
+    ledger_rows: list[dict[str, Any]] = []
+    for row in kaggle_history.to_dict(orient="records"):
+        linked_reports = report_map.get(str(row["file_name"]), [])
+        primary_report = None
+        if linked_reports:
+            primary_report = sorted(
+                linked_reports,
+                key=lambda item: _report_priority(item["report_path"], has_metric=item["primary_metric_name"] is not None),
+            )[0]
+        ledger_rows.append(
+            {
+                **row,
+                "has_local_submission_file": row["file_name"] in local_submission_names,
+                "linked_report_count": int(len(linked_reports)),
+                "primary_report_path": None if primary_report is None else primary_report["report_path"],
+                "primary_report_name": None if primary_report is None else primary_report["report_name"],
+                "local_primary_metric_name": None if primary_report is None else primary_report["primary_metric_name"],
+                "local_primary_metric_value": None if primary_report is None else primary_report["primary_metric_value"],
+            }
+        )
+
+    ledger = pd.DataFrame(ledger_rows)
+    if ledger.empty:
+        summary = {
+            "generated_at_utc": utc_now_iso(),
+            "competition": competition,
+            "history_rows": 0,
+            "local_submission_files": int(len(local_submission_files)),
+            "report_rows": int(len(report_frame)),
+            "error": "No Kaggle submissions returned.",
+        }
+        return ledger, report_frame, summary
+
+    complete_mask = ledger["status"].astype(str).str.contains("COMPLETE", case=False, regex=False)
+    complete_scores = ledger.loc[complete_mask & ledger["public_score"].notna()].copy()
+    best_row = None if complete_scores.empty else complete_scores.sort_values("public_score", ascending=False).iloc[0]
+
+    correlation_rows = []
+    for metric_name, part in ledger.groupby("local_primary_metric_name", dropna=True):
+        subset = part.loc[part["public_score"].notna() & part["local_primary_metric_value"].notna()].copy()
+        if len(subset) < 3:
+            continue
+        subset = subset.sort_values("date")
+        public_score = subset["public_score"].astype(float)
+        local_metric = subset["local_primary_metric_value"].astype(float)
+        correlation_rows.append(
+            {
+                "metric_name": str(metric_name),
+                "rows": int(len(subset)),
+                "pearson": float(public_score.corr(local_metric, method="pearson")),
+                "spearman": float(public_score.corr(local_metric, method="spearman")),
+            }
+        )
+    if correlation_rows:
+        correlation_frame = pd.DataFrame(correlation_rows).sort_values(["rows", "spearman"], ascending=[False, False])
+    else:
+        correlation_frame = pd.DataFrame(columns=["metric_name", "rows", "pearson", "spearman"])
+
+    family_frame = (
+        ledger.loc[complete_mask & ledger["public_score"].notna()]
+        .groupby("submission_family", dropna=False)
+        .agg(
+            submissions=("file_name", "count"),
+            best_public_score=("public_score", "max"),
+            mean_public_score=("public_score", "mean"),
+        )
+        .reset_index()
+        .sort_values(["best_public_score", "mean_public_score"], ascending=False)
+    )
+
+    summary = {
+        "generated_at_utc": utc_now_iso(),
+        "competition": competition,
+        "history_rows": int(len(ledger)),
+        "complete_rows": int(complete_mask.sum()),
+        "error_rows": int(ledger["status"].astype(str).str.contains("ERROR", case=False, regex=False).sum()),
+        "local_submission_files": int(len(local_submission_files)),
+        "report_rows": int(len(report_frame)),
+        "matched_history_rows": int((ledger["linked_report_count"] > 0).sum()),
+        "matched_with_local_metric_rows": int(ledger["local_primary_metric_name"].notna().sum()),
+        "best_public_submission": None
+        if best_row is None
+        else {
+            "file_name": str(best_row["file_name"]),
+            "ref": int(best_row["ref"]),
+            "public_score": float(best_row["public_score"]),
+            "submission_family": str(best_row["submission_family"]),
+        },
+        "family_summary": family_frame.to_dict(orient="records"),
+        "local_public_correlation": correlation_frame.to_dict(orient="records"),
+        "recent_complete_submissions": ledger.loc[complete_mask, ["file_name", "ref", "date", "public_score", "submission_family"]]
+        .head(10)
+        .assign(date=lambda df: df["date"].astype(str))
+        .to_dict(orient="records"),
+        "recommendation": (
+            "Use v3 as incumbent and distrust tiny local deltas unless the same family has already shown "
+            "public survival. Submission history is clustered by family, so forensics should gate any new line "
+            "before CPU is spent on midcap."
+        ),
+    }
+    return ledger, report_frame, summary
+
+
+def write_submission_forensics_outputs(
+    *,
+    competition: str,
+    reports_dir: str | Path,
+    submissions_dir: str | Path,
+    out_summary_json: str | Path,
+    out_ledger_csv: str | Path,
+    out_reports_csv: str | Path,
+) -> dict[str, Any]:
+    ledger, report_frame, summary = build_submission_forensics(
+        competition=competition,
+        reports_dir=reports_dir,
+        submissions_dir=submissions_dir,
+    )
+    ensure_parent_dir(out_ledger_csv)
+    ensure_parent_dir(out_reports_csv)
+    ledger_to_write = ledger.copy()
+    if "date" in ledger_to_write.columns:
+        ledger_to_write["date"] = ledger_to_write["date"].astype(str)
+    ledger_to_write.to_csv(out_ledger_csv, index=False)
+    report_frame.to_csv(out_reports_csv, index=False)
+    write_json(out_summary_json, summary)
+    return summary

--- a/src/churn_baseline/target_priors.py
+++ b/src/churn_baseline/target_priors.py
@@ -1,0 +1,396 @@
+"""Fold-safe hierarchical target priors for churn experiments."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+
+
+PRIOR_TENURE_BIN_COLUMN = "prior_tenure_bin"
+PRIOR_MONTHLY_PER_TENURE_COLUMN = "prior_monthly_per_tenure"
+PRIOR_ADDONS_ACTIVE_COUNT_COLUMN = "prior_addons_active_count"
+PRIOR_KEY_SEPARATOR = "__"
+PRIOR_EPSILON = 1e-6
+SERVICE_COLUMNS = (
+    "OnlineSecurity",
+    "OnlineBackup",
+    "DeviceProtection",
+    "TechSupport",
+    "StreamingTV",
+    "StreamingMovies",
+)
+
+
+@dataclass(frozen=True)
+class PriorSpec:
+    """Definition for one grouped target prior."""
+
+    name: str
+    columns: tuple[str, ...]
+    min_support: int = 50
+    smoothing_alpha: float = 20.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "columns": list(self.columns),
+            "min_support": int(self.min_support),
+            "smoothing_alpha": float(self.smoothing_alpha),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "PriorSpec":
+        return cls(
+            name=str(payload["name"]),
+            columns=tuple(str(v) for v in payload["columns"]),
+            min_support=int(payload["min_support"]),
+            smoothing_alpha=float(payload["smoothing_alpha"]),
+        )
+
+
+def build_default_prior_specs() -> tuple[PriorSpec, ...]:
+    """Return a coarse-to-fine hierarchy of target priors."""
+    return (
+        PriorSpec(name="contract", columns=("Contract",), min_support=1, smoothing_alpha=300.0),
+        PriorSpec(
+            name="contract_internet",
+            columns=("Contract", "InternetService"),
+            min_support=20,
+            smoothing_alpha=120.0,
+        ),
+        PriorSpec(
+            name="segment3",
+            columns=("PaymentMethod", "Contract", "InternetService"),
+            min_support=30,
+            smoothing_alpha=60.0,
+        ),
+        PriorSpec(
+            name="segment4_tenure",
+            columns=("PaymentMethod", "Contract", "InternetService", PRIOR_TENURE_BIN_COLUMN),
+            min_support=50,
+            smoothing_alpha=35.0,
+        ),
+        PriorSpec(
+            name="segment5_paperless",
+            columns=(
+                "PaymentMethod",
+                "Contract",
+                "InternetService",
+                "PaperlessBilling",
+                PRIOR_TENURE_BIN_COLUMN,
+            ),
+            min_support=80,
+            smoothing_alpha=25.0,
+        ),
+    )
+
+
+def build_default_numeric_deviation_columns() -> tuple[str, ...]:
+    """Return numeric columns used for fold-safe cohort means and deviations."""
+    return (
+        "tenure",
+        "MonthlyCharges",
+        "TotalCharges",
+        PRIOR_MONTHLY_PER_TENURE_COLUMN,
+        PRIOR_ADDONS_ACTIVE_COUNT_COLUMN,
+    )
+
+
+def prepare_prior_frame(features: pd.DataFrame) -> pd.DataFrame:
+    """Add deterministic columns needed by grouped target priors."""
+    out = features.copy()
+    tenure_values = pd.to_numeric(out["tenure"], errors="coerce")
+    tenure_safe = tenure_values.clip(lower=1).fillna(1.0)
+    monthly_charges = pd.to_numeric(out["MonthlyCharges"], errors="coerce").fillna(0.0)
+    total_charges = pd.to_numeric(out["TotalCharges"], errors="coerce").fillna(0.0)
+
+    if PRIOR_TENURE_BIN_COLUMN not in out.columns:
+        out[PRIOR_TENURE_BIN_COLUMN] = pd.cut(
+            tenure_values,
+            bins=[-np.inf, 6, 12, 24, 48, np.inf],
+            labels=["0_6", "7_12", "13_24", "25_48", "49_plus"],
+        ).astype(str)
+    out[PRIOR_TENURE_BIN_COLUMN] = out[PRIOR_TENURE_BIN_COLUMN].replace("nan", "__MISSING__")
+
+    if PRIOR_MONTHLY_PER_TENURE_COLUMN not in out.columns:
+        out[PRIOR_MONTHLY_PER_TENURE_COLUMN] = monthly_charges / tenure_safe
+
+    if PRIOR_ADDONS_ACTIVE_COUNT_COLUMN not in out.columns:
+        if "addons_active_count" in out.columns:
+            out[PRIOR_ADDONS_ACTIVE_COUNT_COLUMN] = (
+                pd.to_numeric(out["addons_active_count"], errors="coerce").fillna(0.0).astype("float64")
+            )
+        else:
+            _require_columns(out, SERVICE_COLUMNS)
+            addons_active = np.zeros(len(out), dtype=np.int16)
+            for column in SERVICE_COLUMNS:
+                addons_active += out[column].astype(str).str.lower().eq("yes").to_numpy(dtype=np.int16)
+            out[PRIOR_ADDONS_ACTIVE_COUNT_COLUMN] = addons_active.astype("float64")
+    return out
+
+
+def _require_columns(frame: pd.DataFrame, columns: Sequence[str]) -> None:
+    missing = [name for name in columns if name not in frame.columns]
+    if missing:
+        raise ValueError(f"Target prior columns not found in dataframe: {missing}")
+
+
+def _build_group_keys(frame: pd.DataFrame, columns: Sequence[str]) -> pd.Series:
+    _require_columns(frame, columns)
+    key = frame[columns[0]].astype(str)
+    for column_name in columns[1:]:
+        key = key + PRIOR_KEY_SEPARATOR + frame[column_name].astype(str)
+    return key
+
+
+def _safe_logit(values: pd.Series | np.ndarray | float) -> pd.Series:
+    series = pd.Series(values, copy=False, dtype="float64")
+    clipped = series.clip(lower=PRIOR_EPSILON, upper=1.0 - PRIOR_EPSILON)
+    return np.log(clipped / (1.0 - clipped))
+
+
+class HierarchicalTargetPriorEncoder:
+    """Fit grouped target priors on train folds and reuse them safely."""
+
+    def __init__(
+        self,
+        specs: Sequence[PriorSpec] | None = None,
+        *,
+        include_numeric_deviation: bool = False,
+        numeric_columns: Sequence[str] | None = None,
+    ) -> None:
+        normalized_specs = tuple(specs or build_default_prior_specs())
+        if not normalized_specs:
+            raise ValueError("At least one prior spec is required.")
+        self.specs = normalized_specs
+        self.include_numeric_deviation = bool(include_numeric_deviation)
+        if numeric_columns is None:
+            numeric_columns = (
+                build_default_numeric_deviation_columns() if self.include_numeric_deviation else ()
+            )
+        self.numeric_columns = tuple(str(value) for value in numeric_columns)
+        self.global_mean_: float | None = None
+        self.stats_by_spec_: dict[str, dict[str, dict[str, float | int]]] | None = None
+        self.numeric_global_means_: dict[str, float] | None = None
+
+    def fit(self, features: pd.DataFrame, target: pd.Series) -> "HierarchicalTargetPriorEncoder":
+        work = prepare_prior_frame(features)
+        target_num = pd.to_numeric(target, errors="coerce").astype("float64")
+        if len(work) != len(target_num):
+            raise ValueError("features and target must have the same number of rows.")
+
+        stats_by_spec: dict[str, dict[str, dict[str, float | int]]] = {}
+        self.global_mean_ = float(target_num.mean())
+        self.numeric_global_means_ = {}
+
+        numeric_series_by_column: dict[str, pd.Series] = {}
+        for column_name in self.numeric_columns:
+            numeric_series = pd.to_numeric(work[column_name], errors="coerce").astype("float64")
+            global_numeric_mean = float(numeric_series.mean())
+            self.numeric_global_means_[column_name] = global_numeric_mean
+            numeric_series_by_column[column_name] = numeric_series.fillna(global_numeric_mean)
+
+        for spec in self.specs:
+            grouped = work[list(spec.columns)].copy()
+            grouped["__target__"] = target_num.values
+            aggregations: dict[str, tuple[str, str]] = {
+                "target_sum": ("__target__", "sum"),
+                "count": ("__target__", "count"),
+            }
+            for column_name, series in numeric_series_by_column.items():
+                grouped[f"__num__{column_name}"] = series.values
+                aggregations[f"numeric_sum__{column_name}"] = (f"__num__{column_name}", "sum")
+
+            summary = grouped.groupby(list(spec.columns), dropna=False).agg(**aggregations).reset_index()
+            mapping: dict[str, dict[str, float | int]] = {}
+            for row in summary.to_dict(orient="records"):
+                key_values = [row[column_name] for column_name in spec.columns]
+                key = PRIOR_KEY_SEPARATOR.join(str(value) for value in key_values)
+                mapping[key] = {
+                    "sum": float(row["target_sum"]),
+                    "count": int(row["count"]),
+                }
+                if self.include_numeric_deviation and self.numeric_columns:
+                    mapping[key]["numeric_sums"] = {
+                        column_name: float(row[f"numeric_sum__{column_name}"])
+                        for column_name in self.numeric_columns
+                    }
+            stats_by_spec[spec.name] = mapping
+
+        self.stats_by_spec_ = stats_by_spec
+        return self
+
+    def transform(self, features: pd.DataFrame) -> pd.DataFrame:
+        if self.global_mean_ is None or self.stats_by_spec_ is None:
+            raise RuntimeError("HierarchicalTargetPriorEncoder must be fitted before transform().")
+        if self.include_numeric_deviation and self.numeric_global_means_ is None:
+            raise RuntimeError("Numeric deviation metadata is missing from fitted encoder.")
+
+        work = prepare_prior_frame(features)
+        out = pd.DataFrame(index=work.index)
+
+        base_global = float(self.global_mean_)
+        base_global_logit = float(_safe_logit([base_global]).iloc[0])
+        out["prior_global"] = base_global
+        out["prior_global_logit"] = base_global_logit
+
+        hier_prior = pd.Series(base_global, index=work.index, dtype="float64")
+        hier_support = pd.Series(0, index=work.index, dtype="int32")
+        hier_source = pd.Series("global", index=work.index, dtype="object")
+        hier_level = pd.Series(0, index=work.index, dtype="int8")
+        numeric_mean_by_spec: dict[str, dict[str, pd.Series]] = {}
+
+        spec_order = list(self.specs)
+        for level, spec in enumerate(spec_order, start=1):
+            stats = self.stats_by_spec_[spec.name]
+            keys = _build_group_keys(work, spec.columns)
+            sums = keys.map({key: float(value["sum"]) for key, value in stats.items()}).fillna(0.0)
+            counts = (
+                keys.map({key: int(value["count"]) for key, value in stats.items()}).fillna(0).astype("int32")
+            )
+            posterior = (sums + float(spec.smoothing_alpha) * base_global) / (
+                counts.astype("float64") + float(spec.smoothing_alpha)
+            )
+
+            out[f"prior_{spec.name}"] = posterior.astype("float64")
+            out[f"prior_logit_{spec.name}"] = _safe_logit(posterior).astype("float64")
+            out[f"support_{spec.name}"] = counts
+            out[f"is_low_support_{spec.name}"] = (counts < int(spec.min_support)).astype("int8")
+
+            if self.include_numeric_deviation and self.numeric_columns:
+                numeric_mean_by_spec[spec.name] = {}
+                for column_name in self.numeric_columns:
+                    numeric_sums = keys.map(
+                        {
+                            key: float(
+                                dict(value.get("numeric_sums", {})).get(
+                                    column_name,
+                                    self.numeric_global_means_[column_name],
+                                )
+                            )
+                            for key, value in stats.items()
+                        }
+                    ).fillna(0.0)
+                    global_numeric_mean = float(self.numeric_global_means_[column_name])
+                    numeric_mean = (numeric_sums + float(spec.smoothing_alpha) * global_numeric_mean) / (
+                        counts.astype("float64") + float(spec.smoothing_alpha)
+                    )
+                    numeric_mean_by_spec[spec.name][column_name] = numeric_mean.astype("float64")
+
+        for reverse_level, spec in enumerate(reversed(spec_order), start=1):
+            prior_column = f"prior_{spec.name}"
+            support_column = f"support_{spec.name}"
+            valid_mask = out[support_column] >= int(spec.min_support)
+            assign_mask = valid_mask & hier_source.eq("global")
+            if not bool(assign_mask.any()):
+                continue
+            hier_prior.loc[assign_mask] = out.loc[assign_mask, prior_column]
+            hier_support.loc[assign_mask] = out.loc[assign_mask, support_column]
+            hier_source.loc[assign_mask] = spec.name
+            hier_level.loc[assign_mask] = int(len(spec_order) - reverse_level + 1)
+
+        out["prior_hier"] = hier_prior.astype("float64")
+        out["prior_hier_logit"] = _safe_logit(hier_prior).astype("float64")
+        out["prior_hier_support"] = hier_support.astype("int32")
+        out["prior_hier_source"] = hier_source.astype(str)
+        out["prior_hier_level"] = hier_level.astype("int8")
+        out["prior_hier_is_global"] = hier_source.eq("global").astype("int8")
+
+        if self.include_numeric_deviation and self.numeric_columns:
+            hier_numeric_means: dict[str, pd.Series] = {
+                column_name: pd.Series(
+                    float(self.numeric_global_means_[column_name]),
+                    index=work.index,
+                    dtype="float64",
+                )
+                for column_name in self.numeric_columns
+            }
+            for spec in reversed(spec_order):
+                support_column = f"support_{spec.name}"
+                assign_mask = out["prior_hier_source"].eq(spec.name) & (
+                    out[support_column] >= int(spec.min_support)
+                )
+                if not bool(assign_mask.any()):
+                    continue
+                for column_name in self.numeric_columns:
+                    hier_numeric_means[column_name].loc[assign_mask] = numeric_mean_by_spec[spec.name][
+                        column_name
+                    ].loc[assign_mask]
+
+            for column_name in self.numeric_columns:
+                base_values = pd.to_numeric(work[column_name], errors="coerce").astype("float64")
+                global_numeric_mean = float(self.numeric_global_means_[column_name])
+                base_values = base_values.fillna(global_numeric_mean)
+                cohort_mean = hier_numeric_means[column_name]
+                delta_values = base_values - cohort_mean
+                out[f"cohort_mean_{column_name}"] = cohort_mean.astype("float64")
+                out[f"cohort_delta_{column_name}"] = delta_values.astype("float64")
+                out[f"cohort_rel_{column_name}"] = (
+                    delta_values / (cohort_mean.abs() + 1.0)
+                ).astype("float64")
+        return out
+
+    def fit_transform(self, features: pd.DataFrame, target: pd.Series) -> pd.DataFrame:
+        return self.fit(features, target).transform(features)
+
+    def to_dict(self) -> dict[str, Any]:
+        if self.global_mean_ is None or self.stats_by_spec_ is None:
+            raise RuntimeError("HierarchicalTargetPriorEncoder is not fitted.")
+        return {
+            "global_mean": float(self.global_mean_),
+            "specs": [spec.to_dict() for spec in self.specs],
+            "stats_by_spec": self.stats_by_spec_,
+            "include_numeric_deviation": self.include_numeric_deviation,
+            "numeric_columns": list(self.numeric_columns),
+            "numeric_global_means": dict(self.numeric_global_means_ or {}),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "HierarchicalTargetPriorEncoder":
+        encoder = cls(
+            specs=[PriorSpec.from_dict(item) for item in payload["specs"]],
+            include_numeric_deviation=bool(payload.get("include_numeric_deviation", False)),
+            numeric_columns=payload.get("numeric_columns"),
+        )
+        encoder.global_mean_ = float(payload["global_mean"])
+        encoder.stats_by_spec_ = {
+            str(spec_name): {
+                str(key): {
+                    "sum": float(values["sum"]),
+                    "count": int(values["count"]),
+                    "numeric_sums": {
+                        str(column_name): float(column_value)
+                        for column_name, column_value in dict(values.get("numeric_sums", {})).items()
+                    },
+                }
+                for key, values in dict(spec_stats).items()
+            }
+            for spec_name, spec_stats in dict(payload["stats_by_spec"]).items()
+        }
+        encoder.numeric_global_means_ = {
+            str(column_name): float(column_value)
+            for column_name, column_value in dict(payload.get("numeric_global_means", {})).items()
+        }
+        return encoder
+
+
+def save_target_prior_encoder(
+    encoder: HierarchicalTargetPriorEncoder,
+    path: str | Path,
+) -> Path:
+    """Persist target prior encoder metadata to JSON."""
+    out_path = Path(path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(encoder.to_dict(), indent=2), encoding="utf-8")
+    return out_path
+
+
+def load_target_prior_encoder(path: str | Path) -> HierarchicalTargetPriorEncoder:
+    """Load target prior encoder metadata from disk."""
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    return HierarchicalTargetPriorEncoder.from_dict(payload)

--- a/src/churn_baseline/telco_transfer.py
+++ b/src/churn_baseline/telco_transfer.py
@@ -21,6 +21,9 @@ from .pipeline import _build_stratify_labels, _prepare_train_matrix, _transform_
 DEFAULT_ORIGINAL_CSV = "artifacts/external/blastchar_telco/WA_Fn-UseC_-Telco-Customer-Churn.csv"
 EXTERNAL_ID_COLUMN = "customerID"
 TRANSFER_FEATURE_COLUMN = "external_telco_pred"
+DATA_SOURCE_COLUMN = "dataset_source"
+COMPETITION_SOURCE_VALUE = "competition"
+TELCO_SOURCE_VALUE = "telco_original"
 
 
 def _sanitize_total_charges(frame: pd.DataFrame, *, fallback_median: float | None = None) -> pd.DataFrame:
@@ -181,6 +184,175 @@ def _build_external_prediction_feature(
         }
     )
     return transfer_train, transfer_test
+
+
+def _prepare_joint_source_frames(
+    competition_train_df: pd.DataFrame,
+    external_df: pd.DataFrame,
+    *,
+    stateless_blocks: Sequence[str],
+) -> tuple[pd.DataFrame, pd.Series, pd.DataFrame, pd.Series]:
+    x_competition, y_competition = prepare_train_features(
+        competition_train_df,
+        drop_id=True,
+        feature_blocks=stateless_blocks,
+    )
+    x_external, y_external = prepare_train_features(
+        external_df,
+        drop_id=True,
+        feature_blocks=stateless_blocks,
+    )
+    x_competition = x_competition.copy()
+    x_external = x_external.copy()
+    x_competition[DATA_SOURCE_COLUMN] = COMPETITION_SOURCE_VALUE
+    x_external[DATA_SOURCE_COLUMN] = TELCO_SOURCE_VALUE
+
+    expected_columns = list(x_competition.columns)
+    missing_external = sorted(set(expected_columns).difference(x_external.columns))
+    extra_external = sorted(set(x_external.columns).difference(expected_columns))
+    if missing_external or extra_external:
+        raise ValueError(
+            "Competition and external feature matrices are not column-compatible for joint training: "
+            f"missing_external={missing_external}, extra_external={extra_external}"
+        )
+    x_external = x_external.reindex(columns=expected_columns)
+    return x_competition, y_competition, x_external, y_external
+
+
+def run_telco_joint_training_smoke(
+    *,
+    train_csv_path: str,
+    test_csv_path: str,
+    original_csv_path: str,
+    challenger_params: CatBoostHyperParams,
+    feature_blocks: Sequence[str],
+    folds: int,
+    seed: int,
+    stratify_mode: str,
+    external_weight: float,
+    challenger_early_stopping_rounds: int,
+    verbose: int,
+) -> dict[str, Any]:
+    """Run source-aware joint training with external Telco rows and OOF on competition rows only."""
+    if float(external_weight) <= 0.0:
+        raise ValueError("external_weight must be > 0.")
+
+    competition_train_df = load_csv(train_csv_path)
+    competition_test_df = load_csv(test_csv_path)
+    original_df = _prepare_external_original_frame(original_csv_path)
+    original_filtered_df, dropped_overlaps = _drop_exact_external_overlaps(
+        original_df,
+        competition_train_df=competition_train_df,
+        competition_test_df=competition_test_df,
+    )
+    if original_filtered_df.empty:
+        raise ValueError("External Telco dataset is empty after dropping exact overlaps with competition train/test.")
+
+    normalized_blocks, stateless_blocks, stateful_blocks, _, _ = _prepare_train_matrix(
+        competition_train_df,
+        feature_blocks,
+    )
+    x_competition, y_competition, x_external, y_external = _prepare_joint_source_frames(
+        competition_train_df,
+        original_filtered_df,
+        stateless_blocks=stateless_blocks,
+    )
+
+    splitter = StratifiedKFold(n_splits=int(folds), shuffle=True, random_state=int(seed))
+    stratify_labels = _build_stratify_labels(
+        x_competition,
+        y_competition,
+        stratify_mode=stratify_mode,
+        min_count=int(folds),
+    )
+    oof_pred = pd.Series(index=x_competition.index, dtype="float64", name="oof_pred")
+    fold_metrics: list[dict[str, Any]] = []
+
+    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x_competition, stratify_labels), start=1):
+        x_train_comp = x_competition.iloc[train_idx]
+        y_train_comp = y_competition.iloc[train_idx]
+        x_valid = x_competition.iloc[valid_idx]
+        y_valid = y_competition.iloc[valid_idx]
+
+        x_train_joint = pd.concat([x_train_comp, x_external], axis=0, ignore_index=True)
+        y_train_joint = pd.concat([y_train_comp, y_external], axis=0, ignore_index=True)
+        sample_weight_joint = pd.Series(1.0, index=x_train_joint.index, dtype="float64")
+        sample_weight_joint.iloc[len(x_train_comp) :] = float(external_weight)
+
+        x_train_fit, x_valid_fit = _transform_pair_with_stateful_blocks(x_train_joint, x_valid, stateful_blocks)
+        cat_columns = infer_categorical_columns(x_train_fit)
+        fold_params = CatBoostHyperParams(
+            iterations=challenger_params.iterations,
+            learning_rate=challenger_params.learning_rate,
+            depth=challenger_params.depth,
+            l2_leaf_reg=challenger_params.l2_leaf_reg,
+            random_seed=seed,
+            loss_function=challenger_params.loss_function,
+            eval_metric=challenger_params.eval_metric,
+            monotone_constraints=challenger_params.monotone_constraints,
+        )
+        model = fit_with_validation(
+            x_train=x_train_fit,
+            y_train=y_train_joint,
+            x_valid=x_valid_fit,
+            y_valid=y_valid,
+            cat_columns=cat_columns,
+            params=fold_params,
+            early_stopping_rounds=challenger_early_stopping_rounds,
+            verbose=verbose,
+            sample_weight_train=sample_weight_joint.loc[x_train_fit.index],
+        )
+        fold_pred = predict_proba(model, x_valid_fit)
+        oof_pred.iloc[valid_idx] = fold_pred.values
+        fold_metrics.append(
+            {
+                "fold": int(fold_number),
+                "auc": float(binary_auc(y_valid, fold_pred)),
+                "best_iteration": int(model.get_best_iteration()),
+                "final_iterations": int(best_iteration_or_default(model, challenger_params.iterations)),
+                "competition_train_rows": int(len(x_train_comp)),
+                "external_train_rows": int(len(x_external)),
+                "valid_rows": int(len(valid_idx)),
+                "external_weight": float(external_weight),
+            }
+        )
+
+    if oof_pred.isna().any():
+        raise RuntimeError("Telco joint-training OOF predictions contain missing values.")
+
+    fold_aucs = [float(item["auc"]) for item in fold_metrics]
+    return {
+        "generated_at_utc": utc_now_iso(),
+        "train_csv_path": str(train_csv_path),
+        "test_csv_path": str(test_csv_path),
+        "original_csv_path": str(original_csv_path),
+        "input_files": {
+            "train_csv": describe_file(train_csv_path),
+            "test_csv": describe_file(test_csv_path),
+            "original_csv": describe_file(original_csv_path),
+        },
+        "feature_blocks": list(normalized_blocks),
+        "joint_source_column": DATA_SOURCE_COLUMN,
+        "joint_source_values": {
+            "competition": COMPETITION_SOURCE_VALUE,
+            "external": TELCO_SOURCE_VALUE,
+        },
+        "external_weight": float(external_weight),
+        "teacher_metadata": {
+            "rows_original": int(len(original_df)),
+            "rows_after_overlap_filter": int(len(original_filtered_df)),
+            "dropped_exact_overlaps": int(dropped_overlaps),
+        },
+        "rows": int(len(competition_train_df)),
+        "external_rows": int(len(original_filtered_df)),
+        "folds": int(folds),
+        "seed": int(seed),
+        "cv_mean_auc": float(np.mean(fold_aucs)),
+        "cv_std_auc": float(np.std(fold_aucs)),
+        "oof_auc": float(binary_auc(y_competition, oof_pred)),
+        "fold_metrics": fold_metrics,
+        "oof_pred": oof_pred,
+    }
 
 
 def run_telco_transfer_smoke(

--- a/src/churn_baseline/telco_transfer.py
+++ b/src/churn_baseline/telco_transfer.py
@@ -1,0 +1,317 @@
+"""External Telco teacher transfer feature experiment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import StratifiedKFold, train_test_split
+
+from .config import CatBoostHyperParams, ID_COLUMN, TARGET_COLUMN
+from .data import infer_categorical_columns, load_csv, prepare_test_features, prepare_train_features
+from .diagnostics import describe_file, utc_now_iso
+from .evaluation import binary_auc
+from .feature_engineering import normalize_feature_blocks
+from .modeling import best_iteration_or_default, fit_full_train, fit_with_validation, predict_proba
+from .pipeline import _build_stratify_labels, _prepare_train_matrix, _transform_pair_with_stateful_blocks
+
+
+DEFAULT_ORIGINAL_CSV = "artifacts/external/blastchar_telco/WA_Fn-UseC_-Telco-Customer-Churn.csv"
+EXTERNAL_ID_COLUMN = "customerID"
+TRANSFER_FEATURE_COLUMN = "external_telco_pred"
+
+
+def _sanitize_total_charges(frame: pd.DataFrame, *, fallback_median: float | None = None) -> pd.DataFrame:
+    out = frame.copy()
+    if "TotalCharges" not in out.columns:
+        return out
+    numeric = pd.to_numeric(out["TotalCharges"], errors="coerce")
+    median = float(numeric.median()) if fallback_median is None else float(fallback_median)
+    out["TotalCharges"] = numeric.fillna(median)
+    return out
+
+
+def _prepare_external_original_frame(path: str | Path) -> pd.DataFrame:
+    original_path = Path(path)
+    if not original_path.exists():
+        raise FileNotFoundError(
+            f"External original CSV not found: {original_path}. "
+            "Provide --original-csv explicitly or place the file at the default path."
+        )
+    original_df = load_csv(original_path)
+    if TARGET_COLUMN not in original_df.columns:
+        raise ValueError(f"{original_path} must contain '{TARGET_COLUMN}'")
+    if EXTERNAL_ID_COLUMN in original_df.columns and ID_COLUMN not in original_df.columns:
+        original_df = original_df.rename(columns={EXTERNAL_ID_COLUMN: ID_COLUMN})
+    fallback_median = float(pd.to_numeric(original_df["TotalCharges"], errors="coerce").median())
+    original_df = _sanitize_total_charges(original_df, fallback_median=fallback_median)
+    return original_df
+
+
+def _build_overlap_signature(frame: pd.DataFrame, *, columns: Sequence[str]) -> pd.Series:
+    normalized = frame.loc[:, list(columns)].copy()
+    for column in normalized.columns:
+        if column == "TotalCharges":
+            normalized[column] = pd.to_numeric(normalized[column], errors="coerce").round(2).fillna(-999999.0)
+        elif column == "MonthlyCharges":
+            normalized[column] = pd.to_numeric(normalized[column], errors="coerce").round(2).fillna(-999999.0)
+        else:
+            normalized[column] = normalized[column].fillna("__nan__").astype(str)
+    return pd.util.hash_pandas_object(normalized, index=False)
+
+
+def _drop_exact_external_overlaps(
+    original_df: pd.DataFrame,
+    *,
+    competition_train_df: pd.DataFrame,
+    competition_test_df: pd.DataFrame,
+) -> tuple[pd.DataFrame, int]:
+    common_columns = sorted(
+        (
+            set(original_df.columns)
+            & set(competition_train_df.columns)
+            & set(competition_test_df.columns)
+        )
+        - {ID_COLUMN, TARGET_COLUMN}
+    )
+    if not common_columns:
+        return original_df.copy(), 0
+
+    competition_signatures = pd.concat(
+        [
+            _build_overlap_signature(competition_train_df, columns=common_columns),
+            _build_overlap_signature(competition_test_df, columns=common_columns),
+        ],
+        axis=0,
+        ignore_index=True,
+    )
+    overlap_mask = _build_overlap_signature(original_df, columns=common_columns).isin(set(competition_signatures.tolist()))
+    filtered = original_df.loc[~overlap_mask].reset_index(drop=True)
+    return filtered, int(overlap_mask.sum())
+
+
+def _train_external_teacher(
+    original_df: pd.DataFrame,
+    *,
+    teacher_params: CatBoostHyperParams,
+    valid_size: float,
+    early_stopping_rounds: int,
+    verbose: int,
+) -> tuple[Any, dict[str, Any]]:
+    x_original, y_original = prepare_train_features(original_df, drop_id=True, feature_blocks=[])
+    x_train, x_valid, y_train, y_valid = train_test_split(
+        x_original,
+        y_original,
+        test_size=float(valid_size),
+        random_state=int(teacher_params.random_seed),
+        stratify=y_original,
+    )
+    cat_columns = infer_categorical_columns(x_train)
+    holdout_model = fit_with_validation(
+        x_train=x_train,
+        y_train=y_train,
+        x_valid=x_valid,
+        y_valid=y_valid,
+        cat_columns=cat_columns,
+        params=teacher_params,
+        early_stopping_rounds=early_stopping_rounds,
+        verbose=verbose,
+    )
+    holdout_pred = predict_proba(holdout_model, x_valid)
+    final_iterations = int(best_iteration_or_default(holdout_model, teacher_params.iterations))
+
+    full_params = CatBoostHyperParams(
+        iterations=final_iterations,
+        learning_rate=teacher_params.learning_rate,
+        depth=teacher_params.depth,
+        l2_leaf_reg=teacher_params.l2_leaf_reg,
+        random_seed=teacher_params.random_seed,
+        loss_function=teacher_params.loss_function,
+        eval_metric=teacher_params.eval_metric,
+    )
+    full_model = fit_full_train(
+        x_train=x_original,
+        y_train=y_original,
+        cat_columns=infer_categorical_columns(x_original),
+        params=full_params,
+        verbose=verbose,
+    )
+    metadata = {
+        "rows": int(len(original_df)),
+        "holdout_rows": int(len(x_valid)),
+        "holdout_auc": float(binary_auc(y_valid, holdout_pred)),
+        "best_iteration": int(holdout_model.get_best_iteration()),
+        "final_iterations": int(final_iterations),
+        "teacher_params": teacher_params.to_catboost_kwargs(),
+    }
+    return full_model, metadata
+
+
+def _build_external_prediction_feature(
+    model: Any,
+    *,
+    competition_train_df: pd.DataFrame,
+    competition_test_df: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    train_features = _sanitize_total_charges(
+        competition_train_df.drop(columns=[TARGET_COLUMN], errors="ignore"),
+        fallback_median=float(pd.to_numeric(competition_train_df["TotalCharges"], errors="coerce").median()),
+    )
+    test_features = _sanitize_total_charges(
+        competition_test_df.copy(),
+        fallback_median=float(pd.to_numeric(competition_train_df["TotalCharges"], errors="coerce").median()),
+    )
+    x_train_external = prepare_test_features(train_features, drop_id=True, feature_blocks=[])
+    x_test_external = prepare_test_features(test_features, drop_id=True, feature_blocks=[])
+    train_pred = predict_proba(model, x_train_external)
+    test_pred = predict_proba(model, x_test_external)
+
+    transfer_train = pd.DataFrame(
+        {
+            ID_COLUMN: competition_train_df[ID_COLUMN].astype("int64").values,
+            TRANSFER_FEATURE_COLUMN: train_pred.astype(float).values,
+        }
+    )
+    transfer_test = pd.DataFrame(
+        {
+            ID_COLUMN: competition_test_df[ID_COLUMN].astype("int64").values,
+            TRANSFER_FEATURE_COLUMN: test_pred.astype(float).values,
+        }
+    )
+    return transfer_train, transfer_test
+
+
+def run_telco_transfer_smoke(
+    *,
+    train_csv_path: str,
+    test_csv_path: str,
+    original_csv_path: str,
+    teacher_params: CatBoostHyperParams,
+    challenger_params: CatBoostHyperParams,
+    feature_blocks: Sequence[str],
+    folds: int,
+    seed: int,
+    stratify_mode: str,
+    teacher_valid_size: float,
+    teacher_early_stopping_rounds: int,
+    challenger_early_stopping_rounds: int,
+    verbose: int,
+) -> dict[str, Any]:
+    """Run the minimal external-teacher transfer feature smoke experiment.
+
+    Parameters define:
+    - competition train/test CSV paths
+    - external original Telco CSV path
+    - CatBoost params for the external teacher and the competition challenger
+    - smoke CV controls for the challenger
+
+    Returns a metrics dict with:
+    - input file metadata/hashes
+    - teacher training metadata
+    - challenger CV metrics and fold metrics
+    - `oof_pred` for the competition train set
+    - `transfer_train` / `transfer_test` frames with `id` and `external_telco_pred`
+    """
+    competition_train_df = load_csv(train_csv_path)
+    competition_test_df = load_csv(test_csv_path)
+    original_df = _prepare_external_original_frame(original_csv_path)
+    original_filtered_df, dropped_overlaps = _drop_exact_external_overlaps(
+        original_df,
+        competition_train_df=competition_train_df,
+        competition_test_df=competition_test_df,
+    )
+    teacher_model, teacher_metadata = _train_external_teacher(
+        original_filtered_df,
+        teacher_params=teacher_params,
+        valid_size=teacher_valid_size,
+        early_stopping_rounds=teacher_early_stopping_rounds,
+        verbose=verbose,
+    )
+    transfer_train, transfer_test = _build_external_prediction_feature(
+        teacher_model,
+        competition_train_df=competition_train_df,
+        competition_test_df=competition_test_df,
+    )
+
+    normalized_blocks, _, stateful_blocks, x, y = _prepare_train_matrix(competition_train_df, feature_blocks)
+    x = x.copy()
+    x[TRANSFER_FEATURE_COLUMN] = transfer_train[TRANSFER_FEATURE_COLUMN].astype(float).values
+    splitter = StratifiedKFold(n_splits=int(folds), shuffle=True, random_state=int(seed))
+    stratify_labels = _build_stratify_labels(x, y, stratify_mode=stratify_mode, min_count=int(folds))
+
+    oof_pred = pd.Series(index=x.index, dtype="float64", name="oof_pred")
+    fold_metrics: list[dict[str, Any]] = []
+
+    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x, stratify_labels), start=1):
+        x_train = x.iloc[train_idx]
+        y_train = y.iloc[train_idx]
+        x_valid = x.iloc[valid_idx]
+        y_valid = y.iloc[valid_idx]
+
+        x_train_fit, x_valid_fit = _transform_pair_with_stateful_blocks(x_train, x_valid, stateful_blocks)
+        cat_columns = infer_categorical_columns(x_train_fit)
+        fold_params = CatBoostHyperParams(
+            iterations=challenger_params.iterations,
+            learning_rate=challenger_params.learning_rate,
+            depth=challenger_params.depth,
+            l2_leaf_reg=challenger_params.l2_leaf_reg,
+            random_seed=seed,
+            loss_function=challenger_params.loss_function,
+            eval_metric=challenger_params.eval_metric,
+            monotone_constraints=challenger_params.monotone_constraints,
+        )
+        model = fit_with_validation(
+            x_train=x_train_fit,
+            y_train=y_train,
+            x_valid=x_valid_fit,
+            y_valid=y_valid,
+            cat_columns=cat_columns,
+            params=fold_params,
+            early_stopping_rounds=challenger_early_stopping_rounds,
+            verbose=verbose,
+        )
+        fold_pred = predict_proba(model, x_valid_fit)
+        oof_pred.iloc[valid_idx] = fold_pred.values
+        fold_metrics.append(
+            {
+                "fold": int(fold_number),
+                "auc": float(binary_auc(y_valid, fold_pred)),
+                "best_iteration": int(model.get_best_iteration()),
+                "final_iterations": int(best_iteration_or_default(model, challenger_params.iterations)),
+                "valid_rows": int(len(valid_idx)),
+            }
+        )
+
+    if oof_pred.isna().any():
+        raise RuntimeError("Telco transfer OOF predictions contain missing values.")
+
+    fold_aucs = [float(item["auc"]) for item in fold_metrics]
+    return {
+        "generated_at_utc": utc_now_iso(),
+        "train_csv_path": str(train_csv_path),
+        "test_csv_path": str(test_csv_path),
+        "original_csv_path": str(original_csv_path),
+        "input_files": {
+            "train_csv": describe_file(train_csv_path),
+            "test_csv": describe_file(test_csv_path),
+            "original_csv": describe_file(original_csv_path),
+        },
+        "feature_blocks": list(normalize_feature_blocks(feature_blocks)),
+        "transfer_feature_column": TRANSFER_FEATURE_COLUMN,
+        "teacher_metadata": {
+            **teacher_metadata,
+            "dropped_exact_overlaps": int(dropped_overlaps),
+        },
+        "rows": int(len(competition_train_df)),
+        "folds": int(folds),
+        "seed": int(seed),
+        "cv_mean_auc": float(np.mean(fold_aucs)),
+        "cv_std_auc": float(np.std(fold_aucs)),
+        "oof_auc": float(binary_auc(y, oof_pred)),
+        "fold_metrics": fold_metrics,
+        "oof_pred": oof_pred,
+        "transfer_train": transfer_train,
+        "transfer_test": transfer_test,
+    }

--- a/src/churn_baseline/uncertainty_band.py
+++ b/src/churn_baseline/uncertainty_band.py
@@ -1,0 +1,405 @@
+"""Localized reranker over the incumbent uncertainty band."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+from catboost import CatBoostRegressor
+from sklearn.model_selection import StratifiedKFold
+
+from .artifacts import ensure_parent_dir, write_json
+from .config import CatBoostHyperParams, ID_COLUMN, TARGET_COLUMN
+from .data import encode_target, infer_categorical_columns, load_csv
+from .diagnostics import build_family_frame
+from .evaluation import binary_auc
+from .pipeline import _prepare_train_matrix, _transform_pair_with_stateful_blocks, _transform_single_with_stateful_blocks
+from .specialist import (
+    _append_reference_features,
+    _clip_probability,
+    _normalize_reference_component_frame,
+)
+
+
+DEFAULT_V3_OOF_SPEC = "artifacts/reports/validation_protocol_v3_chain_oof.csv#candidate_pred"
+MIN_BAND_TRAIN_ROWS = 2000
+MIN_BAND_VALID_ROWS = 500
+
+
+def _align_reference_prediction(
+    train_df: pd.DataFrame,
+    reference_frame: pd.DataFrame,
+) -> pd.Series:
+    required = {ID_COLUMN, "target", "reference_pred"}
+    missing = sorted(required.difference(reference_frame.columns))
+    if missing:
+        raise ValueError(f"reference_frame missing required columns: {missing}")
+
+    out = train_df[[ID_COLUMN, TARGET_COLUMN]].merge(
+        reference_frame[[ID_COLUMN, "target", "reference_pred"]],
+        how="left",
+        on=ID_COLUMN,
+        validate="one_to_one",
+    )
+    if out["reference_pred"].isna().any():
+        missing_ids = out.loc[out["reference_pred"].isna(), ID_COLUMN].head(5).tolist()
+        raise ValueError(f"reference_frame missing ids from train.csv: {missing_ids}")
+
+    train_target = encode_target(out[TARGET_COLUMN]).astype("int8")
+    reference_target = pd.to_numeric(out["target"], errors="raise").astype("int8")
+    if not np.array_equal(train_target.to_numpy(dtype="int8"), reference_target.to_numpy(dtype="int8")):
+        raise ValueError("reference_frame target does not align with train.csv")
+
+    reference_pred = pd.to_numeric(out["reference_pred"], errors="raise").astype("float64")
+    if reference_pred.isna().any():
+        raise ValueError("reference_pred contains NaN values after alignment")
+    return pd.Series(reference_pred.values, index=train_df.index, dtype="float64", name="reference_pred")
+
+
+def _build_component_stats(
+    ids: pd.Series,
+    reference_component_frame: pd.DataFrame | None,
+) -> tuple[pd.DataFrame | None, pd.Series | None]:
+    component_frame = _normalize_reference_component_frame(ids, reference_component_frame)
+    if component_frame is None:
+        return None, None
+    component_columns = [column for column in component_frame.columns if column != ID_COLUMN]
+    component_std = pd.Series(
+        component_frame[component_columns].to_numpy(dtype="float64").std(axis=1),
+        index=ids.index,
+        dtype="float64",
+        name="teacher_component_std",
+    )
+    return component_frame, component_std
+
+
+def build_uncertainty_band_mask(
+    train_df: pd.DataFrame,
+    *,
+    reference_pred: pd.Series,
+    reference_component_frame: pd.DataFrame | None,
+    target_family_level: str,
+    target_family_value: str,
+    band_half_width: float,
+    min_teacher_std: float | None,
+    max_relative_mask_drift: float,
+) -> tuple[pd.Series, dict[str, Any], pd.Series | None]:
+    if target_family_level not in {"segment3", "segment5"}:
+        raise ValueError("target_family_level must be 'segment3' or 'segment5'")
+    if float(band_half_width) <= 0.0 or float(band_half_width) >= 0.5:
+        raise ValueError(f"band_half_width must be in (0, 0.5), got {band_half_width}")
+    if float(max_relative_mask_drift) < 0.0:
+        raise ValueError(f"max_relative_mask_drift must be >= 0, got {max_relative_mask_drift}")
+
+    family_frame = build_family_frame(train_df)
+    if family_frame[target_family_level].isna().any():
+        raise ValueError(f"family frame contains NaN values in '{target_family_level}'")
+
+    _, component_std = _build_component_stats(train_df[ID_COLUMN], reference_component_frame)
+
+    family_mask = family_frame[target_family_level].astype(str).eq(str(target_family_value))
+    uncertainty = (reference_pred.astype("float64") - 0.5).abs()
+    band_mask = uncertainty.le(float(band_half_width))
+    baseline_mask = family_mask & band_mask
+    final_mask = baseline_mask.copy()
+    if min_teacher_std is not None:
+        if component_std is None:
+            raise ValueError("min_teacher_std requires reference_component_frame")
+        final_mask = final_mask & component_std.ge(float(min_teacher_std))
+
+    baseline_rows = int(baseline_mask.sum())
+    final_rows = int(final_mask.sum())
+    baseline_rate = float(baseline_rows / max(len(train_df), 1))
+    final_rate = float(final_rows / max(len(train_df), 1))
+    relative_drift = 0.0
+    if baseline_rows > 0:
+        relative_drift = float(abs(final_rows - baseline_rows) / baseline_rows)
+    if relative_drift > float(max_relative_mask_drift):
+        raise ValueError(
+            "uncertainty-band mask rate drift exceeds allowed maximum: "
+            f"baseline_rows={baseline_rows}, final_rows={final_rows}, relative_drift={relative_drift:.6f}, "
+            f"max_relative_mask_drift={float(max_relative_mask_drift):.6f}"
+        )
+
+    mask_summary = {
+        "target_family_level": str(target_family_level),
+        "target_family_value": str(target_family_value),
+        "band_half_width": float(band_half_width),
+        "min_teacher_std": None if min_teacher_std is None else float(min_teacher_std),
+        "max_relative_mask_drift": float(max_relative_mask_drift),
+        "family_rows": int(family_mask.sum()),
+        "family_rate": float(family_mask.mean()),
+        "band_rows": int(band_mask.sum()),
+        "band_rate": float(band_mask.mean()),
+        "baseline_mask_rows": baseline_rows,
+        "baseline_mask_rate": baseline_rate,
+        "final_mask_rows": final_rows,
+        "final_mask_rate": final_rate,
+        "relative_mask_rate_drift": relative_drift,
+        "reference_uncertainty_mean_on_mask": float(uncertainty.loc[final_mask].mean()) if final_rows else None,
+        "reference_uncertainty_max_on_mask": float(uncertainty.loc[final_mask].max()) if final_rows else None,
+        "teacher_component_std_mean_on_mask": (
+            float(component_std.loc[final_mask].mean()) if component_std is not None and final_rows else None
+        ),
+    }
+    return final_mask.astype(bool), mask_summary, component_std
+
+
+def run_uncertainty_band_reranker_cv(
+    *,
+    train_csv_path: str | Path,
+    reference_frame: pd.DataFrame,
+    reference_component_frame: pd.DataFrame | None,
+    params: CatBoostHyperParams,
+    feature_blocks: Sequence[str] | None,
+    folds: int,
+    random_state: int,
+    early_stopping_rounds: int,
+    verbose: int,
+    alpha_grid: Sequence[float],
+    target_family_level: str,
+    target_family_value: str,
+    band_half_width: float,
+    min_teacher_std: float | None,
+    max_relative_mask_drift: float,
+    model_path: str | Path,
+    metrics_path: str | Path,
+    oof_path: str | Path,
+) -> dict[str, Any]:
+    if folds < 2:
+        raise ValueError("folds must be >= 2")
+    if not alpha_grid:
+        raise ValueError("alpha_grid must contain at least one value")
+
+    train_df = load_csv(train_csv_path)
+    normalized_blocks, _, stateful_blocks, x, y = _prepare_train_matrix(train_df, feature_blocks)
+    reference_pred = _align_reference_prediction(train_df, reference_frame)
+    component_frame, teacher_component_std = _build_component_stats(train_df[ID_COLUMN], reference_component_frame)
+    band_mask, mask_summary, teacher_component_std = build_uncertainty_band_mask(
+        train_df,
+        reference_pred=reference_pred,
+        reference_component_frame=component_frame,
+        target_family_level=target_family_level,
+        target_family_value=target_family_value,
+        band_half_width=band_half_width,
+        min_teacher_std=min_teacher_std,
+        max_relative_mask_drift=max_relative_mask_drift,
+    )
+
+    mask_rows = int(band_mask.sum())
+    if mask_rows < MIN_BAND_TRAIN_ROWS:
+        raise ValueError(
+            f"uncertainty band selects only {mask_rows} rows. Minimum required: {MIN_BAND_TRAIN_ROWS}"
+        )
+    if y.loc[band_mask].nunique() < 2:
+        raise ValueError("uncertainty band must contain both classes")
+
+    splitter = StratifiedKFold(n_splits=folds, shuffle=True, random_state=random_state)
+    residual_pred = pd.Series(index=x.index, dtype="float64", name="residual_pred")
+    fold_rows: list[dict[str, Any]] = []
+    fold_iterations: list[int] = []
+    disagreement_columns: list[str] = []
+
+    for fold_number, (train_idx, valid_idx) in enumerate(splitter.split(x, y), start=1):
+        x_train = x.iloc[train_idx]
+        y_train = y.iloc[train_idx]
+        x_valid = x.iloc[valid_idx]
+        y_valid = y.iloc[valid_idx]
+        x_train, x_valid = _transform_pair_with_stateful_blocks(x_train, x_valid, stateful_blocks)
+
+        train_mask = band_mask.iloc[train_idx].to_numpy(dtype=bool)
+        valid_mask = band_mask.iloc[valid_idx].to_numpy(dtype=bool)
+        masked_train_rows = int(np.sum(train_mask))
+        masked_valid_rows = int(np.sum(valid_mask))
+        if masked_train_rows < MIN_BAND_TRAIN_ROWS:
+            raise ValueError(
+                f"Fold {fold_number} train rows inside uncertainty band {masked_train_rows} below minimum {MIN_BAND_TRAIN_ROWS}"
+            )
+        if masked_valid_rows < MIN_BAND_VALID_ROWS:
+            raise ValueError(
+                f"Fold {fold_number} valid rows inside uncertainty band {masked_valid_rows} below minimum {MIN_BAND_VALID_ROWS}"
+            )
+        if y_train.iloc[train_mask].nunique() < 2 or y_valid.iloc[valid_mask].nunique() < 2:
+            raise ValueError(f"Fold {fold_number} uncertainty band lost one class in train or valid")
+
+        train_reference = reference_pred.iloc[train_idx]
+        valid_reference = reference_pred.iloc[valid_idx]
+        train_components = component_frame.iloc[train_idx] if component_frame is not None else None
+        valid_components = component_frame.iloc[valid_idx] if component_frame is not None else None
+
+        x_train, train_disagreement_columns = _append_reference_features(
+            x_train,
+            reference_pred=train_reference,
+            reference_component_frame=train_components,
+            include_logit=True,
+        )
+        x_valid, valid_disagreement_columns = _append_reference_features(
+            x_valid,
+            reference_pred=valid_reference,
+            reference_component_frame=valid_components,
+            include_logit=True,
+        )
+        if train_disagreement_columns != valid_disagreement_columns:
+            raise RuntimeError("Teacher disagreement feature mismatch between train and valid folds")
+        if not disagreement_columns:
+            disagreement_columns = list(train_disagreement_columns)
+
+        cat_columns = infer_categorical_columns(x_train)
+        y_train_residual = y_train.iloc[train_mask].astype("float64") - train_reference.iloc[train_mask].astype("float64")
+        y_valid_residual = y_valid.iloc[valid_mask].astype("float64") - valid_reference.iloc[valid_mask].astype("float64")
+
+        fold_model = CatBoostRegressor(
+            iterations=params.iterations,
+            learning_rate=params.learning_rate,
+            depth=params.depth,
+            l2_leaf_reg=params.l2_leaf_reg,
+            random_seed=random_state,
+            loss_function="RMSE",
+            eval_metric="RMSE",
+            verbose=verbose,
+        )
+        fold_model.fit(
+            x_train.iloc[train_mask],
+            y_train_residual,
+            cat_features=cat_columns,
+            eval_set=(x_valid.iloc[valid_mask], y_valid_residual),
+            use_best_model=True,
+            early_stopping_rounds=early_stopping_rounds,
+            verbose=verbose,
+        )
+
+        valid_residual_pred = pd.Series(
+            fold_model.predict(x_valid.iloc[valid_mask]),
+            index=x_valid.iloc[valid_mask].index,
+            dtype="float64",
+        )
+        residual_pred.iloc[np.asarray(valid_idx)[valid_mask]] = valid_residual_pred.values
+
+        fold_best_iter = fold_model.get_best_iteration()
+        fold_final_iterations = params.iterations if fold_best_iter is None or fold_best_iter < 0 else int(fold_best_iter) + 1
+        fold_iterations.append(int(fold_final_iterations))
+        reference_auc = binary_auc(y_valid.iloc[valid_mask], valid_reference.iloc[valid_mask])
+        reranked_valid = _clip_probability(valid_reference.iloc[valid_mask] + valid_residual_pred)
+        reranked_auc = binary_auc(y_valid.iloc[valid_mask], reranked_valid)
+        fold_rows.append(
+            {
+                "fold": int(fold_number),
+                "masked_train_rows": masked_train_rows,
+                "masked_valid_rows": masked_valid_rows,
+                "masked_positive_rate_train": float(y_train.iloc[train_mask].mean()),
+                "masked_positive_rate_valid": float(y_valid.iloc[valid_mask].mean()),
+                "reference_auc_on_mask": reference_auc,
+                "reranked_auc_on_mask": reranked_auc,
+                "delta_auc_on_mask": float(reranked_auc - reference_auc),
+                "final_iterations": int(fold_final_iterations),
+            }
+        )
+
+    if residual_pred.loc[band_mask].isna().any():
+        raise RuntimeError("Residual OOF predictions contain missing values inside the uncertainty band")
+
+    alpha_scan_rows: list[dict[str, Any]] = []
+    for alpha in alpha_grid:
+        alpha_value = float(alpha)
+        candidate = reference_pred.copy()
+        candidate.loc[band_mask] = _clip_probability(
+            reference_pred.loc[band_mask] + alpha_value * residual_pred.loc[band_mask]
+        ).values
+        alpha_scan_rows.append(
+            {
+                "alpha": alpha_value,
+                "oof_auc": float(binary_auc(y, candidate)),
+                "oof_auc_on_mask": float(binary_auc(y.loc[band_mask], candidate.loc[band_mask])),
+                "reference_auc_on_mask": float(binary_auc(y.loc[band_mask], reference_pred.loc[band_mask])),
+            }
+        )
+
+    best_alpha_row = max(alpha_scan_rows, key=lambda row: row["oof_auc"])
+    best_alpha = float(best_alpha_row["alpha"])
+    candidate_best = reference_pred.copy()
+    candidate_best.loc[band_mask] = _clip_probability(
+        reference_pred.loc[band_mask] + best_alpha * residual_pred.loc[band_mask]
+    ).values
+
+    final_iterations = max(int(round(float(np.mean(fold_iterations)))), 1)
+    x_full = _transform_single_with_stateful_blocks(x, stateful_blocks)
+    x_full, disagreement_columns_full = _append_reference_features(
+        x_full,
+        reference_pred=reference_pred,
+        reference_component_frame=component_frame,
+        include_logit=True,
+    )
+    if disagreement_columns and disagreement_columns_full != disagreement_columns:
+        raise RuntimeError("Teacher disagreement feature mismatch between CV folds and full train")
+    if not disagreement_columns:
+        disagreement_columns = list(disagreement_columns_full)
+
+    cat_columns = infer_categorical_columns(x_full)
+    full_model = CatBoostRegressor(
+        iterations=final_iterations,
+        learning_rate=params.learning_rate,
+        depth=params.depth,
+        l2_leaf_reg=params.l2_leaf_reg,
+        random_seed=params.random_seed,
+        loss_function="RMSE",
+        eval_metric="RMSE",
+        verbose=verbose,
+    )
+    full_model.fit(
+        x_full.loc[band_mask],
+        (y.loc[band_mask].astype("float64") - reference_pred.loc[band_mask].astype("float64")),
+        cat_features=cat_columns,
+        verbose=verbose,
+    )
+    model_out_path = ensure_parent_dir(model_path)
+    full_model.save_model(str(model_out_path))
+
+    family_frame = build_family_frame(train_df)
+    oof_output = pd.DataFrame(
+        {
+            ID_COLUMN: train_df[ID_COLUMN].values,
+            "target": y.astype(int).values,
+            "reference_pred": reference_pred.values,
+            "candidate_pred": candidate_best.values,
+            "residual_pred": residual_pred.values,
+            "family_mask": family_frame[target_family_level].astype(str).eq(str(target_family_value)).astype("int8").values,
+            "uncertainty_mask": (reference_pred.sub(0.5).abs().le(float(band_half_width))).astype("int8").values,
+            "specialist_mask": band_mask.astype("int8").values,
+            "reference_uncertainty": (reference_pred.sub(0.5).abs()).astype("float64").values,
+        }
+    )
+    if teacher_component_std is not None:
+        oof_output["teacher_component_std"] = teacher_component_std.astype("float64").values
+    oof_out_path = ensure_parent_dir(oof_path)
+    oof_output.to_csv(oof_out_path, index=False)
+
+    metrics: dict[str, Any] = {
+        "approach": "uncertainty_band_residual",
+        "train_rows": int(len(train_df)),
+        "feature_blocks": list(normalized_blocks),
+        "feature_count": int(x_full.shape[1]),
+        "feature_columns": list(x_full.columns),
+        "teacher_disagreement_columns": list(disagreement_columns),
+        "categorical_columns": cat_columns,
+        "mask_summary": mask_summary,
+        "masked_positive_rate": float(y.loc[band_mask].mean()),
+        "cv_folds": int(folds),
+        "cv_fold_metrics": fold_rows,
+        "fold_final_iterations": [int(value) for value in fold_iterations],
+        "final_iterations": int(final_iterations),
+        "alpha_scan": alpha_scan_rows,
+        "best_alpha": best_alpha,
+        "reference_oof_auc": float(binary_auc(y, reference_pred)),
+        "reference_oof_auc_on_mask": float(binary_auc(y.loc[band_mask], reference_pred.loc[band_mask])),
+        "candidate_oof_auc": float(binary_auc(y, candidate_best)),
+        "candidate_oof_auc_on_mask": float(binary_auc(y.loc[band_mask], candidate_best.loc[band_mask])),
+        "delta_vs_reference_oof_auc": float(binary_auc(y, candidate_best) - binary_auc(y, reference_pred)),
+        "model_path": str(model_out_path),
+        "oof_path": str(oof_out_path),
+        "target_column": TARGET_COLUMN,
+        "id_column": ID_COLUMN,
+    }
+    write_json(metrics_path, metrics)
+    return metrics

--- a/src/churn_baseline/v3_dominance.py
+++ b/src/churn_baseline/v3_dominance.py
@@ -1,0 +1,478 @@
+"""Aggressive diagnostics for why incumbent v3 dominates challengers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+
+from .artifacts import ensure_parent_dir, write_json
+from .config import ID_COLUMN
+from .data import load_csv
+from .diagnostics import (
+    OOF_TARGET_COLUMN,
+    build_family_frame,
+    describe_file,
+    load_reference_prediction_frame,
+    utc_now_iso,
+)
+from .evaluation import binary_auc
+from .validation_protocol import DOMINANT_MACROFAMILY
+
+
+DEFAULT_V3_OOF_SPEC = "artifacts/reports/validation_protocol_v3_chain_oof.csv#candidate_pred"
+
+
+@dataclass(frozen=True)
+class ChallengerSpec:
+    """Descriptor for one challenger OOF artifact."""
+
+    name: str
+    path: str
+    prediction_column: str = "oof_pred"
+    family: str = "unknown"
+
+
+DEFAULT_CHALLENGERS: tuple[ChallengerSpec, ...] = (
+    ChallengerSpec(
+        name="global_feature_block_rv_issue7",
+        path="artifacts/reports/fe_blockRV_issue7_smoke_oof.csv",
+        family="global_feature_block",
+    ),
+    ChallengerSpec(
+        name="family_gated_ec_mtm_fiber",
+        path="artifacts/reports/family_gated_ec_mtm_fiber_any_teacher_smoke_oof.csv",
+        prediction_column="candidate_pred",
+        family="family_challenger",
+    ),
+    ChallengerSpec(
+        name="near_duplicate_drop",
+        path="artifacts/reports/noise_mitigation_drop_smoke_oof.csv",
+        family="data_centric",
+    ),
+    ChallengerSpec(
+        name="external_telco_transfer",
+        path="artifacts/reports/telco_transfer_smoke_oof.csv",
+        family="external_transfer",
+    ),
+    ChallengerSpec(
+        name="residual_ec_mtm_fiber_paperless_any",
+        path="artifacts/reports/residual_reranker_ec_mtm_fiber_paperless_any_teacher_smoke_oof.csv",
+        prediction_column="candidate_pred",
+        family="near_pass_residual",
+    ),
+)
+
+
+def _clip_probability(values: pd.Series, epsilon: float = 1e-6) -> pd.Series:
+    return values.astype("float64").clip(epsilon, 1.0 - epsilon)
+
+
+def _safe_binary_auc(y_true: pd.Series, pred: pd.Series) -> float:
+    if int(y_true.nunique(dropna=False)) < 2:
+        return float("nan")
+    return float(binary_auc(y_true, pred))
+
+
+def _logloss_vector(y_true: pd.Series, pred: pd.Series) -> pd.Series:
+    clipped = _clip_probability(pred)
+    target = y_true.astype("float64")
+    return -(target * np.log(clipped) + (1.0 - target) * np.log(1.0 - clipped))
+
+
+def _load_candidate_frame(spec: ChallengerSpec) -> pd.DataFrame:
+    frame = pd.read_csv(spec.path)
+    required = {ID_COLUMN, OOF_TARGET_COLUMN, spec.prediction_column}
+    missing = sorted(required.difference(frame.columns))
+    if missing:
+        raise ValueError(f"{spec.path} missing required columns {missing}")
+    out = frame[[ID_COLUMN, OOF_TARGET_COLUMN, spec.prediction_column]].copy()
+    out = out.rename(columns={spec.prediction_column: "candidate_pred"})
+    return out
+
+
+def _validate_pair(reference_frame: pd.DataFrame, candidate_frame: pd.DataFrame, *, challenger_name: str) -> pd.DataFrame:
+    merged = reference_frame[[ID_COLUMN, OOF_TARGET_COLUMN, "reference_pred"]].merge(
+        candidate_frame[[ID_COLUMN, OOF_TARGET_COLUMN, "candidate_pred"]],
+        how="inner",
+        on=[ID_COLUMN, OOF_TARGET_COLUMN],
+        validate="one_to_one",
+    )
+    if len(merged) != len(reference_frame):
+        raise ValueError(
+            f"Candidate '{challenger_name}' does not fully cover the v3 reference rows: "
+            f"{len(merged)} vs {len(reference_frame)}"
+        )
+    return merged.sort_values(ID_COLUMN).reset_index(drop=True)
+
+
+def _bucket_from_edges(values: pd.Series, edges: Sequence[float], *, prefix: str) -> pd.Series:
+    numeric_edges = np.unique(np.asarray(list(edges), dtype="float64"))
+    if len(numeric_edges) < 2:
+        numeric_edges = np.asarray([0.0, 1.0], dtype="float64")
+    labels = [f"{prefix}_{idx:02d}" for idx in range(len(numeric_edges) - 1)]
+    bucket = pd.cut(
+        values.astype("float64"),
+        bins=numeric_edges,
+        include_lowest=True,
+        labels=labels,
+        duplicates="drop",
+    )
+    return bucket.astype(str).replace("nan", "__missing__")
+
+
+def _compute_slice_frame(analysis: pd.DataFrame) -> pd.DataFrame:
+    score_edges = np.quantile(
+        analysis["reference_pred"].astype("float64").to_numpy(),
+        q=np.linspace(0.0, 1.0, 11),
+    )
+    score_edges[0] = 0.0
+    score_edges[-1] = 1.0
+    confidence_edges = [0.0, 0.05, 0.10, 0.20, 0.30, 0.40, 0.50]
+    disagreement_edges = [0.0, 0.005, 0.01, 0.02, 0.05, 0.10, 1.0]
+
+    analysis = analysis.copy()
+    analysis["v3_score_decile"] = _bucket_from_edges(analysis["reference_pred"], score_edges, prefix="score")
+    analysis["v3_confidence_bucket"] = _bucket_from_edges(
+        (analysis["reference_pred"].astype("float64") - 0.5).abs(),
+        confidence_edges,
+        prefix="confidence",
+    )
+    analysis["v3_disagreement_bucket"] = _bucket_from_edges(
+        (analysis["candidate_pred"].astype("float64") - analysis["reference_pred"].astype("float64")).abs(),
+        disagreement_edges,
+        prefix="disagreement",
+    )
+    return analysis
+
+
+def _aggregate_family_delta(
+    analysis: pd.DataFrame,
+    *,
+    family_column: str,
+    challenger_name: str,
+) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    total_rows = float(len(analysis))
+    for family_value, part in analysis.groupby(family_column, dropna=False):
+        y_true = part[OOF_TARGET_COLUMN].astype(int)
+        reference_auc = _safe_binary_auc(y_true, part["reference_pred"])
+        candidate_auc = _safe_binary_auc(y_true, part["candidate_pred"])
+        reference_logloss = float(part["reference_loss"].mean())
+        candidate_logloss = float(part["candidate_loss"].mean())
+        rows.append(
+            {
+                "challenger": challenger_name,
+                "family_level": family_column,
+                "family_value": str(family_value),
+                "rows": int(len(part)),
+                "reference_auc": reference_auc,
+                "candidate_auc": candidate_auc,
+                "delta_auc": float(candidate_auc - reference_auc),
+                "reference_logloss": reference_logloss,
+                "candidate_logloss": candidate_logloss,
+                "delta_logloss": float(candidate_logloss - reference_logloss),
+                "reference_logloss_contribution": float(reference_logloss * len(part) / total_rows),
+                "candidate_logloss_contribution": float(candidate_logloss * len(part) / total_rows),
+                "delta_logloss_contribution": float((candidate_logloss - reference_logloss) * len(part) / total_rows),
+                "v3_wins_auc": bool(reference_auc >= candidate_auc),
+                "v3_wins_logloss": bool(reference_logloss <= candidate_logloss),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _aggregate_slice_delta(
+    analysis: pd.DataFrame,
+    *,
+    slice_column: str,
+    challenger_name: str,
+) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    for slice_value, part in analysis.groupby(slice_column, dropna=False):
+        y_true = part[OOF_TARGET_COLUMN].astype(int)
+        reference_auc = _safe_binary_auc(y_true, part["reference_pred"])
+        candidate_auc = _safe_binary_auc(y_true, part["candidate_pred"])
+        rows.append(
+            {
+                "challenger": challenger_name,
+                "slice_type": slice_column,
+                "slice_value": str(slice_value),
+                "rows": int(len(part)),
+                "reference_auc": reference_auc,
+                "candidate_auc": candidate_auc,
+                "delta_auc": float(candidate_auc - reference_auc) if np.isfinite(reference_auc) and np.isfinite(candidate_auc) else float("nan"),
+                "reference_logloss": float(part["reference_loss"].mean()),
+                "candidate_logloss": float(part["candidate_loss"].mean()),
+                "delta_logloss": float(part["candidate_loss"].mean() - part["reference_loss"].mean()),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _build_one_challenger_summary(
+    *,
+    analysis: pd.DataFrame,
+    challenger: ChallengerSpec,
+) -> tuple[dict[str, Any], pd.DataFrame, pd.DataFrame]:
+    y_true = analysis[OOF_TARGET_COLUMN].astype(int)
+    reference_auc = float(binary_auc(y_true, analysis["reference_pred"]))
+    candidate_auc = float(binary_auc(y_true, analysis["candidate_pred"]))
+    reference_logloss = float(analysis["reference_loss"].mean())
+    candidate_logloss = float(analysis["candidate_loss"].mean())
+
+    segment3_delta = _aggregate_family_delta(analysis, family_column="segment3", challenger_name=challenger.name)
+    segment5_delta = _aggregate_family_delta(analysis, family_column="segment5", challenger_name=challenger.name)
+    slices = pd.concat(
+        [
+            _aggregate_slice_delta(analysis, slice_column="v3_score_decile", challenger_name=challenger.name),
+            _aggregate_slice_delta(analysis, slice_column="v3_confidence_bucket", challenger_name=challenger.name),
+            _aggregate_slice_delta(analysis, slice_column="v3_disagreement_bucket", challenger_name=challenger.name),
+        ],
+        axis=0,
+        ignore_index=True,
+    )
+
+    dominant_segment3 = segment3_delta.loc[segment3_delta["family_value"].eq(DOMINANT_MACROFAMILY)]
+    dominant_payload = dominant_segment3.iloc[0].to_dict() if not dominant_segment3.empty else None
+    summary = {
+        "challenger": challenger.name,
+        "challenger_family": challenger.family,
+        "global_rows": int(len(analysis)),
+        "reference_auc": reference_auc,
+        "candidate_auc": candidate_auc,
+        "delta_auc": float(candidate_auc - reference_auc),
+        "reference_logloss": reference_logloss,
+        "candidate_logloss": candidate_logloss,
+        "delta_logloss": float(candidate_logloss - reference_logloss),
+        "pearson_corr_vs_v3": float(analysis["reference_pred"].corr(analysis["candidate_pred"])),
+        "mean_abs_pred_diff_vs_v3": float((analysis["candidate_pred"] - analysis["reference_pred"]).abs().mean()),
+        "dominant_segment3": dominant_payload,
+        "segment3_v3_auc_win_rate": float(segment3_delta["v3_wins_auc"].mean()),
+        "segment3_v3_logloss_win_rate": float(segment3_delta["v3_wins_logloss"].mean()),
+        "segment5_v3_auc_win_rate": float(segment5_delta["v3_wins_auc"].mean()),
+        "segment5_v3_logloss_win_rate": float(segment5_delta["v3_wins_logloss"].mean()),
+        "top_segment3_damage_losses": segment3_delta.sort_values(
+            by=["delta_logloss_contribution", "delta_logloss"],
+            ascending=False,
+        ).head(10).to_dict(orient="records"),
+        "top_segment3_damage_gains": segment3_delta.sort_values(
+            by=["delta_logloss_contribution", "delta_logloss"],
+            ascending=True,
+        ).head(10).to_dict(orient="records"),
+        "top_segment5_damage_losses": segment5_delta.sort_values(
+            by=["delta_logloss_contribution", "delta_logloss"],
+            ascending=False,
+        ).head(10).to_dict(orient="records"),
+        "top_disagreement_losses": slices.loc[slices["slice_type"].eq("v3_disagreement_bucket")].sort_values(
+            by=["delta_logloss", "delta_auc"],
+            ascending=[False, True],
+        ).head(10).to_dict(orient="records"),
+    }
+    return summary, pd.concat([segment3_delta, segment5_delta], axis=0, ignore_index=True), slices
+
+
+def _derive_operational_recommendation(challenger_summaries: pd.DataFrame) -> str:
+    if challenger_summaries.empty:
+        return "No hay challengers para analizar."
+    dominant_losses = challenger_summaries["dominant_delta_logloss"].astype("float64")
+    global_losses = challenger_summaries["delta_logloss"].astype("float64")
+    if bool((dominant_losses > 0.0).all() and (global_losses > 0.0).all()):
+        return (
+            "v3 gana de forma consistente por mejor ranking/logloss en la macrofamilia dominante y tambien fuera de ella; "
+            "la siguiente hipotesis no debe ser otro challenger standalone, sino una explicacion/regularizacion de por que "
+            "el blend residual actual conserva mejor el ranking global."
+        )
+    return (
+        "La superioridad de v3 no es completamente uniforme; revisar los slices donde algun challenger gane logloss o AUC "
+        "antes de abrir la siguiente hipotesis."
+    )
+
+
+def _derive_dominance_patterns(
+    challenger_summary: pd.DataFrame,
+    slice_delta: pd.DataFrame,
+) -> dict[str, Any]:
+    patterns: dict[str, Any] = {}
+    if challenger_summary.empty:
+        return patterns
+
+    dominant_losses = challenger_summary["dominant_delta_logloss"].astype("float64")
+    if bool((dominant_losses > 0.0).all()):
+        patterns["dominant_family_consistent_v3_advantage"] = True
+
+    confidence = slice_delta.loc[slice_delta["slice_type"].eq("v3_confidence_bucket")].copy()
+    if not confidence.empty:
+        grouped = (
+            confidence.groupby("slice_value", dropna=False)
+            .agg(
+                mean_delta_logloss=("delta_logloss", "mean"),
+                challenger_count=("challenger", "nunique"),
+                support_rows=("rows", "sum"),
+            )
+            .reset_index()
+            .sort_values(by=["mean_delta_logloss", "support_rows"], ascending=[False, False])
+        )
+        patterns["confidence_slice_pressure"] = grouped.head(5).to_dict(orient="records")
+
+    disagreement = slice_delta.loc[slice_delta["slice_type"].eq("v3_disagreement_bucket")].copy()
+    if not disagreement.empty:
+        grouped = (
+            disagreement.groupby("slice_value", dropna=False)
+            .agg(
+                mean_delta_logloss=("delta_logloss", "mean"),
+                challenger_count=("challenger", "nunique"),
+                support_rows=("rows", "sum"),
+            )
+            .reset_index()
+            .sort_values(by=["mean_delta_logloss", "support_rows"], ascending=[False, False])
+        )
+        patterns["disagreement_slice_pressure"] = grouped.head(5).to_dict(orient="records")
+
+    return patterns
+
+
+def _derive_specific_recommendation(
+    challenger_summary: pd.DataFrame,
+    slice_delta: pd.DataFrame,
+) -> str:
+    if challenger_summary.empty:
+        return "No hay suficiente informacion para proponer la siguiente hipotesis."
+
+    dominant_consistent = bool((challenger_summary["dominant_delta_logloss"].astype("float64") > 0.0).mean() >= 0.8)
+    confidence = slice_delta.loc[slice_delta["slice_type"].eq("v3_confidence_bucket")].copy()
+    disagreement = slice_delta.loc[slice_delta["slice_type"].eq("v3_disagreement_bucket")].copy()
+
+    low_confidence_worse = False
+    if not confidence.empty:
+        low_confidence = confidence.loc[confidence["slice_value"].isin(["confidence_00", "confidence_01", "confidence_02"])]
+        low_confidence_worse = bool((low_confidence.groupby("challenger")["delta_logloss"].mean() > 0.0).all())
+
+    high_disagreement_worse = False
+    if not disagreement.empty:
+        high_disagreement = disagreement.loc[disagreement["slice_value"].isin(["disagreement_03", "disagreement_04", "disagreement_05"])]
+        high_disagreement_worse = bool((high_disagreement.groupby("challenger")["delta_logloss"].mean() > 0.0).all())
+
+    if dominant_consistent and low_confidence_worse and high_disagreement_worse:
+        return (
+            "La siguiente hipotesis debe centrarse en la banda de baja confianza de v3 dentro de la macrofamilia dominante: "
+            "no otro challenger global, sino una correccion que solo intente reordenar ejemplos de alta ambiguedad "
+            "(`abs(v3-0.5) <= 0.20`) y alto desacuerdo contra v3 dentro de `Electronic check__Month-to-month__Fiber optic`. "
+            "La excepcion parcial es el residual casi-vivo, que mejora algo de logloss pero no ranking; eso sugiere atacar la zona ambigua, "
+            "no reemplazar a v3 globalmente."
+        )
+
+    return _derive_operational_recommendation(challenger_summary)
+
+
+def run_v3_dominance_diagnostic(
+    *,
+    train_csv_path: str,
+    reference_oof_spec: str,
+    challengers: Sequence[ChallengerSpec],
+    out_dir: str | Path,
+    label: str = "v3_dominance",
+) -> dict[str, Any]:
+    """Compare v3 against a curated challenger set using only existing OOF artifacts."""
+    out_root = Path(out_dir)
+    train_df = load_csv(train_csv_path)
+    family_frame = build_family_frame(train_df)
+    reference_frame, reference_source = load_reference_prediction_frame(
+        reference_oof_spec=reference_oof_spec,
+        id_column=ID_COLUMN,
+        target_column=OOF_TARGET_COLUMN,
+    )
+    reference_analysis = reference_frame[[ID_COLUMN, OOF_TARGET_COLUMN, "reference_pred"]].merge(
+        family_frame,
+        how="inner",
+        on=ID_COLUMN,
+        validate="one_to_one",
+    )
+    if len(reference_analysis) != len(train_df):
+        raise ValueError(
+            f"Reference OOF does not align with train.csv row count: {len(reference_analysis)} vs {len(train_df)}"
+        )
+
+    all_family_rows: list[pd.DataFrame] = []
+    all_slice_rows: list[pd.DataFrame] = []
+    challenger_summary_rows: list[dict[str, Any]] = []
+
+    for challenger in challengers:
+        candidate_frame = _load_candidate_frame(challenger)
+        merged = _validate_pair(reference_frame, candidate_frame, challenger_name=challenger.name)
+        analysis = merged.merge(
+            family_frame,
+            how="inner",
+            on=ID_COLUMN,
+            validate="one_to_one",
+        )
+        analysis["reference_pred"] = _clip_probability(analysis["reference_pred"])
+        analysis["candidate_pred"] = _clip_probability(analysis["candidate_pred"])
+        analysis["reference_loss"] = _logloss_vector(analysis[OOF_TARGET_COLUMN], analysis["reference_pred"])
+        analysis["candidate_loss"] = _logloss_vector(analysis[OOF_TARGET_COLUMN], analysis["candidate_pred"])
+        analysis = _compute_slice_frame(analysis)
+
+        summary, family_rows, slice_rows = _build_one_challenger_summary(
+            analysis=analysis,
+            challenger=challenger,
+        )
+        dominant_segment3 = summary.get("dominant_segment3") or {}
+        challenger_summary_rows.append(
+            {
+                "challenger": challenger.name,
+                "challenger_family": challenger.family,
+                "delta_auc": float(summary["delta_auc"]),
+                "delta_logloss": float(summary["delta_logloss"]),
+                "pearson_corr_vs_v3": float(summary["pearson_corr_vs_v3"]),
+                "mean_abs_pred_diff_vs_v3": float(summary["mean_abs_pred_diff_vs_v3"]),
+                "dominant_delta_auc": float(dominant_segment3.get("delta_auc", np.nan)),
+                "dominant_delta_logloss": float(dominant_segment3.get("delta_logloss", np.nan)),
+                "segment3_v3_auc_win_rate": float(summary["segment3_v3_auc_win_rate"]),
+                "segment3_v3_logloss_win_rate": float(summary["segment3_v3_logloss_win_rate"]),
+                "segment5_v3_auc_win_rate": float(summary["segment5_v3_auc_win_rate"]),
+                "segment5_v3_logloss_win_rate": float(summary["segment5_v3_logloss_win_rate"]),
+            }
+        )
+        all_family_rows.append(family_rows)
+        all_slice_rows.append(slice_rows)
+
+    challenger_summary = pd.DataFrame(challenger_summary_rows).sort_values(
+        by=["delta_auc", "delta_logloss"],
+        ascending=[False, True],
+    ).reset_index(drop=True)
+    family_delta = pd.concat(all_family_rows, axis=0, ignore_index=True) if all_family_rows else pd.DataFrame()
+    slice_delta = pd.concat(all_slice_rows, axis=0, ignore_index=True) if all_slice_rows else pd.DataFrame()
+
+    summary_json = {
+        "generated_at_utc": utc_now_iso(),
+        "train_csv_path": str(train_csv_path),
+        "reference_oof_spec": str(reference_oof_spec),
+        "reference_source": reference_source,
+        "reference_file": describe_file(Path(reference_oof_spec.split("#", 1)[0])),
+        "challengers": [vars(item) for item in challengers],
+        "dominant_family_value": DOMINANT_MACROFAMILY,
+        "challenger_summary": challenger_summary.to_dict(orient="records"),
+        "dominance_patterns": _derive_dominance_patterns(challenger_summary, slice_delta),
+        "operational_recommendation": _derive_specific_recommendation(challenger_summary, slice_delta),
+    }
+
+    summary_path = ensure_parent_dir(out_root / f"{label}_summary.json")
+    challenger_csv_path = ensure_parent_dir(out_root / f"{label}_challengers.csv")
+    family_csv_path = ensure_parent_dir(out_root / f"{label}_families.csv")
+    slice_csv_path = ensure_parent_dir(out_root / f"{label}_slices.csv")
+
+    challenger_summary.to_csv(challenger_csv_path, index=False)
+    family_delta.to_csv(family_csv_path, index=False)
+    slice_delta.to_csv(slice_csv_path, index=False)
+    write_json(summary_path, summary_json)
+
+    return {
+        "summary_path": str(summary_path),
+        "challenger_csv_path": str(challenger_csv_path),
+        "family_csv_path": str(family_csv_path),
+        "slice_csv_path": str(slice_csv_path),
+        "summary": summary_json,
+    }

--- a/src/churn_baseline/validation_protocol.py
+++ b/src/churn_baseline/validation_protocol.py
@@ -403,14 +403,12 @@ def evaluate_validation_protocol(
     ].copy()
     micro_only = False
     if not positive_improvements.empty:
-        micro_only = bool(
-            (
-                positive_improvements["train_rows"].astype(int) < MIN_MICRO_TRAIN_ROWS
-            )
-            | (
-                positive_improvements["test_rows"].fillna(0).astype(int) < MIN_MICRO_TEST_ROWS
-            )
-        ).all()
+        micro_mask = (
+            positive_improvements["train_rows"].astype(int) < MIN_MICRO_TRAIN_ROWS
+        ) | (
+            positive_improvements["test_rows"].fillna(0).astype(int) < MIN_MICRO_TEST_ROWS
+        )
+        micro_only = bool(micro_mask.all())
     checks.append(
         make_check(
             "micro_family_dependence",

--- a/src/churn_baseline/validation_protocol.py
+++ b/src/churn_baseline/validation_protocol.py
@@ -1,0 +1,580 @@
+"""Validation reset gate for candidate OOF artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+
+from .artifacts import write_json
+from .config import ID_COLUMN, TARGET_COLUMN
+from .data import encode_target, load_csv
+from .diagnostics import (
+    DEFAULT_REFERENCE_OOF_SPECS,
+    FAIL_STATUS,
+    OOF_TARGET_COLUMN,
+    PASS_STATUS,
+    WARN_STATUS,
+    build_family_frame,
+    collect_git_context,
+    describe_file,
+    load_merged_oof_matrix,
+    load_reference_prediction_frame,
+    make_check,
+    parse_oof_input_spec,
+    summarize_checks,
+    summarize_reference_family_metrics,
+    utc_now_iso,
+)
+from .evaluation import binary_auc
+
+
+SMOKE_STAGE = "smoke"
+MIDCAP_STAGE = "midcap"
+SUBMISSION_STAGE = "submission"
+SUPPORTED_STAGES = (SMOKE_STAGE, MIDCAP_STAGE, SUBMISSION_STAGE)
+SUPPORTED_TARGET_LEVELS = ("segment3", "segment5")
+DOMINANT_MACROFAMILY = "Electronic check__Month-to-month__Fiber optic"
+TENURE_BUCKET_ORDER = ("0_6", "7_12", "13_24", "25_48", "49_plus")
+MIN_DELTA_AUC = 1e-05
+MAX_DOMINANT_DELTA_AUC = -2e-04
+MAX_TARGET_DELTA_AUC = -1e-04
+MAX_TOP_DAMAGE_REL_LOGLOSS = 0.03
+MAX_CV_STD_MULTIPLIER = 1.15
+MIN_PROMOTABLE_TRAIN_ROWS = 2000
+MIN_PROMOTABLE_TEST_ROWS = 800
+MIN_LARGE_TRAIN_ROWS = 5000
+MIN_LARGE_TEST_ROWS = 2000
+MIN_MICRO_TRAIN_ROWS = 1000
+MIN_MICRO_TEST_ROWS = 400
+TOP_DAMAGE_COUNT = 3
+
+
+def _logloss_vector(y_true: pd.Series, pred: pd.Series, epsilon: float = 1e-6) -> pd.Series:
+    clipped = pred.astype("float64").clip(lower=epsilon, upper=1.0 - epsilon)
+    y = y_true.astype("float64")
+    return -(y * np.log(clipped) + (1.0 - y) * np.log(1.0 - clipped))
+
+
+def _safe_auc(y_true: pd.Series, pred: pd.Series) -> float | None:
+    if y_true.nunique(dropna=False) < 2:
+        return None
+    return float(binary_auc(y_true.astype(int), pred.astype("float64")))
+
+
+def _normalize_analysis_oof_target(frame: pd.DataFrame) -> pd.DataFrame:
+    out = frame.copy()
+    target_series = out[OOF_TARGET_COLUMN]
+    if pd.api.types.is_numeric_dtype(target_series):
+        out[OOF_TARGET_COLUMN] = pd.to_numeric(target_series, errors="raise").astype("int8")
+    else:
+        out[OOF_TARGET_COLUMN] = encode_target(target_series)
+    return out
+
+
+def _load_candidate_prediction_frame(
+    *,
+    candidate_oof_spec: str,
+    id_column: str = ID_COLUMN,
+    target_column: str = OOF_TARGET_COLUMN,
+) -> pd.DataFrame:
+    spec = parse_oof_input_spec(f"candidate={candidate_oof_spec}")
+    merged, _ = load_merged_oof_matrix((spec,), id_column=id_column, target_column=target_column)
+    merged = _normalize_analysis_oof_target(merged)
+    return merged[[id_column, target_column, "pred_candidate"]].rename(columns={"pred_candidate": "candidate_pred"})
+
+
+def _load_analysis_oof_frame(analysis_oof_path: str | Path) -> pd.DataFrame:
+    frame = pd.read_csv(analysis_oof_path)
+    required = {ID_COLUMN, OOF_TARGET_COLUMN, "reference_pred", "candidate_pred"}
+    missing = sorted(required.difference(frame.columns))
+    if missing:
+        raise ValueError(f"{analysis_oof_path} must contain columns {sorted(required)}; missing {missing}")
+    return _normalize_analysis_oof_target(frame[[ID_COLUMN, OOF_TARGET_COLUMN, "reference_pred", "candidate_pred"]].copy())
+
+
+def _extract_cv_std(metrics_path: str | Path | None) -> float | None:
+    if metrics_path is None:
+        return None
+    payload = json.loads(Path(metrics_path).read_text(encoding="utf-8"))
+    for key in ("cv_std_auc", "cv_std", "oof_cv_std"):
+        value = payload.get(key)
+        if value is None:
+            continue
+        return float(value)
+    return None
+
+
+def _derive_sister_family_value(
+    *,
+    target_family_level: str,
+    target_family_value: str | None,
+) -> str | None:
+    if target_family_level != "segment5" or not target_family_value:
+        return None
+    parts = str(target_family_value).split("__")
+    if len(parts) != 5:
+        return None
+    payment, contract, internet, paperless, tenure_bin = parts
+    if tenure_bin in TENURE_BUCKET_ORDER:
+        position = TENURE_BUCKET_ORDER.index(tenure_bin)
+        if position > 0:
+            sibling_bucket = TENURE_BUCKET_ORDER[position - 1]
+        elif position + 1 < len(TENURE_BUCKET_ORDER):
+            sibling_bucket = TENURE_BUCKET_ORDER[position + 1]
+        else:
+            sibling_bucket = tenure_bin
+        return "__".join((payment, contract, internet, paperless, sibling_bucket))
+    sibling_paperless = "No" if paperless == "Yes" else "Yes"
+    return "__".join((payment, contract, internet, sibling_paperless, tenure_bin))
+
+
+def _relative_delta(candidate_value: float, reference_value: float, epsilon: float = 1e-12) -> float:
+    denominator = max(abs(float(reference_value)), epsilon)
+    return float((float(candidate_value) - float(reference_value)) / denominator)
+
+
+def _summarize_family_candidate_metrics(
+    analysis_frame: pd.DataFrame,
+    *,
+    family_level: str,
+    test_family_counts: pd.Series | None,
+) -> pd.DataFrame:
+    y_true = analysis_frame[OOF_TARGET_COLUMN].astype(int)
+    reference_pred = analysis_frame["reference_pred"].astype("float64")
+    candidate_pred = analysis_frame["candidate_pred"].astype("float64")
+    reference_loss = _logloss_vector(y_true, reference_pred)
+    candidate_loss = _logloss_vector(y_true, candidate_pred)
+
+    work = analysis_frame[[family_level]].copy()
+    work["target"] = y_true.values
+    work["reference_pred"] = reference_pred.values
+    work["candidate_pred"] = candidate_pred.values
+    work["reference_loss"] = reference_loss.values
+    work["candidate_loss"] = candidate_loss.values
+    total_rows = float(len(work))
+
+    rows: list[dict[str, Any]] = []
+    for family_value, part in work.groupby(family_level, dropna=False):
+        reference_auc = _safe_auc(part["target"], part["reference_pred"])
+        candidate_auc = _safe_auc(part["target"], part["candidate_pred"])
+        reference_logloss = float(part["reference_loss"].mean())
+        candidate_logloss = float(part["candidate_loss"].mean())
+        reference_contribution = float(reference_logloss * float(len(part)) / total_rows)
+        candidate_contribution = float(candidate_logloss * float(len(part)) / total_rows)
+        test_rows = None
+        if test_family_counts is not None:
+            test_rows = int(test_family_counts.get(str(family_value), 0))
+        rows.append(
+            {
+                "family_level": family_level,
+                "family_value": str(family_value),
+                "train_rows": int(len(part)),
+                "test_rows": test_rows,
+                "positive_rate": float(part["target"].mean()),
+                "reference_auc": reference_auc,
+                "candidate_auc": candidate_auc,
+                "delta_auc": None if reference_auc is None or candidate_auc is None else float(candidate_auc - reference_auc),
+                "reference_logloss": reference_logloss,
+                "candidate_logloss": candidate_logloss,
+                "reference_logloss_contribution": reference_contribution,
+                "candidate_logloss_contribution": candidate_contribution,
+                "relative_logloss_contribution_delta": _relative_delta(candidate_contribution, reference_contribution),
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def load_protocol_analysis_frame(
+    *,
+    train_csv_path: str | Path,
+    analysis_oof_path: str | Path | None = None,
+    candidate_oof_spec: str | None = None,
+    reference_oof_spec: str | None = None,
+    oof_specs: Sequence[str] | None = None,
+    reference_weights_json: str | Path | None = None,
+) -> tuple[pd.DataFrame, dict[str, Any]]:
+    train_df = load_csv(train_csv_path)
+    family_frame = build_family_frame(train_df)
+
+    if analysis_oof_path is not None:
+        prediction_frame = _load_analysis_oof_frame(analysis_oof_path)
+        prediction_source = {
+            "mode": "analysis_oof",
+            "analysis_oof_path": str(analysis_oof_path),
+        }
+    else:
+        if not candidate_oof_spec:
+            raise ValueError("candidate_oof_spec is required when analysis_oof_path is not provided.")
+        reference_frame, reference_source = load_reference_prediction_frame(
+            reference_oof_spec=reference_oof_spec,
+            oof_specs=oof_specs or DEFAULT_REFERENCE_OOF_SPECS,
+            reference_weights_json=reference_weights_json,
+            id_column=ID_COLUMN,
+            target_column=OOF_TARGET_COLUMN,
+        )
+        candidate_frame = _load_candidate_prediction_frame(candidate_oof_spec=candidate_oof_spec)
+        prediction_frame = reference_frame.merge(
+            candidate_frame[[ID_COLUMN, OOF_TARGET_COLUMN, "candidate_pred"]],
+            how="inner",
+            on=[ID_COLUMN, OOF_TARGET_COLUMN],
+            validate="one_to_one",
+        )
+        prediction_source = {
+            "mode": "reference_plus_candidate",
+            "reference_source": reference_source,
+            "candidate_oof_spec": candidate_oof_spec,
+        }
+
+    analysis = train_df[[ID_COLUMN, TARGET_COLUMN]].copy().merge(
+        family_frame[[ID_COLUMN, "segment3", "segment5"]],
+        how="inner",
+        on=ID_COLUMN,
+        validate="one_to_one",
+    )
+    analysis = analysis.merge(
+        prediction_frame[[ID_COLUMN, OOF_TARGET_COLUMN, "reference_pred", "candidate_pred"]],
+        how="inner",
+        on=ID_COLUMN,
+        validate="one_to_one",
+    )
+    if analysis.empty:
+        raise ValueError("Merged validation protocol frame is empty.")
+    encoded_target = encode_target(analysis[TARGET_COLUMN])
+    oof_target = analysis[OOF_TARGET_COLUMN].astype("int8")
+    if not np.array_equal(encoded_target.to_numpy(dtype="int8"), oof_target.to_numpy(dtype="int8")):
+        raise ValueError("OOF target does not align with train.csv target labels.")
+    analysis = analysis.drop(columns=[TARGET_COLUMN]).copy()
+    analysis[OOF_TARGET_COLUMN] = oof_target.astype("int8").values
+    return analysis, prediction_source
+
+
+def evaluate_validation_protocol(
+    *,
+    train_csv_path: str | Path,
+    test_csv_path: str | Path,
+    stage: str,
+    analysis_oof_path: str | Path | None = None,
+    candidate_oof_spec: str | None = None,
+    reference_oof_spec: str | None = None,
+    oof_specs: Sequence[str] | None = None,
+    reference_weights_json: str | Path | None = None,
+    target_family_level: str = "segment5",
+    target_family_value: str | None = None,
+    sister_family_value: str | None = None,
+    dominant_family_value: str = DOMINANT_MACROFAMILY,
+    candidate_metrics_json: str | Path | None = None,
+    reference_metrics_json: str | Path | None = None,
+    submission_csv_path: str | Path | None = None,
+    out_json_path: str | Path | None = None,
+) -> dict[str, Any]:
+    stage_value = str(stage).strip().lower()
+    if stage_value not in SUPPORTED_STAGES:
+        raise ValueError(f"Unsupported stage '{stage}'. Supported: {SUPPORTED_STAGES}")
+    if target_family_level not in SUPPORTED_TARGET_LEVELS:
+        raise ValueError(f"Unsupported target_family_level '{target_family_level}'. Supported: {SUPPORTED_TARGET_LEVELS}")
+
+    analysis, prediction_source = load_protocol_analysis_frame(
+        train_csv_path=train_csv_path,
+        analysis_oof_path=analysis_oof_path,
+        candidate_oof_spec=candidate_oof_spec,
+        reference_oof_spec=reference_oof_spec,
+        oof_specs=oof_specs,
+        reference_weights_json=reference_weights_json,
+    )
+    test_df = load_csv(test_csv_path)
+    test_family = build_family_frame(test_df)
+    segment5_test_counts = test_family["segment5"].astype(str).value_counts(dropna=False)
+    segment3_test_counts = test_family["segment3"].astype(str).value_counts(dropna=False)
+
+    y_true = analysis[OOF_TARGET_COLUMN].astype(int)
+    reference_pred = analysis["reference_pred"].astype("float64")
+    candidate_pred = analysis["candidate_pred"].astype("float64")
+    reference_auc = float(binary_auc(y_true, reference_pred))
+    candidate_auc = float(binary_auc(y_true, candidate_pred))
+    delta_auc = float(candidate_auc - reference_auc)
+
+    segment5_summary = _summarize_family_candidate_metrics(
+        analysis,
+        family_level="segment5",
+        test_family_counts=segment5_test_counts,
+    )
+    segment3_summary = _summarize_family_candidate_metrics(
+        analysis,
+        family_level="segment3",
+        test_family_counts=segment3_test_counts,
+    )
+
+    target_summary = segment5_summary if target_family_level == "segment5" else segment3_summary
+    target_family_row = None
+    if target_family_value:
+        target_match = target_summary.loc[target_summary["family_value"].astype(str).eq(str(target_family_value))]
+        if not target_match.empty:
+            target_family_row = target_match.iloc[0].to_dict()
+    resolved_sister_family = sister_family_value or _derive_sister_family_value(
+        target_family_level=target_family_level,
+        target_family_value=target_family_value,
+    )
+    sister_family_row = None
+    if resolved_sister_family and target_family_level == "segment5":
+        sister_match = segment5_summary.loc[segment5_summary["family_value"].astype(str).eq(str(resolved_sister_family))]
+        if not sister_match.empty:
+            sister_family_row = sister_match.iloc[0].to_dict()
+
+    dominant_match = segment3_summary.loc[segment3_summary["family_value"].astype(str).eq(str(dominant_family_value))]
+    dominant_row = dominant_match.iloc[0].to_dict() if not dominant_match.empty else None
+
+    top_damage = segment5_summary.loc[
+        (segment5_summary["train_rows"].astype(int) >= MIN_LARGE_TRAIN_ROWS)
+        | (segment5_summary["test_rows"].fillna(0).astype(int) >= MIN_LARGE_TEST_ROWS)
+    ].copy()
+    if top_damage.empty:
+        top_damage = segment5_summary.copy()
+    top_damage = top_damage.sort_values(
+        by=["reference_logloss_contribution", "train_rows"],
+        ascending=[False, False],
+    ).head(TOP_DAMAGE_COUNT)
+
+    candidate_cv_std = _extract_cv_std(candidate_metrics_json)
+    reference_cv_std = _extract_cv_std(reference_metrics_json)
+
+    checks: list[dict[str, Any]] = []
+    checks.append(
+        make_check(
+            "split_a_delta_auc",
+            PASS_STATUS if delta_auc >= MIN_DELTA_AUC else FAIL_STATUS,
+            {
+                "stage": stage_value,
+                "candidate_oof_auc": candidate_auc,
+                "reference_oof_auc": reference_auc,
+                "delta_oof_auc": delta_auc,
+                "min_required": MIN_DELTA_AUC,
+            },
+        )
+    )
+
+    if dominant_row is None:
+        checks.append(make_check("split_b_dominant_family", FAIL_STATUS, {"family_value": dominant_family_value, "reason": "missing"}))
+    else:
+        dominant_delta_auc = dominant_row.get("delta_auc")
+        dominant_status = PASS_STATUS
+        if dominant_delta_auc is None or float(dominant_delta_auc) < MAX_DOMINANT_DELTA_AUC:
+            dominant_status = FAIL_STATUS
+        checks.append(
+            make_check(
+                "split_b_dominant_family",
+                dominant_status,
+                {
+                    "family_value": dominant_family_value,
+                    "delta_auc": dominant_delta_auc,
+                    "min_allowed": MAX_DOMINANT_DELTA_AUC,
+                },
+            )
+        )
+
+    top_damage_breaks: list[dict[str, Any]] = []
+    for row in top_damage.to_dict(orient="records"):
+        relative_delta = float(row["relative_logloss_contribution_delta"])
+        if relative_delta > MAX_TOP_DAMAGE_REL_LOGLOSS:
+            top_damage_breaks.append(
+                {
+                    "family_value": row["family_value"],
+                    "relative_logloss_contribution_delta": relative_delta,
+                }
+            )
+    checks.append(
+        make_check(
+            "split_b_top_damage_families",
+            PASS_STATUS if not top_damage_breaks else FAIL_STATUS,
+            {
+                "max_allowed_relative_delta": MAX_TOP_DAMAGE_REL_LOGLOSS,
+                "top_damage_families": top_damage[["family_value", "reference_logloss_contribution"]].to_dict(orient="records"),
+                "breaks": top_damage_breaks,
+            },
+        )
+    )
+
+    positive_improvements = segment5_summary.loc[
+        segment5_summary["relative_logloss_contribution_delta"].astype("float64") < 0.0
+    ].copy()
+    micro_only = False
+    if not positive_improvements.empty:
+        micro_only = bool(
+            (
+                positive_improvements["train_rows"].astype(int) < MIN_MICRO_TRAIN_ROWS
+            )
+            | (
+                positive_improvements["test_rows"].fillna(0).astype(int) < MIN_MICRO_TEST_ROWS
+            )
+        ).all()
+    checks.append(
+        make_check(
+            "micro_family_dependence",
+            FAIL_STATUS if micro_only else PASS_STATUS,
+            {
+                "micro_only_improvement": micro_only,
+                "improved_family_count": int(len(positive_improvements)),
+                "micro_thresholds": {
+                    "train_rows_lt": MIN_MICRO_TRAIN_ROWS,
+                    "test_rows_lt": MIN_MICRO_TEST_ROWS,
+                },
+            },
+        )
+    )
+
+    if stage_value in {MIDCAP_STAGE, SUBMISSION_STAGE}:
+        if candidate_cv_std is None or reference_cv_std is None:
+            checks.append(
+                make_check(
+                    "midcap_cv_std",
+                    FAIL_STATUS,
+                    {
+                        "reason": "candidate_metrics_json and reference_metrics_json with cv std are required",
+                        "candidate_cv_std": candidate_cv_std,
+                        "reference_cv_std": reference_cv_std,
+                    },
+                )
+            )
+        else:
+            checks.append(
+                make_check(
+                    "midcap_cv_std",
+                    PASS_STATUS if candidate_cv_std <= (reference_cv_std * MAX_CV_STD_MULTIPLIER) else FAIL_STATUS,
+                    {
+                        "candidate_cv_std": candidate_cv_std,
+                        "reference_cv_std": reference_cv_std,
+                        "max_multiplier": MAX_CV_STD_MULTIPLIER,
+                    },
+                )
+            )
+
+    if target_family_value:
+        if target_family_row is None:
+            checks.append(
+                make_check(
+                    "target_family_presence",
+                    FAIL_STATUS,
+                    {
+                        "target_family_level": target_family_level,
+                        "target_family_value": target_family_value,
+                    },
+                )
+            )
+        else:
+            checks.append(
+                make_check(
+                    "target_family_presence",
+                    PASS_STATUS,
+                    {
+                        "target_family_level": target_family_level,
+                        "target_family_value": target_family_value,
+                        "train_rows": int(target_family_row["train_rows"]),
+                        "test_rows": int(target_family_row["test_rows"] or 0),
+                    },
+                )
+            )
+            if stage_value in {MIDCAP_STAGE, SUBMISSION_STAGE}:
+                target_delta_auc = target_family_row.get("delta_auc")
+                checks.append(
+                    make_check(
+                        "target_family_on_mask_auc",
+                        PASS_STATUS if target_delta_auc is not None and float(target_delta_auc) >= MAX_TARGET_DELTA_AUC else FAIL_STATUS,
+                        {
+                            "target_family_level": target_family_level,
+                            "target_family_value": target_family_value,
+                            "delta_auc": target_delta_auc,
+                            "min_allowed": MAX_TARGET_DELTA_AUC,
+                        },
+                    )
+                )
+            if stage_value == SUBMISSION_STAGE:
+                promotable = (
+                    int(target_family_row["train_rows"]) >= MIN_PROMOTABLE_TRAIN_ROWS
+                    and int(target_family_row["test_rows"] or 0) >= MIN_PROMOTABLE_TEST_ROWS
+                )
+                checks.append(
+                    make_check(
+                        "target_family_promotable_support",
+                        PASS_STATUS if promotable else FAIL_STATUS,
+                        {
+                            "train_rows": int(target_family_row["train_rows"]),
+                            "test_rows": int(target_family_row["test_rows"] or 0),
+                            "min_train_rows": MIN_PROMOTABLE_TRAIN_ROWS,
+                            "min_test_rows": MIN_PROMOTABLE_TEST_ROWS,
+                        },
+                    )
+                )
+
+    if resolved_sister_family and stage_value == SUBMISSION_STAGE and target_family_level == "segment5":
+        if sister_family_row is None:
+            checks.append(
+                make_check(
+                    "sister_family_guardrail",
+                    FAIL_STATUS,
+                    {
+                        "sister_family_value": resolved_sister_family,
+                        "reason": "missing",
+                    },
+                )
+            )
+        else:
+            sister_delta_auc = sister_family_row.get("delta_auc")
+            checks.append(
+                make_check(
+                    "sister_family_guardrail",
+                    PASS_STATUS if sister_delta_auc is not None and float(sister_delta_auc) >= MAX_TARGET_DELTA_AUC else FAIL_STATUS,
+                    {
+                        "sister_family_value": resolved_sister_family,
+                        "delta_auc": sister_delta_auc,
+                        "min_allowed": MAX_TARGET_DELTA_AUC,
+                    },
+                )
+            )
+
+    if stage_value == SUBMISSION_STAGE:
+        checks.append(
+            make_check(
+                "submission_trace_artifacts",
+                PASS_STATUS if submission_csv_path else FAIL_STATUS,
+                {
+                    "submission_csv": None if submission_csv_path is None else describe_file(submission_csv_path),
+                    "candidate_metrics_json": None if candidate_metrics_json is None else describe_file(candidate_metrics_json),
+                    "reference_metrics_json": None if reference_metrics_json is None else describe_file(reference_metrics_json),
+                    "analysis_oof_path": None if analysis_oof_path is None else describe_file(analysis_oof_path),
+                },
+            )
+        )
+
+    verdict = summarize_checks(checks)
+    result: dict[str, Any] = {
+        "generated_at_utc": utc_now_iso(),
+        "stage": stage_value,
+        "train_csv_path": str(train_csv_path),
+        "test_csv_path": str(test_csv_path),
+        "prediction_source": prediction_source,
+        "target_family_level": target_family_level,
+        "target_family_value": target_family_value,
+        "resolved_sister_family_value": resolved_sister_family,
+        "dominant_family_value": dominant_family_value,
+        "overall_metrics": {
+            "reference_oof_auc": reference_auc,
+            "candidate_oof_auc": candidate_auc,
+            "delta_oof_auc": delta_auc,
+            "candidate_cv_std": candidate_cv_std,
+            "reference_cv_std": reference_cv_std,
+        },
+        "top_damage_families": top_damage.to_dict(orient="records"),
+        "dominant_family": dominant_row,
+        "target_family": target_family_row,
+        "sister_family": sister_family_row,
+        "checks": checks,
+        "verdict": verdict,
+        "git_context": collect_git_context(),
+    }
+    if out_json_path is not None:
+        write_json(out_json_path, result)
+    return result


### PR DESCRIPTION
## Summary
- add submission forensics tooling to join Kaggle history with local submission/report artifacts
- add a clean-room CatBoost smoke suite compared directly against incumbent `v3`
- update README and phase-reset docs with the operational conclusions

## Why
We needed a reset point before opening more model lines:
- identify which submission families actually survived on the public leaderboard
- measure whether `v3` is beating challengers because of accidental complexity or because it retains real edge

## Results
- Kaggle history audited: `20` submissions, `18` `COMPLETE`, `2` `ERROR`
- best public submission confirmed: `playground-series-s6e3-residual-hier-v3.csv` (`ref 50828079`, `0.91421`)
- only family with repeated public survival: `residual_hierarchy`
- clean-room smoke against `v3`:
  - `cb_raw = 0.9125779`
  - `cb_r = 0.9132509`
  - `cb_rv = 0.9138610`
  - none improve or blend with `v3`

## Artifacts
- `artifacts/reports/submission_forensics_summary.json`
- `artifacts/reports/submission_forensics_ledger.csv`
- `artifacts/reports/cleanroom_baseline_suite_summary.json`

## Validation
- `python -m compileall src/churn_baseline/submission_forensics.py src/churn_baseline/cleanroom_baseline.py scripts/analyze_submission_forensics.py scripts/experiment_cleanroom_baselines.py`
- `python scripts/analyze_submission_forensics.py`
- `python scripts/experiment_cleanroom_baselines.py --folds 2 --iterations 150 --learning-rate 0.05 --depth 6 --l2-leaf-reg 5.0 --early-stopping-rounds 60 --verbose 0`

## Traceability
- issue: #24
- reviews: `dry-enforcer`, `backend-architect`, `documentation-writer`